### PR TITLE
Fix LIANA demo failure by aligning demo gene symbols in adata.raw

### DIFF
--- a/skills/spatial/spatial-communication/spatial_communication.py
+++ b/skills/spatial/spatial-communication/spatial_communication.py
@@ -199,8 +199,8 @@ def get_demo_data() -> tuple:
             raise FileNotFoundError(f"Expected {processed}")
         adata = sc.read_h5ad(processed)
         logger.info("Demo: %d cells × %d genes", adata.n_obs, adata.n_vars)
-        
-        # Inject realistic gene names to pass LIANA's valid proportion check
+
+        # Inject realistic gene names so LIANA's built-in resource can match them.
         valid_genes = [
             "A1BG", "A2M", "AANAT", "ABCA1", "ACE", "ACKR1", "ACKR2", "ACKR3", "ACKR4", "ACTR2", 
             "ACVR1", "ACVR1B", "ACVR1C", "ACVR2A", "ACVR2B", "ACVRL1", "ADA", "ADAM10", "ADAM11", "ADAM12", 
@@ -216,7 +216,23 @@ def get_demo_data() -> tuple:
         # Pad with dummies if somehow n_vars > 100
         if adata.n_vars > len(valid_genes):
             valid_genes += [f"Gene_dummy_{i}" for i in range(adata.n_vars - len(valid_genes))]
-        adata.var_names = valid_genes[:adata.n_vars]
+        valid_genes = valid_genes[:adata.n_vars]
+        adata.var_names = valid_genes
+
+        # LIANA reads from `.raw` when available, so keep raw gene symbols aligned.
+        if adata.raw is not None:
+            raw_adata = adata.raw.to_adata()
+            if raw_adata.n_vars == len(valid_genes):
+                raw_adata.var_names = valid_genes
+                adata.raw = raw_adata
+            else:
+                logger.warning(
+                    "Demo raw matrix gene count (%d) did not match processed matrix (%d); "
+                    "refreshing `.raw` from the processed matrix for LIANA demo compatibility.",
+                    raw_adata.n_vars,
+                    len(valid_genes),
+                )
+                adata.raw = adata.copy()
         
         return adata, None
 

--- a/skills/spatial/spatial-communication/tests/test_demo_data.py
+++ b/skills/spatial/spatial-communication/tests/test_demo_data.py
@@ -1,0 +1,27 @@
+"""Focused tests for spatial communication demo data preparation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_skill_module():
+    skill_script = Path(__file__).resolve().parent.parent / "spatial_communication.py"
+    spec = importlib.util.spec_from_file_location("spatial_communication", skill_script)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_demo_data_renames_raw_var_names_for_liana():
+    """Demo data should expose real-looking gene symbols in both X and raw."""
+    module = _load_skill_module()
+
+    adata, _ = module.get_demo_data()
+
+    assert adata.raw is not None
+    assert list(adata.var_names[:5]) == ["A1BG", "A2M", "AANAT", "ABCA1", "ACE"]
+    assert list(adata.raw.var_names[:5]) == ["A1BG", "A2M", "AANAT", "ABCA1", "ACE"]
+    assert all("_" not in gene for gene in adata.raw.var_names)


### PR DESCRIPTION
## Summary

This PR fixes the `spatial-cell-communication --demo --method liana` failure in the spatial transcriptomics workflow.

The demo data preparation previously renamed `adata.var_names` to realistic gene symbols, but LIANA reads from `adata.raw` when it is available. Since `adata.raw.var_names` still contained synthetic names like `Gene_000`, LIANA could not match the built-in ligand-receptor resource and failed with a coverage error.

## Changes

- update spatial communication demo preparation to align gene symbols in both `adata.var_names` and `adata.raw.var_names`
- add a safe fallback when `.raw` and processed matrices do not have matching gene counts
- add a regression test covering LIANA-compatible demo gene naming in `.raw`

## Validation

Verified by running:

```bash
./.venv/bin/python omicsclaw.py run spatial-cell-communication --demo --method liana
