### PR TITLE
修复 OpenAI-compatible 工具调用链中的 schema 与 tool output 历史问题

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -2300,6 +2300,58 @@ MAX_TOOL_ITERATIONS = int(os.getenv("OMICSCLAW_MAX_TOOL_ITERATIONS", "20"))  # I
 # ---------------------------------------------------------------------------
 
 
+def _sanitize_tool_history(history: list[dict]) -> list[dict]:
+    """Drop orphaned or incomplete tool-call bundles from history."""
+    sanitised: list[dict] = []
+    pending_bundle: list[dict] | None = None
+    pending_tool_ids: set[str] = set()
+
+    def flush_pending(drop_incomplete: bool) -> None:
+        nonlocal pending_bundle, pending_tool_ids
+        if pending_bundle is None:
+            return
+        if drop_incomplete and pending_tool_ids:
+            logger.warning(
+                "Dropped incomplete assistant/tool bundle from history; "
+                f"missing tool outputs for: {sorted(pending_tool_ids)}"
+            )
+        else:
+            sanitised.extend(pending_bundle)
+        pending_bundle = None
+        pending_tool_ids = set()
+
+    for msg in history:
+        role = msg.get("role")
+
+        if role == "assistant" and msg.get("tool_calls"):
+            flush_pending(drop_incomplete=True)
+            pending_bundle = [msg]
+            pending_tool_ids = {
+                tc.get("id")
+                for tc in msg.get("tool_calls", [])
+                if isinstance(tc, dict) and tc.get("id")
+            }
+            continue
+
+        if role == "tool":
+            tool_call_id = msg.get("tool_call_id")
+            if pending_bundle is not None and tool_call_id in pending_tool_ids:
+                pending_bundle.append(msg)
+                pending_tool_ids.remove(tool_call_id)
+                if not pending_tool_ids:
+                    flush_pending(drop_incomplete=False)
+                continue
+
+            logger.warning("Dropped orphaned tool message from history")
+            continue
+
+        flush_pending(drop_incomplete=True)
+        sanitised.append(msg)
+
+    flush_pending(drop_incomplete=True)
+    return sanitised
+
+
 async def llm_tool_loop(
     chat_id: int | str,
     user_content: str | list,
@@ -2534,18 +2586,7 @@ For more info: https://github.com/TianGzlab/OmicsClaw"""
     if len(history) > MAX_HISTORY:
         history[:] = history[-MAX_HISTORY:]
 
-    # Sanitise: drop orphaned tool messages
-    sanitised: list[dict] = []
-    for msg in history:
-        if msg.get("role") == "tool":
-            if sanitised and sanitised[-1].get("role") == "assistant":
-                if sanitised[-1].get("tool_calls"):
-                    sanitised.append(msg)
-                    continue
-            logger.warning("Dropped orphaned tool message from history")
-            continue
-        sanitised.append(msg)
-    history[:] = sanitised
+    history[:] = _sanitize_tool_history(history)
 
     last_message = None
     _notified_methods: set[str] = set()  # Avoid duplicate progress messages

--- a/bot/tests/test_tools.py
+++ b/bot/tests/test_tools.py
@@ -4,7 +4,7 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_ROOT))
 
-from bot.core import TOOLS, OMICS_EXTENSIONS
+from bot.core import TOOLS, OMICS_EXTENSIONS, _sanitize_tool_history
 
 def test_tools_generated():
     assert len(TOOLS) > 0
@@ -40,3 +40,45 @@ def test_create_csv_file_data_schema_is_valid():
     data_schema = csv_tool["function"]["parameters"]["properties"]["data"]
     assert data_schema["type"] == "array"
     assert data_schema["items"]["type"] == "object"
+
+
+def test_sanitize_tool_history_keeps_complete_multi_tool_bundle():
+    history = [
+        {"role": "user", "content": "do two things"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "call_2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result 1"},
+        {"role": "tool", "tool_call_id": "call_2", "content": "result 2"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+    sanitised = _sanitize_tool_history(history)
+    assert sanitised == history
+
+
+def test_sanitize_tool_history_drops_incomplete_tool_bundle():
+    history = [
+        {"role": "user", "content": "do two things"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "call_2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result 1"},
+        {"role": "assistant", "content": "next turn"},
+    ]
+
+    sanitised = _sanitize_tool_history(history)
+    assert sanitised == [
+        {"role": "user", "content": "do two things"},
+        {"role": "assistant", "content": "next turn"},
+    ]


### PR DESCRIPTION
## 变更说明

这次 PR 修复了 bot / interactive 在 OpenAI-compatible 接口下的两类工具调用问题：

1. 修复 `create_csv_file` 工具 schema 不完整的问题
- 为 `data` 数组参数补充 `items` 定义
- 避免在更严格的 OpenAI-compatible 服务端上报错：
  `array schema missing items`

2. 修复多次 tool call 场景下历史消息不完整的问题
- 调整 tool history 清洗逻辑
- 只有当一组 assistant `tool_calls` 与对应的全部 `tool` 输出都完整时才保留
- 避免再次请求模型时出现：
  `No tool output found for function call ...`

3. 补充并稳定回归测试
- 增加所有 array schema 必须声明 `items` 的检查
- 增加 `create_csv_file` schema 的定向测试
- 增加多 tool call 历史完整/不完整两类测试
- 修正旧测试中对 legacy alias `vcf-ops` 的不稳定断言，改为检查 canonical skill 名称

## 验证

已完成以下验证：

- `python -m pytest -q bot/tests/test_tools.py`
- 结果：`5 passed`

另外还做了真实接口验证：
- 使用 DashScope OpenAI-compatible 接口对普通聊天请求测试成功
- 携带 `TOOLS` 的请求返回 `200 OK`
- 未再出现 `create_csv_file` schema 的 400 错误

## 影响范围

主要影响 LLM 工具调用链：
- bot
- `oc interactive`

不影响直接运行技能的命令，例如：
- `oc run <skill> --demo`
- `oc run <skill> --input ...`
