### PR TITLE
fix(singlecell): align scrna methods and guides on latest main

### DIFF
--- a/knowledge_base/knowhows/KH-sc-ambient-removal-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-ambient-removal-guardrails.md
@@ -1,0 +1,26 @@
+---
+doc_id: sc-ambient-removal-guardrails
+title: Single-Cell Ambient RNA Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the selected ambient-removal path and its true required inputs before running sc-ambient-removal
+domains: [singlecell]
+related_skills: [sc-ambient-removal]
+phases: [before_run, on_warning, after_run]
+search_terms: [ambient RNA, CellBender, SoupX, contamination fraction, raw h5, 单细胞环境RNA, 背景污染, 调参]
+priority: 1.0
+source_urls:
+  - https://cellbender.readthedocs.io/en/v0.2.0/getting_started/remove_background/
+  - https://cellbender.readthedocs.io/en/v0.1.0/help_and_reference/remove_background/index.html
+  - https://github.com/constantAmateur/SoupX
+---
+
+# Single-Cell Ambient RNA Guardrails
+
+- **Inspect first**: verify whether the user actually has `raw_h5` or paired raw/filtered 10x directories, because the method choice depends on those files.
+- **Key wrapper controls**: explain `method`, `contamination`, `expected_cells`, `raw_h5`, `raw_matrix_dir`, and `filtered_matrix_dir`.
+- **Use method-correct language**: `simple` uses a wrapper-level contamination fraction; `cellbender` relies on `expected_cells`; `soupx` requires raw and filtered matrices.
+- **Enforce the input contract**: the current CellBender wrapper only accepts raw 10x `.h5` input; if the user only has processed `.h5ad`, do not try to run CellBender.
+- **Do not invent hidden knobs**: official CellBender docs also discuss `total-droplets-included`, but the current OmicsClaw wrapper does not expose it.
+- **Do not fake SoupX readiness**: if the required raw/filtered inputs are missing, say the wrapper will fall back instead of pretending full SoupX control is available.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-ambient-removal.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-ambient-removal.md`.

--- a/knowledge_base/knowhows/KH-sc-batch-integration-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-batch-integration-guardrails.md
@@ -1,0 +1,27 @@
+---
+doc_id: sc-batch-integration-guardrails
+title: Single-Cell Batch Integration Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the selected integration backend plus the batch metadata it uses before running sc-batch-integration
+domains: [singlecell]
+related_skills: [sc-batch-integration, sc-integrate]
+phases: [before_run, on_warning, after_run]
+search_terms: [batch integration, Harmony, scVI, scANVI, BBKNN, Scanorama, batch key, 单细胞整合, 批次校正, 调参]
+priority: 1.0
+source_urls:
+  - https://scanpy.readthedocs.io/en/latest/generated/scanpy.external.pp.harmony_integrate.html
+  - https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.SCVI.html
+  - https://docs.scvi-tools.org/en/1.3.1/api/reference/scvi.model.SCANVI.html
+  - https://bbknn.readthedocs.io/en/latest/bbknn.bbknn.html
+  - https://scanpy.readthedocs.io/en/latest/generated/scanpy.external.pp.scanorama_integrate.html
+---
+
+# Single-Cell Batch Integration Guardrails
+
+- **Inspect first**: confirm the batch column and whether labels exist, because `scanvi` needs labels while other methods only need batch structure.
+- **Key wrapper controls**: explain `method`, `batch_key`, `n_epochs`, and `no_gpu` before running.
+- **Use method-correct language**: `batch_key` is the core control across Harmony, scVI, BBKNN, and Scanorama; `n_epochs` only matters for scVI/scANVI in this wrapper.
+- **Do not invent unsupported knobs**: official docs discuss additional parameters such as Harmony `theta`, BBKNN `neighbors_within_batch`, and Scanorama `knn`/`sigma`, but the current OmicsClaw wrapper does not expose them.
+- **Respect the matrix contract**: `harmony`, `bbknn`, and `scanorama` operate on normalized / PCA-ready representations, while `scvi`, `scanvi`, `fastmnn`, `seurat_cca`, and `seurat_rpca` should preserve or read raw counts from `layers["counts"]` when available.
+- **Be honest about runtime dependencies**: `fastmnn`, `seurat_cca`, and `seurat_rpca` are public methods, but they require a working R environment with batchelor or Seurat plus the shared H5AD bridge packages.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-batch-integration.md`.

--- a/knowledge_base/knowhows/KH-sc-cell-annotation-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-cell-annotation-guardrails.md
@@ -1,0 +1,26 @@
+---
+doc_id: sc-cell-annotation-guardrails
+title: Single-Cell Annotation Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the selected annotation source and the exact reference/model input before running sc-cell-annotation
+domains: [singlecell]
+related_skills: [sc-cell-annotation, sc-annotate]
+phases: [before_run, on_warning, after_run]
+search_terms: [cell annotation, CellTypist, SingleR, scmap, model, reference, 单细胞注释, 参考集, 调参]
+priority: 1.0
+source_urls:
+  - https://celltypist.readthedocs.io/en/stable/_modules/celltypist/annotate.html
+  - https://celltypist.readthedocs.io/en/stable/notebook/celltypist_tutorial.html
+  - https://bioconductor.org/packages/release/bioc/vignettes/SingleR/inst/doc/SingleR.html
+  - https://bioconductor.org/packages/SingleR/
+---
+
+# Single-Cell Annotation Guardrails
+
+- **Inspect first**: check whether cluster labels already exist and whether the user wants marker-based annotation, CellTypist, or a reference-style path.
+- **Key wrapper controls**: explain `method`, `cluster_key`, `model`, and `reference` before running.
+- **Use method-correct language**: `model` is the main CellTypist selector; `reference` is the wrapper-level choice for the reference-style path.
+- **Do not invent unsupported knobs**: official CellTypist docs also expose options like `majority_voting`, but the current OmicsClaw wrapper does not expose them.
+- **Respect the matrix contract**: marker scoring, CellTypist, SingleR, and scmap should read log-normalized expression, preferably from `adata.raw`; do not describe raw counts as direct input for these methods.
+- **Be honest about runtime dependencies**: `singler` requires an R environment with SingleR, celldex, SingleCellExperiment, and zellkonverter; `scmap` is a public method and requires `scmap` plus the same R bridge stack.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-cell-annotation.md`.

--- a/knowledge_base/knowhows/KH-sc-cell-communication-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-cell-communication-guardrails.md
@@ -1,0 +1,24 @@
+---
+doc_id: sc-cell-communication-guardrails
+title: Single-Cell Communication Guardrails
+doc_type: knowhow
+critical_rule: MUST verify the cell-type labels and explain the selected communication backend plus species setting before running sc-cell-communication
+domains: [singlecell]
+related_skills: [sc-cell-communication]
+phases: [before_run, on_warning, after_run]
+search_terms: [cell communication, ligand receptor, LIANA, CellChat, species, 单细胞通讯, 配体受体, 调参]
+priority: 1.0
+source_urls:
+  - https://liana-py.readthedocs.io/en/latest/generated/liana.method.rank_aggregate.__call__.html
+  - https://github.com/jinworks/CellChat
+---
+
+# Single-Cell Communication Guardrails
+
+- **Inspect first**: confirm that the chosen `cell_type_key` contains biologically interpretable labels rather than raw QC groups.
+- **Key wrapper controls**: explain `method`, `cell_type_key`, and `species` before running.
+- **Use method-correct language**: LIANA and CellChat both depend on how cells are grouped; the grouping column is therefore the most important user-facing control in this wrapper.
+- **Do not invent unsupported knobs**: official LIANA and CellChat workflows expose extra filters such as expression cutoffs and permutation settings, but the current OmicsClaw wrapper does not expose them.
+- **Do not overclaim species support**: if the ligand-receptor database coverage is uncertain for the requested species, say so.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-cell-communication.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-cell-communication.md`.

--- a/knowledge_base/knowhows/KH-sc-de-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-de-guardrails.md
@@ -1,0 +1,24 @@
+---
+doc_id: sc-de-guardrails
+title: Single-Cell Differential Expression Guardrails
+doc_type: knowhow
+critical_rule: MUST distinguish exploratory marker ranking from replicate-aware pseudobulk inference before running sc-de
+domains: [singlecell]
+related_skills: [sc-de]
+phases: [before_run, on_warning, after_run]
+search_terms: [single-cell differential expression, marker ranking, wilcoxon, DESeq2 pseudobulk, group comparison, 单细胞差异表达, 伪bulk, 调参]
+priority: 1.0
+source_urls:
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
+  - https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html
+---
+
+# Single-Cell Differential Expression Guardrails
+
+- **Inspect first**: decide whether the user wants cluster markers or replicate-aware condition DE, because those are different statistical questions.
+- **Key wrapper controls**: explain `method`, `groupby`, `group1`, `group2`, `sample_key`, `celltype_key`, and `n_top_genes` before running.
+- **Use method-correct language**: Scanpy `wilcoxon` and `t-test` are exploratory single-cell ranking paths; `mast` is an R-backed hurdle-model path on log-normalized expression; `deseq2_r` is the replicate-aware pseudobulk path on raw counts.
+- **Do not invent unsupported knobs**: the current wrapper does not expose a full DESeq2 design formula editor or Scanpy low-level test parameters.
+- **Respect the matrix contract**: `wilcoxon`, `t-test`, and `mast` should use log-normalized expression, preferably `adata.raw`; `deseq2_r` should use raw counts from `layers["counts"]`.
+- **Be honest about runtime dependencies**: `mast` and `deseq2_r` are real public R-backed methods and require their corresponding R stacks.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-de.md`.

--- a/knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md
@@ -1,0 +1,25 @@
+---
+doc_id: sc-doublet-detection-guardrails
+title: Single-Cell Doublet Detection Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the expected doublet-rate assumption before running sc-doublet-detection and must not invent unsupported backend-specific tuning knobs
+domains: [singlecell]
+related_skills: [sc-doublet-detection, sc-doublet]
+phases: [before_run, on_warning, after_run]
+search_terms: [doublet detection, Scrublet, DoubletFinder, scDblFinder, expected doublet rate, 单细胞双细胞, 双细胞检测, 调参]
+priority: 1.0
+source_urls:
+  - https://github.com/swolock/scrublet
+  - https://github.com/chris-mcginnis-ucsf/DoubletFinder
+  - https://bioconductor.org/packages/release/bioc/vignettes/scDblFinder/inst/doc/scDblFinder.html
+---
+
+# Single-Cell Doublet Detection Guardrails
+
+- **Inspect first**: confirm whether the input is a single capture or mixed samples, because doublet expectations depend on capture structure.
+- **Key wrapper controls**: explain `method`, `expected_doublet_rate`, and `threshold` before running.
+- **Use method-correct language**: `threshold` only applies to the Scrublet path in the current wrapper.
+- **Do not invent unsupported knobs**: official DoubletFinder and scDblFinder document extra controls such as `pK`, `nExp`, `dbr`, `samples`, or `clusters`, but the current OmicsClaw wrapper does not expose them.
+- **Do not overclaim removal**: this skill annotates doublets in `obs`; it does not silently drop them from the dataset.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.

--- a/knowledge_base/knowhows/KH-sc-filter-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-filter-guardrails.md
@@ -1,0 +1,25 @@
+---
+doc_id: sc-filter-guardrails
+title: Single-Cell Filtering Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the effective QC thresholds before running sc-filter and treat tissue presets as wrapper heuristics rather than universal biology rules
+domains: [singlecell]
+related_skills: [sc-filter]
+phases: [before_run, on_warning, after_run]
+search_terms: [single-cell filtering, qc filtering, min genes, max mt percent, tissue preset, 单细胞过滤, 质控阈值, 调参]
+priority: 1.0
+source_urls:
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.filter_cells.html
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.filter_genes.html
+  - https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.calculate_qc_metrics.html
+---
+
+# Single-Cell Filtering Guardrails
+
+- **Inspect first**: review `n_genes_by_counts`, `total_counts`, and `%MT` distributions before choosing thresholds.
+- **Key wrapper controls**: explain `min_genes`, `max_genes`, `min_counts`, `max_counts`, `max_mt_percent`, and `min_cells` before running.
+- **Treat `--tissue` honestly**: it is an OmicsClaw preset that overrides thresholds; do not describe it as an upstream Scanpy parameter.
+- **Do not overclaim automation**: this wrapper applies explicit threshold filters only; it does not infer optimal cutoffs from the data.
+- **Use method-correct language**: cell filtering and gene filtering are separate operations, and `min_cells` is a gene-retention control, not a cell-quality score.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-filter.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-filter.md`.

--- a/knowledge_base/knowhows/KH-sc-grn-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-grn-guardrails.md
@@ -1,0 +1,24 @@
+---
+doc_id: sc-grn-guardrails
+title: Single-Cell GRN Guardrails
+doc_type: knowhow
+critical_rule: MUST verify the external pySCENIC resources before running sc-grn and must not imply the workflow is self-contained without them
+domains: [singlecell]
+related_skills: [sc-grn]
+phases: [before_run, on_warning, after_run]
+search_terms: [GRN, pySCENIC, regulon, TF list, motif database, 单细胞调控网络, 转录因子, 调参]
+priority: 1.0
+source_urls:
+  - https://pyscenic.readthedocs.io/
+  - https://github.com/aertslab/pySCENIC
+---
+
+# Single-Cell GRN Guardrails
+
+- **Inspect first**: verify the user has a TF list, motif annotations, and cisTarget databases, because those are core prerequisites.
+- **Key wrapper controls**: explain `tf_list`, `db`, `motif`, `n_top_targets`, `n_jobs`, and `seed` before running.
+- **Use method-correct language**: the workflow combines GRNBoost2 adjacency inference, motif pruning, and AUCell scoring.
+- **Do not invent hidden database knobs**: pySCENIC exposes many resource-specific details, but the current OmicsClaw wrapper only exposes a compact resource-selection surface.
+- **Do not overclaim automation**: this wrapper does not automatically fetch pySCENIC resources for the user.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-grn.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-grn.md`.

--- a/knowledge_base/knowhows/KH-sc-markers-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-markers-guardrails.md
@@ -1,0 +1,23 @@
+---
+doc_id: sc-markers-guardrails
+title: Single-Cell Marker Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the cluster grouping and ranking method before running sc-markers
+domains: [singlecell]
+related_skills: [sc-markers]
+phases: [before_run, on_warning, after_run]
+search_terms: [marker genes, rank genes groups, wilcoxon, logreg, cluster markers, 单细胞marker, 调参]
+priority: 1.0
+source_urls:
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
+---
+
+# Single-Cell Marker Guardrails
+
+- **Inspect first**: confirm the grouping column really represents clusters or labels worth ranking against.
+- **Key wrapper controls**: explain `groupby`, `method`, `n_genes`, and `n_top` before running.
+- **Use method-correct language**: `wilcoxon`, `t-test`, and `logreg` are alternative ranking modes for the same cluster-marker question.
+- **Do not overclaim biological certainty**: top-ranked markers are candidate discriminative genes, not final cell-type labels by themselves.
+- **Do not invent unsupported thresholds**: this wrapper does not expose a large matrix of extra rank-gene parameters beyond the public flags above.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-markers.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-markers.md`.

--- a/knowledge_base/knowhows/KH-sc-pseudotime-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-pseudotime-guardrails.md
@@ -1,0 +1,25 @@
+---
+doc_id: sc-pseudotime-guardrails
+title: Single-Cell Pseudotime Guardrails
+doc_type: knowhow
+critical_rule: MUST explain the root choice and distinguish the trajectory method from the trajectory-gene correlation method before running sc-pseudotime
+domains: [singlecell]
+related_skills: [sc-pseudotime]
+phases: [before_run, on_warning, after_run]
+search_terms: [pseudotime, DPT, PAGA, diffusion map, root cluster, trajectory genes, 单细胞拟时序, 轨迹, 调参]
+priority: 1.0
+source_urls:
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.paga.html
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.diffmap.html
+  - https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.dpt.html
+---
+
+# Single-Cell Pseudotime Guardrails
+
+- **Inspect first**: verify the cluster labels and whether the user has a biologically defensible root cluster or root cell.
+- **Key wrapper controls**: explain `method`, `cluster_key`, `root_cluster`, `root_cell`, `n_dcs`, `n_genes`, and `corr_method` before running.
+- **Use method-correct language**: in the current wrapper, `method` selects the trajectory algorithm (`dpt`), while `corr_method` only controls how trajectory-associated genes are ranked afterward.
+- **Do not invent unsupported backends**: this build exposes only the DPT trajectory path, even if users mention other trajectory tools.
+- **Do not hide root selection**: if the root is uncertain, say that explicitly instead of pretending pseudotime direction is fixed by the algorithm alone.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-pseudotime.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-pseudotime.md`.

--- a/knowledge_base/knowhows/KH-sc-velocity-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-velocity-guardrails.md
@@ -1,0 +1,24 @@
+---
+doc_id: sc-velocity-guardrails
+title: Single-Cell Velocity Guardrails
+doc_type: knowhow
+critical_rule: MUST check for spliced and unspliced layers and explain the chosen velocity mode before running sc-velocity
+domains: [singlecell]
+related_skills: [sc-velocity]
+phases: [before_run, on_warning, after_run]
+search_terms: [RNA velocity, scVelo, stochastic, dynamical, steady_state, latent time, 单细胞速度, 调参]
+priority: 1.0
+source_urls:
+  - https://scvelo.readthedocs.io/en/stable/scvelo.tl.velocity.html
+  - https://scvelo.readthedocs.io/en/stable/VelocityBasics.html
+---
+
+# Single-Cell Velocity Guardrails
+
+- **Inspect first**: verify `layers["spliced"]` and `layers["unspliced"]` exist before promising any velocity run.
+- **Key wrapper controls**: explain `method` or `mode` and `n_jobs` before running.
+- **Use method-correct language**: `stochastic`, `dynamical`, and `steady_state` are backend modes for the same velocity skill.
+- **Do not overclaim latent time**: latent time is tied to the dynamical path and should not be promised for every velocity run.
+- **Do not invent unsupported scVelo knobs**: the current OmicsClaw wrapper does not expose the full velocity-model parameter surface from upstream scVelo.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-velocity.md`.
+- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-velocity.md`.

--- a/knowledge_base/skill-guides/singlecell/sc-ambient-removal.md
+++ b/knowledge_base/skill-guides/singlecell/sc-ambient-removal.md
@@ -1,0 +1,112 @@
+---
+doc_id: skill-guide-sc-ambient-removal
+title: OmicsClaw Skill Guide — SC Ambient Removal
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-ambient-removal]
+search_terms: [ambient RNA, CellBender, SoupX, contamination fraction, raw h5, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Ambient Removal
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-ambient-removal` skill. This guide focuses on real wrapper behavior and
+input requirements, not the full upstream CellBender or SoupX parameter space.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether ambient removal is actually justified before downstream analysis
+- whether the user has the inputs required for `cellbender` or `soupx`
+- which parameters matter in the current wrapper
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Technology context**:
+  - droplet-based data is the main use case
+- **Input assets**:
+  - raw 10x `.h5` for CellBender
+  - paired raw / filtered 10x directories for SoupX
+- **Current matrix state**:
+  - the wrapper fallback uses the current expression matrix directly
+- **Contamination evidence**:
+  - marker leakage, ambient signatures, or strong background genes
+
+Important implementation notes in current OmicsClaw:
+- the wrapper exposes `simple`, `cellbender`, and `soupx`
+- `simple` is an OmicsClaw fallback, not an official CellBender/SoupX equivalent
+- `contamination` is a wrapper-side control for the `simple` path
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **simple** | Fast baseline when raw inputs for other tools are missing | `contamination=0.05` | Wrapper heuristic, not a full probabilistic model |
+| **cellbender** | Best when a raw 10x `.h5` from CellRanger is available | `raw_h5`, `expected_cells` | Heavy model; processed `.h5ad` is rejected by the current wrapper |
+| **soupx** | Best when raw and filtered 10x directories are available | `raw_matrix_dir`, `filtered_matrix_dir` | Current wrapper does not expose the full SoupX tuning surface |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run ambient RNA removal
+  Method: cellbender
+  Parameters: raw_h5=sample_raw.h5, expected_cells=10000
+  Note: this wrapper exposes only the core input/prior knobs, not the full CellBender training API.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Simple
+
+Tune in this order:
+1. `contamination`
+
+Guidance:
+- use it as a fallback when no better method inputs are available
+- increase only if background contamination is clearly visible
+
+### CellBender
+
+Tune in this order:
+1. `raw_h5`
+2. `expected_cells`
+
+Guidance:
+- `raw_h5` is not optional for a real CellBender run
+- the current wrapper expects the raw 10x `.h5` produced by CellRanger, not a postprocessed `.h5ad`
+- `expected_cells` is the main public prior worth exposing in the current wrapper
+
+Important warnings:
+- do not promise low-level CellBender knobs such as latent-dimension or training internals
+- do not write `total-droplets-included` as a current OmicsClaw public parameter
+
+### SoupX
+
+Tune in this order:
+1. `raw_matrix_dir`
+2. `filtered_matrix_dir`
+
+Guidance:
+- confirm both directories exist before claiming SoupX is available
+- if those inputs are missing, explain the fallback explicitly
+
+## Step 5: What To Say After The Run
+
+- If counts drop only slightly: say contamination may have been mild.
+- If correction is very strong: tell the user to sanity-check marker retention.
+- If CellBender/SoupX could not run: explain the missing inputs rather than pretending the fallback is equivalent.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe `corrected.h5ad` as the corrected expression object
+- describe the before/after count plots as wrapper diagnostics, not formal validation metrics
+- describe `result.json.data.params` as the actual public settings used
+
+## Official References
+
+- https://cellbender.readthedocs.io/en/stable/usage
+- https://cellbender.readthedocs.io/en/v0.2.2/help_and_reference/remove_background/index.html
+- https://github.com/broadinstitute/CellBender/blob/master/docs/source/usage/index.rst
+- https://github.com/constantAmateur/SoupX

--- a/knowledge_base/skill-guides/singlecell/sc-batch-integration.md
+++ b/knowledge_base/skill-guides/singlecell/sc-batch-integration.md
@@ -1,0 +1,125 @@
+---
+doc_id: skill-guide-sc-batch-integration
+title: OmicsClaw Skill Guide — SC Batch Integration
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-batch-integration, sc-integrate]
+search_terms: [single-cell batch integration, Harmony, scVI, scANVI, BBKNN, Scanorama, batch key, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Batch Integration
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-batch-integration` skill. This guide explains the real wrapper behavior,
+including the public R-backed methods when the matching R stack is available.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether integration is needed or whether the user is really asking for simple joint visualization
+- which integration backend is the best first pass
+- which parameters matter first in the current wrapper
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Batch column**:
+  - `batch_key` must exist and reflect real technical or sample structure
+- **Label availability**:
+  - `scanvi` only makes sense if usable labels already exist
+- **Upstream state**:
+  - PCA should exist or be recomputable
+- **Runtime budget**:
+  - scVI / scANVI are heavier than Harmony or BBKNN
+- **Matrix contract**:
+  - `harmony`, `bbknn`, and `scanorama` operate on normalized / PCA-ready representations
+  - `scvi`, `scanvi`, `fastmnn`, `seurat_cca`, and `seurat_rpca` should preserve or read raw counts from `layers["counts"]` when available
+
+Important implementation notes in current OmicsClaw:
+- implemented paths are `harmony`, `scvi`, `scanvi`, `bbknn`, `scanorama`, `fastmnn`, `seurat_cca`, and `seurat_rpca`
+- the R-backed methods run through the shared H5AD bridge and depend on matching R packages
+- `n_epochs` only matters for scVI / scANVI
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **harmony** | Fast first-pass correction when a batch column is clear | `batch_key` | Wrapper does not expose Harmony’s full low-level tuning surface |
+| **scvi** | Best general deep generative baseline when count data and GPU/compute are available | `batch_key`, `n_epochs`, `no_gpu` | Heavier and slower than graph-based methods |
+| **scanvi** | Best when existing labels should guide integration and transfer | `batch_key`, `n_epochs`, `no_gpu` | Requires labels; otherwise wrapper falls back to scVI |
+| **bbknn** | Lightweight graph correction after PCA | `batch_key` | Mainly graph correction, not a generative latent model |
+| **scanorama** | Useful panorama-style integration baseline | `batch_key` | Wrapper does not expose Scanorama’s full parameter set |
+| **fastmnn** | R-backed correction when users want batchelor fastMNN | `batch_key` | Requires the R batchelor stack and counts-aware input handling |
+| **seurat_cca** | R-backed Seurat integration with CCA anchors | `batch_key` | Requires the R Seurat stack and counts-aware input handling |
+| **seurat_rpca** | R-backed Seurat integration with RPCA anchors | `batch_key` | Requires the R Seurat stack and counts-aware input handling |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run batch integration
+  Method: scvi
+  Parameters: batch_key=batch, n_epochs=400, no_gpu=false
+  Note: n_epochs is only meaningful for the scVI/scANVI paths.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Harmony / BBKNN / Scanorama
+
+Tune in this order:
+1. `batch_key`
+
+Guidance:
+- treat `batch_key` as the most important scientific input because it defines what should be corrected
+- use Harmony as the safest first-pass correction when the user has not chosen a deep model
+
+Important warnings:
+- do not promise Harmony `theta`, BBKNN `neighbors_within_batch`, or Scanorama `knn/sigma` as current public OmicsClaw parameters
+
+### scVI / scANVI
+
+Tune in this order:
+1. `batch_key`
+2. `n_epochs`
+3. `no_gpu`
+
+Guidance:
+- confirm the batch column before tuning epochs
+- use `n_epochs` as the main runtime / convergence control in the current wrapper
+- use `scanvi` only when meaningful labels exist
+
+Important warnings:
+- do not describe scANVI as a drop-in replacement for unlabeled integration
+- do not expose `labels_key`, `unlabeled_category`, or architectural internals as current public wrapper knobs
+
+### fastMNN / Seurat CCA / Seurat RPCA
+
+Tune in this order:
+1. `batch_key`
+
+Guidance:
+- keep raw counts available in `layers["counts"]` before handing data to these backends
+- describe these as R-backed integration paths, not as Python-native code paths
+
+## Step 5: What To Say After The Run
+
+- If batches remain separated: question `batch_key` quality before changing methods.
+- If clusters collapse biologically: explain possible over-correction.
+- If scANVI falls back: say it was because usable labels were missing, not because the model “failed”.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe integrated embeddings as corrected latent or graph spaces, depending on the method
+- describe batch-mixing tables as diagnostics, not universal quality scores
+- describe `processed.h5ad` as the integrated AnnData used for downstream clustering and plotting
+
+## Official References
+
+- https://scanpy.readthedocs.io/en/latest/generated/scanpy.external.pp.harmony_integrate.html
+- https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.SCVI.html
+- https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.SCANVI.html
+- https://bbknn.readthedocs.io/en/latest/bbknn.bbknn.html
+- https://scanpy.readthedocs.io/en/latest/generated/scanpy.external.pp.scanorama_integrate.html
+- https://bioconductor.org/packages/release/bioc/html/batchelor.html
+- https://satijalab.org/seurat/reference/findintegrationanchors

--- a/knowledge_base/skill-guides/singlecell/sc-cell-annotation.md
+++ b/knowledge_base/skill-guides/singlecell/sc-cell-annotation.md
@@ -1,0 +1,118 @@
+---
+doc_id: skill-guide-sc-cell-annotation
+title: OmicsClaw Skill Guide — SC Cell Annotation
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-cell-annotation, sc-annotate]
+search_terms: [single-cell annotation, CellTypist, SingleR, marker-based annotation, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Cell Annotation
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-cell-annotation` skill. This is a wrapper guide for method choice and
+reference/model reasoning, not a claim that all upstream annotation features
+are already exposed.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether marker-based or reference/model-based annotation is the better first pass
+- which parameters matter first in the current wrapper
+- how to explain current fallback behavior honestly
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Cluster labels**:
+  - `markers` depends on a sensible `cluster_key`
+- **Reference / model availability**:
+  - CellTypist needs a real model choice
+  - reference-style paths need a trustworthy reference concept
+- **Expression state**:
+  - marker scoring, CellTypist, SingleR, and scmap should read log-normalized expression
+  - when `adata.raw` exists and matches the current cells/genes, treat it as the preferred source for annotation backends
+
+Important implementation notes in current OmicsClaw:
+- implemented methods are `markers`, `celltypist`, `singler`, and `scmap`
+- `singler` and `scmap` are available via the shared R bridge when the required R packages are installed
+- `model` is the key user-facing CellTypist selector
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **markers** | Fast baseline when clusters are already interpretable | `cluster_key` | Quality is limited by upstream clustering and marker quality; use log-normalized expression rather than counts |
+| **celltypist** | Best first automated model-based label transfer | `model` | Wrapper does not expose the full CellTypist tuning surface |
+| **singler** | Reference-based annotation through SingleR | `reference` | Requires an R environment with SingleR and celldex |
+| **scmap** | Cluster-level projection against a reference atlas | `reference` | Requires the R `scmap` stack and is only as good as the reference clusters |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run cell annotation
+  Method: celltypist
+  Parameters: model=Immune_All_Low
+  Note: reference-style paths read log-normalized expression, preferably from adata.raw.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Marker-Based
+
+Tune in this order:
+1. `cluster_key`
+
+Guidance:
+- use marker-based mode only when clusters already look biologically coherent
+
+### CellTypist
+
+Tune in this order:
+1. `model`
+
+Guidance:
+- choose the smallest model that matches the biology before trying bigger generic atlases
+
+Important warnings:
+- do not expose `majority_voting`, `mode`, or other CellTypist internals as current public OmicsClaw parameters
+
+### SingleR
+
+Tune in this order:
+1. `reference`
+
+Important warnings:
+- ensure the requested reference is available in the current R environment
+- be explicit that this path depends on Bioconductor packages outside the Python environment
+
+### scmap
+
+Tune in this order:
+1. `reference`
+
+Important warnings:
+- use scmap for atlas projection, not as a substitute for marker reasoning when clusters are badly defined
+- keep the explanation clear that scmap is reference-driven and depends on the R bridge stack
+
+## Step 5: What To Say After The Run
+
+- If one label dominates everything: question reference/model mismatch before trusting the labels.
+- If marker-based labels look noisy: question cluster quality first.
+- If SingleR cannot run: explain which R packages are missing instead of pretending marker mode is equivalent.
+- If scmap and SingleR disagree: report the disagreement and revisit the reference choice before forcing a single label story.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe `cell_type` as the standardized label column
+- describe `annotation_method` as the actual wrapper method used
+- describe confidence only when the chosen backend truly produced one
+
+## Official References
+
+- https://celltypist.readthedocs.io/en/latest/celltypist.annotate.html
+- https://celltypist.readthedocs.io/en/latest/notebook/celltypist_tutorial.html
+- https://github.com/Teichlab/celltypist
+- https://bioconductor.org/packages/release/bioc/vignettes/SingleR/inst/doc/SingleR.html
+- https://bioconductor.org/packages/release/bioc/html/scmap.html

--- a/knowledge_base/skill-guides/singlecell/sc-cell-communication.md
+++ b/knowledge_base/skill-guides/singlecell/sc-cell-communication.md
@@ -1,0 +1,88 @@
+---
+doc_id: skill-guide-sc-cell-communication
+title: OmicsClaw Skill Guide — SC Cell Communication
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-cell-communication]
+search_terms: [cell communication, ligand receptor, LIANA, CellChat, groupby, species, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Cell Communication
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-cell-communication` skill. This guide explains the current wrapper surface
+and does not imply the full LIANA or CellChat parameter set is exposed.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether the current cell-type labels are good enough for communication analysis
+- which backend is the best first pass
+- how to explain grouping and species settings correctly
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Grouping column**:
+  - `cell_type_key` must hold biologically meaningful labels
+- **Species context**:
+  - species affects ligand-receptor resource interpretation
+- **Expression representation**:
+  - raw vs normalized state matters differently across backends
+
+Important implementation notes in current OmicsClaw:
+- public methods are `builtin`, `liana`, and `cellchat_r`
+- `cell_type_key` is the most important scientific parameter in the wrapper
+- the built-in path is a lightweight OmicsClaw baseline, not a full external method
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **builtin** | Fast sanity-check baseline | `cell_type_key`, `species` | Small curated interaction list |
+| **liana** | Best first rich Python-native backend | `cell_type_key`, `species` | Wrapper does not expose LIANA’s full filtering surface |
+| **cellchat_r** | When users explicitly want CellChat-style analysis | `cell_type_key`, `species` | R backend and resource assumptions matter |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run cell-cell communication
+  Method: liana
+  Parameters: cell_type_key=cell_type, species=human
+  Note: the grouping column is the most important scientific input for this analysis.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+Tune in this order:
+1. `cell_type_key`
+2. `method`
+3. `species`
+
+Guidance:
+- treat grouping quality as more important than backend switching
+- use `builtin` as a quick baseline, then `liana` or `cellchat_r` if the user needs richer inference
+
+Important warnings:
+- do not expose LIANA `expr_prop`, `min_cells`, or CellChat internal model parameters as current public OmicsClaw knobs
+- do not promise correct species-specific biology if the requested resource support is uncertain
+
+## Step 5: What To Say After The Run
+
+- If interactions are sparse: question label quality and species/resource compatibility first.
+- If the built-in method and LIANA disagree: explain that the built-in method is intentionally lightweight.
+- If users ask for pathway-level CellChat controls: explain that the current wrapper does not expose that full surface.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe interaction tables as ranked ligand-receptor hypotheses between label groups
+- describe top plots as summaries of scored interactions, not direct causal proof
+- describe method names explicitly because score semantics differ by backend
+
+## Official References
+
+- https://liana-py.readthedocs.io/en/latest/generated/liana.method.rank_aggregate.__call__.html
+- https://liana-py.readthedocs.io/
+- https://github.com/jinworks/CellChat
+

--- a/knowledge_base/skill-guides/singlecell/sc-de.md
+++ b/knowledge_base/skill-guides/singlecell/sc-de.md
@@ -1,0 +1,119 @@
+---
+doc_id: skill-guide-sc-de
+title: OmicsClaw Skill Guide — SC Differential Expression
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-de]
+search_terms: [single-cell differential expression, Wilcoxon, DESeq2 pseudobulk, groupby, replicates, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Differential Expression
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-de` skill. This guide emphasizes the difference between exploratory
+single-cell marker ranking and replicate-aware pseudobulk inference.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether the user wants exploratory marker ranking or formal condition DE
+- which method is the best first pass
+- which parameters matter first in the current wrapper
+
+## Step 1: Inspect The Design First
+
+Key properties to check:
+- **Comparison target**:
+  - cluster markers vs condition comparison
+- **Grouping variable**:
+  - `groupby` must reflect the intended biological comparison
+- **Replicates**:
+  - `deseq2_r` only makes sense if replicate/sample structure exists
+- **Cell-type restriction**:
+  - pseudobulk paths often need a meaningful `celltype_key`
+- **Expression layer**:
+  - `wilcoxon`, `t-test`, and `mast` should use log-normalized expression, ideally `adata.raw`
+  - `deseq2_r` should use raw counts, ideally `layers["counts"]`; only use `adata.X` if `X` is still the unnormalized count matrix
+
+Important implementation notes in current OmicsClaw:
+- `wilcoxon` and `t-test` are Scanpy exploratory paths
+- the current public wrapper exposes Scanpy exploratory tests, the R-backed `mast` path, and the DESeq2 pseudobulk path
+- `deseq2_r` is the wrapper’s replicate-aware pseudobulk path
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **wilcoxon** | Safest first-pass marker or group ranking | `groupby`, `n_top_genes` | Exploratory, not replicate-aware |
+| **t-test** | Parametric alternative for simple group ranking | `groupby`, `n_top_genes` | Still exploratory |
+| **mast** | When a hurdle-model single-cell test is preferred on log-normalized expression | `groupby`, `group1`, `group2`, `n_top_genes` | Needs the R MAST stack and still is not a replicate-aware pseudobulk design |
+| **deseq2_r** | Best formal path for replicate-aware condition DE | `groupby`, `group1`, `group2`, `sample_key`, `celltype_key` | Needs true replicate structure |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run single-cell differential expression
+  Method: deseq2_r
+  Parameters: groupby=condition, group1=treated, group2=control, sample_key=sample_id, celltype_key=cell_type
+  Note: this is a pseudobulk replicate-aware path, not simple per-cell ranking.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Exploratory Scanpy Paths
+
+Tune in this order:
+1. `groupby`
+2. `method`
+3. `n_top_genes`
+4. `group1` / `group2`
+
+Guidance:
+- use these when the goal is fast ranking, not formal replicate-aware inference
+
+### DESeq2 pseudobulk
+
+Tune in this order:
+1. `groupby`
+2. `group1` / `group2`
+3. `sample_key`
+4. `celltype_key`
+
+Guidance:
+- choose this path only when the user truly has replicate-level samples
+- `sample_key` and `celltype_key` are as important as the statistical method itself
+
+Important warnings:
+- do not expose a free-form DESeq2 design formula as if the wrapper supports it
+
+### MAST
+
+Tune in this order:
+1. `groupby`
+2. `group1` / `group2`
+3. `n_top_genes`
+
+Guidance:
+- use this path when users want an R-backed single-cell DE model on log-normalized expression
+- do not confuse it with the pseudobulk DESeq2 path; it answers a different statistical question
+
+## Step 5: What To Say After The Run
+
+- If users want cluster markers: recommend keeping the explanation in exploratory language.
+- If users want treatment-vs-control claims without replicates: say the design is weak before discussing p-values.
+- If pseudobulk results look odd: revisit `sample_key` and `celltype_key` before blaming DESeq2.
+- If MAST and Wilcoxon disagree: inspect the grouping variable and expression layer before interpreting biology.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe Scanpy results as ranked marker-style DE outputs
+- describe MAST results as single-cell hurdle-model DE outputs on log-normalized expression
+- describe DESeq2 results as pseudobulk replicate-aware inference
+- describe `de_full.csv` as the full result table and `markers_top.csv` as the condensed export
+
+## Official References
+
+- https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html
+- https://bioconductor.org/packages/release/bioc/html/MAST.html
+- https://bioconductor.org/packages/release/bioc/vignettes/DESeq2/inst/doc/DESeq2.html

--- a/knowledge_base/skill-guides/singlecell/sc-doublet-detection.md
+++ b/knowledge_base/skill-guides/singlecell/sc-doublet-detection.md
@@ -1,0 +1,90 @@
+---
+doc_id: skill-guide-sc-doublet-detection
+title: OmicsClaw Skill Guide — SC Doublet Detection
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-doublet-detection, sc-doublet]
+search_terms: [doublet detection, Scrublet, DoubletFinder, scDblFinder, expected doublet rate, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Doublet Detection
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-doublet-detection` skill. This guide explains the current wrapper surface,
+not every backend-specific parameter described upstream.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether doublet detection should be run before clustering / annotation / DE
+- which backend is the most appropriate first pass
+- how to explain expected doublet rate and thresholding honestly
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Capture type**:
+  - droplet-based datasets are the primary use case
+- **Load / multiplexing context**:
+  - expected doublet burden depends on loading and sample design
+- **Current analysis stage**:
+  - doublet labeling is usually more useful before final annotation
+
+Important implementation notes in current OmicsClaw:
+- the wrapper exposes `scrublet`, `doubletfinder`, and `scdblfinder`
+- `threshold` only affects the Scrublet path
+- the wrapper annotates doublets; it does not automatically drop them
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **scrublet** | Fast Python-native first pass | `expected_doublet_rate`, optional `threshold` | Threshold override only applies here |
+| **doubletfinder** | When an R-based Seurat-style path is explicitly desired | `expected_doublet_rate` | Current wrapper does not expose the full DoubletFinder tuning stack |
+| **scdblfinder** | Strong R/Bioconductor baseline with a simpler public surface | `expected_doublet_rate` | Wrapper hides many advanced scDblFinder options |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run doublet detection
+  Method: scrublet
+  Parameters: expected_doublet_rate=0.06, threshold=auto
+  Note: threshold override is only implemented for the Scrublet path.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Shared first-pass rule
+
+Tune in this order:
+1. `expected_doublet_rate`
+2. `threshold` (Scrublet only)
+
+Guidance:
+- `expected_doublet_rate` is the main shared scientific prior in the current wrapper
+- only use manual `threshold` when Scrublet’s automatic separation is clearly unsatisfactory
+
+Important warnings:
+- do not promise DoubletFinder `pK`, `pN`, or `nExp`; the wrapper does not expose them
+- do not promise scDblFinder sample-level / cluster-level fine controls; the wrapper does not expose them
+
+## Step 5: What To Say After The Run
+
+- If many doublets are called: mention loading burden or sample complexity, not just “bad quality”.
+- If very few are called: mention the assumed expected rate and whether the threshold was conservative.
+- If users ask whether cells were removed: state clearly that the wrapper labels but does not auto-delete.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe `doublet_score` as backend-specific evidence, not a universal probability
+- describe `predicted_doublet` as the wrapper’s boolean call
+- describe `doublet_classification` as the human-readable summary column
+
+## Official References
+
+- https://github.com/swolock/scrublet
+- https://github.com/chris-mcginnis-ucsf/DoubletFinder/blob/master/README.md
+- https://bioconductor.org/packages/release/bioc/vignettes/scDblFinder/inst/doc/scDblFinder.html
+- https://github.com/plger/scDblFinder/blob/devel/README.md
+

--- a/knowledge_base/skill-guides/singlecell/sc-filter.md
+++ b/knowledge_base/skill-guides/singlecell/sc-filter.md
@@ -1,0 +1,110 @@
+---
+doc_id: skill-guide-sc-filter
+title: OmicsClaw Skill Guide — SC Filter
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-filter]
+search_terms: [single-cell filtering, QC filtering, min genes, mitochondrial percent, tissue preset, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Filter
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-filter` skill. This is a living guide for threshold reasoning and
+wrapper-specific caveats, not a claim that OmicsClaw already performs automatic
+QC decision-making.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether `sc-filter` should be run now or whether `sc-qc` is still needed first
+- which filtering thresholds matter most in the current wrapper
+- how to explain wrapper presets without pretending they are universal biology rules
+
+## Step 1: Inspect The Data First
+
+If the dataset has not been inspected yet in this conversation, inspect it
+before running filtering.
+
+Key properties to check:
+- **QC metrics availability**:
+  - `n_genes_by_counts`
+  - `total_counts`
+  - `pct_counts_mt`
+- **Matrix state**:
+  - current wrapper assumes count-like or QC-ready AnnData input
+- **Biological context**:
+  - blood, tumor, and solid tissues often justify different `%MT` tolerance
+- **Filtering goal**:
+  - remove low-quality cells only
+  - remove extreme high-count / likely doublet-like cells
+  - remove low-support genes
+
+Important implementation notes in current OmicsClaw:
+- the public workflow is `threshold_filtering`
+- `tissue` is an OmicsClaw wrapper preset, not a Scanpy upstream parameter
+- `min_genes`, `max_mt_percent`, and `min_cells` are the primary first-pass controls
+
+## Step 2: Pick The Method Deliberately
+
+Current OmicsClaw exposes one filtering workflow:
+
+| Workflow | Best first use | Main caveat |
+|----------|----------------|-------------|
+| **threshold_filtering** | Standard QC thresholding after reviewing QC plots | Does not infer optimal cutoffs automatically |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+Before execution, summarize the real run in a short block, for example:
+
+```text
+About to run single-cell filtering
+  Workflow: threshold_filtering
+  Parameters: min_genes=200, max_mt_percent=20, min_cells=3
+  Note: tissue presets are wrapper heuristics, not Scanpy-native parameters.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+### Threshold Filtering
+
+Tune in this order:
+1. `min_genes`
+2. `max_mt_percent`
+3. `min_cells`
+4. `max_genes` / `max_counts`
+5. `tissue`
+
+Guidance:
+- start with `min_genes` and `max_mt_percent`; they usually control the largest low-quality tail
+- use `min_cells` to remove ultra-rare genes after deciding cell retention
+- use `max_genes` or `max_counts` when you specifically suspect high-count outliers or doublets
+- use `tissue` only as a fast wrapper preset, then review whether its implied thresholds fit the biology
+
+Important warnings:
+- do not describe `tissue` as an official Scanpy argument
+- do not imply this wrapper learns optimal cutoffs from the data
+- do not treat `max_counts` and `max_genes` as universally mandatory first-pass knobs
+
+## Step 5: What To Say After The Run
+
+- If retention is unexpectedly low: revisit `min_genes` and `max_mt_percent` first.
+- If obvious high-count outliers remain: consider adding `max_counts` or a dedicated doublet step.
+- If users ask why genes disappeared: explain `min_cells` separately from cell filtering.
+- If the preset felt too aggressive: say the issue is the wrapper heuristic, not necessarily the dataset quality.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+When summarizing results:
+- describe `filtered.h5ad` as the threshold-filtered AnnData
+- describe `tables/filter_stats.csv` as the exact filtering audit trail
+- describe `report.md` as the narrative summary of retained cells and genes
+- describe the reproducibility bundle as the replayable command plus environment snapshot
+
+## Official References
+
+- https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.filter_cells.html
+- https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.filter_genes.html
+- https://scanpy.readthedocs.io/en/stable/api/scanpy.pp.calculate_qc_metrics.html
+

--- a/knowledge_base/skill-guides/singlecell/sc-grn.md
+++ b/knowledge_base/skill-guides/singlecell/sc-grn.md
@@ -1,0 +1,94 @@
+---
+doc_id: skill-guide-sc-grn
+title: OmicsClaw Skill Guide — SC GRN
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-grn]
+search_terms: [GRN, pySCENIC, regulon, TF list, motif database, AUCell, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC GRN
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-grn` skill. This guide focuses on the current pySCENIC-style wrapper and
+its real resource requirements.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether the user has the external resources needed for a real GRN run
+- which parameters matter most in the current wrapper
+- how to explain pySCENIC stages without pretending they are one monolithic step
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Expression state**:
+  - preprocessed expression matrix is expected
+- **External resources**:
+  - TF list
+  - motif annotation file
+  - cisTarget / ranking database files
+- **Compute budget**:
+  - GRNBoost2 can be expensive on large matrices
+
+Important implementation notes in current OmicsClaw:
+- the public workflow is effectively `pyscenic_workflow`
+- the wrapper covers GRNBoost2, motif pruning, and AUCell scoring
+- `n_top_targets` is mainly a wrapper export cap, not a pySCENIC core algorithm knob
+
+## Step 2: Pick The Method Deliberately
+
+Current OmicsClaw exposes one GRN workflow:
+
+| Workflow | Best first use | Main caveat |
+|----------|----------------|-------------|
+| **pyscenic_workflow** | Full regulon analysis when required resources are available | Not self-contained; external databases are mandatory |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run GRN inference
+  Workflow: pyscenic_workflow
+  Parameters: tf_list=tfs.txt, db=*.feather, motif=motifs.tbl, n_jobs=8
+  Note: this workflow requires external pySCENIC resources and will not auto-download them.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+Tune in this order:
+1. `tf_list`
+2. `db`
+3. `motif`
+4. `n_jobs`
+5. `seed`
+
+Guidance:
+- treat `tf_list`, `db`, and `motif` as core scientific inputs, not optional extras
+- use `n_jobs` for runtime scaling
+- use `seed` when reproducibility matters across repeated runs
+
+Important warnings:
+- do not pretend the wrapper exposes the full pySCENIC CLI parameter surface
+- do not say the workflow can run meaningfully without database resources
+
+## Step 5: What To Say After The Run
+
+- If no regulons are found: check TF list coverage and motif database compatibility first.
+- If runtime is excessive: mention `n_jobs` and resource size before changing biology-facing assumptions.
+- If AUCell activity looks sparse: explain that resource mismatch can matter as much as model quality.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe adjacencies as candidate TF-target co-expression edges
+- describe regulons as motif-pruned TF target sets
+- describe AUCell scores as per-cell regulon activity estimates
+
+## Official References
+
+- https://pyscenic.readthedocs.io/en/latest/tutorial.html
+- https://pyscenic.readthedocs.io/en/latest/installation.html
+- https://github.com/aertslab/pySCENIC
+- https://arboreto.readthedocs.io/en/latest/userguide.html
+

--- a/knowledge_base/skill-guides/singlecell/sc-markers.md
+++ b/knowledge_base/skill-guides/singlecell/sc-markers.md
@@ -1,0 +1,90 @@
+---
+doc_id: skill-guide-sc-markers
+title: OmicsClaw Skill Guide — SC Markers
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-markers]
+search_terms: [marker genes, rank_genes_groups, wilcoxon, logreg, cluster markers, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Markers
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-markers` skill. This guide is about cluster-level marker ranking, not
+replicate-aware condition DE.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether the user wants cluster markers or condition DE
+- which ranking method is the best first pass
+- which output parameters matter for interpretation
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Grouping column**:
+  - `groupby` should represent meaningful clusters or labels
+- **Upstream clustering quality**:
+  - poor clusters lead to poor markers
+- **Expression state**:
+  - the wrapper expects preprocessed single-cell data
+
+Important implementation notes in current OmicsClaw:
+- methods are `wilcoxon`, `t-test`, and `logreg`
+- `groupby` is the core scientific parameter
+- `n_genes` and `n_top` mainly control exported results and visualization scope
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **wilcoxon** | Safest first-pass cluster marker ranking | `groupby`, `n_genes`, `n_top` | Still exploratory, not replicate-aware |
+| **t-test** | Parametric alternative when users want a simple mean-shift test | `groupby`, `n_genes`, `n_top` | More sensitive to distribution assumptions |
+| **logreg** | When users want classification-style marker ranking | `groupby`, `n_genes`, `n_top` | Do not oversell as minimal marker-panel selection |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run cluster marker discovery
+  Method: wilcoxon
+  Parameters: groupby=leiden, n_genes=all, n_top=10
+  Note: this skill is for cluster markers, not replicate-aware condition DE.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+Tune in this order:
+1. `groupby`
+2. `method`
+3. `n_genes`
+4. `n_top`
+
+Guidance:
+- treat `groupby` as the most important decision because it defines the biological comparison
+- start with `wilcoxon` unless the user has a strong reason to prefer another ranking mode
+- use `n_genes` to control export breadth
+- use `n_top` to control summary tables and plots
+
+Important warnings:
+- do not present this as condition-aware DE
+- do not claim low-level Scanpy ranking knobs are publicly exposed here
+
+## Step 5: What To Say After The Run
+
+- If markers look weak: question cluster quality before blaming the ranking test.
+- If too many markers are exported: reduce `n_genes` or rely on `n_top` for summaries.
+- If users want treated-vs-control DE: redirect them to `sc-de`.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe marker tables as cluster-discriminative genes
+- describe the heatmap/dotplot as visualization summaries, not validation by themselves
+- describe `adata_with_markers.h5ad` as the same AnnData with marker-related metadata preserved for reuse
+
+## Official References
+
+- https://scanpy.readthedocs.io/en/stable/api/scanpy.tl.rank_genes_groups.html
+- https://scanpy.readthedocs.io/en/1.9.x/generated/scanpy.tl.rank_genes_groups.html
+

--- a/knowledge_base/skill-guides/singlecell/sc-pseudotime.md
+++ b/knowledge_base/skill-guides/singlecell/sc-pseudotime.md
@@ -1,0 +1,92 @@
+---
+doc_id: skill-guide-sc-pseudotime
+title: OmicsClaw Skill Guide — SC Pseudotime
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-pseudotime]
+search_terms: [pseudotime, DPT, PAGA, diffusion map, root cluster, trajectory genes, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Pseudotime
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-pseudotime` skill. This guide separates the trajectory method itself from
+the trajectory-gene ranking method used afterward.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether DPT is the right trajectory path for the current dataset
+- how to explain root choice correctly
+- which parameters matter most in the current wrapper
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Cluster labels**:
+  - `cluster_key` must exist and be biologically interpretable
+- **Graph readiness**:
+  - neighbors should exist or be recomputable
+- **Root knowledge**:
+  - a biologically plausible root cluster or root cell is often the most important human choice
+
+Important implementation notes in current OmicsClaw:
+- trajectory `method` is currently only `dpt`
+- `corr_method` is not a trajectory algorithm; it only ranks trajectory genes after pseudotime is inferred
+- the wrapper bundles PAGA, diffusion map, and DPT into one execution path
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **dpt** | Classic Scanpy pseudotime after clustering and graph construction | `cluster_key`, `root_cluster`, `n_dcs`, `corr_method` | Root choice still governs directionality |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run pseudotime analysis
+  Method: dpt
+  Parameters: cluster_key=leiden, root_cluster=0, n_dcs=10, n_genes=50, corr_method=pearson
+  Note: corr_method only affects trajectory-gene ranking after DPT is computed.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+Tune in this order:
+1. `cluster_key`
+2. `root_cluster` or `root_cell`
+3. `n_dcs`
+4. `n_genes`
+5. `corr_method`
+
+Guidance:
+- choose `root_cluster` or `root_cell` before touching numeric tuning
+- use `n_dcs` to control how much diffusion structure is retained for DPT
+- use `n_genes` to control how many trajectory-associated genes are exported
+- use `corr_method` only to change the downstream ranking rule
+
+Important warnings:
+- do not describe `pearson` or `spearman` as pseudotime methods
+- do not imply Palantir or CellRank are implemented in this wrapper
+- do not expose Scanpy parameters that the wrapper does not currently forward
+
+## Step 5: What To Say After The Run
+
+- If pseudotime looks biologically reversed: revisit root choice first.
+- If trajectory genes are unstable: revisit `corr_method` only after confirming the trajectory itself makes sense.
+- If branch structure looks implausible: question upstream clustering or neighbor graph quality.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe PAGA as coarse cluster connectivity
+- describe DPT as pseudotemporal ordering from the chosen root
+- describe trajectory genes as genes correlated with inferred pseudotime in the current wrapper
+
+## Official References
+
+- https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.paga.html
+- https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.diffmap.html
+- https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.dpt.html
+- https://scanpy.readthedocs.io/en/latest/tutorials/trajectories/paga-paul15.html
+

--- a/knowledge_base/skill-guides/singlecell/sc-velocity.md
+++ b/knowledge_base/skill-guides/singlecell/sc-velocity.md
@@ -1,0 +1,91 @@
+---
+doc_id: skill-guide-sc-velocity
+title: OmicsClaw Skill Guide — SC Velocity
+doc_type: method-reference
+domains: [singlecell]
+related_skills: [sc-velocity]
+search_terms: [RNA velocity, scVelo, stochastic, dynamical, steady_state, latent time, tuning]
+priority: 0.8
+---
+
+# OmicsClaw Skill Guide — SC Velocity
+
+**Status**: implementation-aligned guide derived from the current OmicsClaw
+`sc-velocity` skill. This guide explains the current wrapper surface around
+scVelo modes without pretending the full scVelo API is exposed.
+
+## Purpose
+
+Use this guide when you need to decide:
+- whether the input is genuinely velocity-ready
+- which scVelo mode is appropriate
+- how to explain latent time honestly
+
+## Step 1: Inspect The Data First
+
+Key properties to check:
+- **Required layers**:
+  - `layers["spliced"]`
+  - `layers["unspliced"]`
+- **Upstream state**:
+  - preprocessed / graph-ready data is preferred
+- **Scientific question**:
+  - directionality only
+  - full dynamical interpretation with latent time
+
+Important implementation notes in current OmicsClaw:
+- public methods are `scvelo_stochastic`, `scvelo_dynamical`, and `scvelo_steady_state`
+- `--mode` is a public alias for the same backend selection
+- `latent_time` should not be promised outside the dynamical path
+
+## Step 2: Pick The Method Deliberately
+
+| Method | Best first use | Strong starting parameters | Main caveat |
+|--------|----------------|----------------------------|-------------|
+| **scvelo_stochastic** | Standard first-pass velocity visualization | `n_jobs` | No guarantee of latent time |
+| **scvelo_dynamical** | When users explicitly want latent-time-style interpretation | `n_jobs` | Requires stronger modeling assumptions |
+| **scvelo_steady_state** | Simpler steady-state approximation path | `n_jobs` | More limited than dynamical modeling |
+
+## Step 3: Always Show A Parameter Summary Before Running
+
+```text
+About to run RNA velocity
+  Method: scvelo_dynamical
+  Parameters: n_jobs=4
+  Note: latent time is only expected on the dynamical path and still depends on successful dynamics recovery.
+```
+
+## Step 4: Method-Specific Tuning Rules
+
+Tune in this order:
+1. `method` / `mode`
+2. `n_jobs`
+
+Guidance:
+- choose the mode before touching runtime controls
+- use `stochastic` as the safest first-pass default
+- use `dynamical` when the user specifically wants stronger temporal interpretation
+
+Important warnings:
+- do not expose `recover_dynamics` internals as if they were current public wrapper parameters
+- do not promise latent time for every velocity run
+- do not imply arbitrary scVelo options are available just because upstream scVelo documents them
+
+## Step 5: What To Say After The Run
+
+- If latent time is missing: explain that the selected mode or model fit may not support it.
+- If velocity plots look noisy: mention input-layer quality and upstream preprocessing before blaming mode choice.
+- If users ask for more scVelo knobs: state clearly that the current wrapper exposes only a narrow control surface.
+
+## Step 6: Explain Outputs Using Method-Correct Language
+
+- describe velocity stream / embedding plots as directional summaries on the chosen embedding
+- describe velocity magnitude as a heuristic summary, not a direct biological rate constant
+- describe latent time only as a dynamical-model-derived quantity
+
+## Official References
+
+- https://scvelo.readthedocs.io/en/stable/scvelo.tl.velocity.html
+- https://scvelo.readthedocs.io/en/stable/scvelo.tl.recover_dynamics.html
+- https://scvelo.readthedocs.io/en/stable/VelocityBasics.html
+- https://scvelo.readthedocs.io/en/stable/DynamicalModeling.html

--- a/omicsclaw/common/report.py
+++ b/omicsclaw/common/report.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from omicsclaw.common.checksums import sha256_file
+
+logger = logging.getLogger(__name__)
 
 DISCLAIMER = (
     "OmicsClaw is a research and educational tool for multi-omics "
@@ -183,6 +186,76 @@ def write_output_readme(
     lines.extend(["", "## Notes", "", f"- {DISCLAIMER}"])
     readme_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return readme_path
+
+
+def write_repro_requirements(
+    output_dir: str | Path,
+    packages: list[str],
+) -> Path:
+    """Write a best-effort pinned requirements file under reproducibility/."""
+    output_dir = Path(output_dir)
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    env_lines: list[str] = []
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    for pkg in packages:
+        try:
+            env_lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+
+    req_path = repro_dir / "requirements.txt"
+    req_path.write_text("\n".join(env_lines) + ("\n" if env_lines else ""), encoding="utf-8")
+    return req_path
+
+
+def write_standard_run_artifacts(
+    output_dir: str | Path,
+    *,
+    skill_alias: str,
+    description: str,
+    result_payload: dict[str, Any],
+    preferred_method: str | None,
+    script_path: str | Path,
+    actual_command: list[str],
+) -> None:
+    """Emit notebook and README artifacts when dependencies allow."""
+    output_dir = Path(output_dir)
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=skill_alias,
+            description=description,
+            result_payload=result_payload,
+            preferred_method=preferred_method,
+            script_path=Path(script_path).resolve(),
+            actual_command=actual_command,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook for %s: %s", skill_alias, exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=skill_alias,
+            description=description,
+            result_payload=result_payload,
+            preferred_method=preferred_method,
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md for %s: %s", skill_alias, exc)
 
 
 def generate_report_header(

--- a/omicsclaw/core/r_script_runner.py
+++ b/omicsclaw/core/r_script_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -111,6 +112,7 @@ class RScriptRunner:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=self._build_r_env(),
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -137,6 +139,7 @@ class RScriptRunner:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                env=self._build_r_env(),
             )
             for line in result.stdout.strip().splitlines():
                 line = line.strip()
@@ -223,7 +226,7 @@ class RScriptRunner:
         if self.verbose:
             logger.info("Running: %s", " ".join(cmd))
 
-        run_env = os.environ.copy()
+        run_env = self._build_r_env()
         if env:
             run_env.update(env)
 
@@ -288,6 +291,36 @@ class RScriptRunner:
             output_dir=Path(output_dir) if output_dir else None,
             elapsed_seconds=elapsed,
         )
+
+    def _build_r_env(self) -> dict[str, str]:
+        """Build a subprocess environment that stays inside the active conda env.
+
+        This keeps reticulate/zellkonverter from silently pulling a managed Python
+        runtime that differs from the current OmicsClaw environment.
+        """
+        env = os.environ.copy()
+        conda_prefix = env.get("CONDA_PREFIX")
+
+        python_candidates: list[str] = []
+        if conda_prefix:
+            python_candidates.append(str(Path(conda_prefix) / "bin" / "python"))
+        python_candidates.append(sys.executable)
+
+        for candidate in python_candidates:
+            if candidate and Path(candidate).exists():
+                env.setdefault("RETICULATE_PYTHON", candidate)
+                env.setdefault("PYTHON_BIN", candidate)
+                break
+
+        if conda_prefix:
+            r_libs_user = Path(conda_prefix) / "lib" / "R" / "omicsclaw-library"
+            r_libs_user.mkdir(parents=True, exist_ok=True)
+            env.setdefault("OMICSCLAW_R_LIBS", str(r_libs_user))
+            env.setdefault("R_LIBS_USER", str(r_libs_user))
+
+        # Disable reticulate's managed ephemeral Python selection when possible.
+        env.setdefault("RETICULATE_USE_MANAGED_VENV", "no")
+        return env
 
     # ------------------------------------------------------------------
     # Helpers

--- a/omicsclaw/knowledge/knowhow.py
+++ b/omicsclaw/knowledge/knowhow.py
@@ -263,8 +263,11 @@ class KnowHowInjector:
 
         keyword_match = bool(query_lower) and self._contains_term(query_lower, keyword_terms)
         domain_match = bool(domain_lower) and (
-            "__all__" in domain_terms or domain_lower in domain_terms
+            "__all__" in domain_terms or "general" in domain_terms or domain_lower in domain_terms
         )
+
+        if domain_lower and domain_terms and not domain_match:
+            return None
 
         if domain_match and keyword_match:
             return 500.0 + meta.priority, "domain+query"
@@ -353,6 +356,11 @@ class KnowHowInjector:
 
         matched.sort(key=lambda item: (-item[0], item[1]))
         return matched
+
+    def get_all_kh_ids(self) -> list[str]:
+        """Return list of all loaded KH document identifiers."""
+        self._ensure_loaded()
+        return list(self._cache.keys())
 
     def get_kh_for_skill(self, skill: str) -> list[str]:
         """Return KH filenames relevant to a specific skill."""

--- a/omicsclaw/r_scripts/sc_cellchat.R
+++ b/omicsclaw/r_scripts/sc_cellchat.R
@@ -47,6 +47,12 @@ tryCatch({
     if (!"samples" %in% colnames(meta))
         meta$samples <- "sample1"
 
+    meta[[cell_type_key]] <- as.character(meta[[cell_type_key]])
+    meta[[cell_type_key]] <- ifelse(grepl("^[0-9]", meta[[cell_type_key]]),
+        paste0("cluster_", meta[[cell_type_key]]),
+        meta[[cell_type_key]])
+    meta[[cell_type_key]] <- factor(meta[[cell_type_key]])
+
     cat(sprintf("  %d cells, %d cell types, species=%s\n",
         ncol(counts), length(unique(meta[[cell_type_key]])), species))
 
@@ -70,10 +76,20 @@ tryCatch({
     cellchat <- aggregateNet(cellchat)
 
     cat("Computing network centrality metrics...\n")
-    cellchat <- netAnalysis_computeCentrality(cellchat)
+    tryCatch({
+        cellchat <- netAnalysis_computeCentrality(cellchat)
+    }, error = function(e) {
+        cat(sprintf("  Note: centrality computation skipped (%s)\n", e$message))
+    })
 
     # --- Export L-R pair interactions ---
-    df <- subsetCommunication(cellchat)
+    df <- tryCatch(
+        subsetCommunication(cellchat),
+        error = function(e) {
+            cat(sprintf("  Note: interaction export returned no significant hits (%s)\n", e$message))
+            data.frame()
+        }
+    )
 
     if (!nrow(df)) {
         cat("WARNING: No significant interactions found\n")

--- a/omicsclaw/r_scripts/sc_doubletfinder.R
+++ b/omicsclaw/r_scripts/sc_doubletfinder.R
@@ -47,7 +47,7 @@ tryCatch({
 
     seurat_obj <- doubletFinder(seurat_obj,
         PCs = 1:30, pN = 0.25, pK = pK_optimal,
-        nExp = nExp_poi_adj, reuse.pANN = FALSE, sct = FALSE)
+        nExp = nExp_poi_adj, reuse.pANN = NULL, sct = FALSE)
 
     df_cols  <- grep("^DF.classifications", colnames(seurat_obj@meta.data), value = TRUE)
     pann_cols <- grep("^pANN", colnames(seurat_obj@meta.data), value = TRUE)

--- a/omicsclaw/r_scripts/sc_mast_de.R
+++ b/omicsclaw/r_scripts/sc_mast_de.R
@@ -1,0 +1,73 @@
+#!/usr/bin/env Rscript
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 3) {
+    cat("Usage: Rscript sc_mast_de.R <h5ad_file> <output_dir> <groupby> [group1] [group2]\n")
+    quit(status = 1)
+}
+
+h5ad_file  <- args[1]
+output_dir <- args[2]
+groupby    <- args[3]
+group1     <- if (length(args) >= 4) args[4] else ""
+group2     <- if (length(args) >= 5) args[5] else ""
+
+suppressPackageStartupMessages({
+    library(MAST)
+    library(SingleCellExperiment)
+    library(zellkonverter)
+})
+
+if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+
+run_one <- function(expr_mat, meta, label, comparison_label) {
+    fdata <- data.frame(primerid = rownames(expr_mat), row.names = rownames(expr_mat), stringsAsFactors = FALSE)
+    sca <- FromMatrix(exprsArray = as.matrix(expr_mat), cData = meta, fData = fdata)
+    colData(sca)$cngeneson <- scale(colSums(assay(sca) > 0))
+    z <- zlm(~ contrast_group + cngeneson, sca, method = "bayesglm", silent = TRUE, parallel = FALSE)
+    s <- summary(z, doLRT = "contrast_groupcase")$datatable
+    cont <- s[s$component == "C" & s$contrast == "contrast_groupcase", c("primerid", "coef")]
+    disc <- s[s$component == "H" & s$contrast == "contrast_groupcase", c("primerid", "Pr(>Chisq)")]
+    out <- merge(cont, disc, by = "primerid", all = TRUE)
+    colnames(out) <- c("gene", "logFC", "pvalue")
+    out$padj <- p.adjust(out$pvalue, method = "BH")
+    out$group <- label
+    out$comparison <- comparison_label
+    out
+}
+
+tryCatch({
+    sce <- readH5AD(h5ad_file)
+    meta <- as.data.frame(SummarizedExperiment::colData(sce))
+    if (!groupby %in% colnames(meta)) stop(sprintf("Column '%s' not found in metadata", groupby))
+
+    expr_mat <- SummarizedExperiment::assay(sce, "X")
+    if (nrow(expr_mat) == nrow(meta)) {
+        expr_mat <- t(expr_mat)
+    }
+    if (is(expr_mat, "sparseMatrix")) expr_mat <- as.matrix(expr_mat)
+    rownames(expr_mat) <- rownames(sce)
+    colnames(expr_mat) <- colnames(sce)
+
+    results <- list()
+    if (nzchar(group1) && nzchar(group2)) {
+        keep <- meta[[groupby]] %in% c(group1, group2)
+        meta_sub <- meta[keep, , drop = FALSE]
+        expr_sub <- expr_mat[, keep, drop = FALSE]
+        meta_sub$contrast_group <- factor(ifelse(meta_sub[[groupby]] == group1, "case", "ref"), levels = c("ref", "case"))
+        results[[1]] <- run_one(expr_sub, meta_sub, group1, sprintf("%s vs %s", group1, group2))
+    } else {
+        groups <- unique(as.character(meta[[groupby]]))
+        for (grp in groups) {
+            meta_sub <- meta
+            meta_sub$contrast_group <- factor(ifelse(as.character(meta_sub[[groupby]]) == grp, "case", "ref"), levels = c("ref", "case"))
+            results[[grp]] <- run_one(expr_mat, meta_sub, grp, sprintf("%s vs rest", grp))
+        }
+    }
+
+    out <- do.call(rbind, results)
+    rownames(out) <- NULL
+    write.csv(out, file.path(output_dir, "mast_results.csv"), quote = FALSE, row.names = FALSE)
+}, error = function(e) {
+    cat(sprintf("ERROR: %s\n", e$message), file = stderr())
+    quit(status = 1)
+})

--- a/omicsclaw/r_scripts/sc_scmap_annotate.R
+++ b/omicsclaw/r_scripts/sc_scmap_annotate.R
@@ -1,0 +1,68 @@
+#!/usr/bin/env Rscript
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 2) {
+    cat("Usage: Rscript sc_scmap_annotate.R <h5ad_file> <output_dir> [reference]\n")
+    quit(status = 1)
+}
+
+h5ad_file  <- args[1]
+output_dir <- args[2]
+reference  <- if (length(args) >= 3) args[3] else "HPCA"
+
+suppressPackageStartupMessages({
+    library(scmap)
+    library(celldex)
+    library(SingleCellExperiment)
+    library(zellkonverter)
+})
+
+if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+
+cache_dir <- file.path(path.expand("~"), ".cache", "omicsclaw", "experimenthub")
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+Sys.setenv(EXPERIMENT_HUB_CACHE = cache_dir)
+options(timeout = max(600, getOption("timeout")))
+
+tryCatch({
+    sce <- readH5AD(h5ad_file)
+    if (!"logcounts" %in% SummarizedExperiment::assayNames(sce)) {
+        SummarizedExperiment::assay(sce, "logcounts") <- SummarizedExperiment::assay(sce, "X")
+    }
+    rowData(sce)$feature_symbol <- rownames(sce)
+
+    ref_data <- switch(reference,
+        HPCA = celldex::HumanPrimaryCellAtlasData(),
+        Blueprint_Encode = celldex::BlueprintEncodeData(),
+        Monaco = celldex::MonacoImmuneData(),
+        Mouse = celldex::MouseRNAseqData(),
+        stop(sprintf("Unsupported scmap reference: %s", reference))
+    )
+    ref_data <- as(ref_data, "SingleCellExperiment")
+    rowData(ref_data)$feature_symbol <- rownames(ref_data)
+    ref_data <- scmap::selectFeatures(ref_data, suppress_plot = TRUE)
+    ref_data <- scmap::indexCluster(ref_data, cluster_col = "label.main")
+
+    res <- scmap::scmapCluster(
+        projection = sce,
+        index_list = list(reference = metadata(ref_data)$scmap_cluster_index),
+        threshold = 0.7
+    )
+
+    siml <- res$scmap_cluster_siml
+    score <- apply(siml, 1, function(x) {
+        if (all(is.na(x))) return(NA_real_)
+        max(x, na.rm = TRUE)
+    })
+    out <- data.frame(
+        cell = colnames(sce),
+        cell_type = as.character(res$combined_labs),
+        pruned_label = as.character(res$combined_labs),
+        score = as.numeric(score),
+        stringsAsFactors = FALSE,
+        row.names = colnames(sce)
+    )
+    write.csv(out, file.path(output_dir, "scmap_results.csv"), quote = FALSE)
+}, error = function(e) {
+    cat(sprintf("ERROR: %s\n", e$message), file = stderr())
+    quit(status = 1)
+})

--- a/omicsclaw/r_scripts/sc_seurat_integrate.R
+++ b/omicsclaw/r_scripts/sc_seurat_integrate.R
@@ -41,18 +41,20 @@ tryCatch({
 
     if (method == "fastmnn") {
         suppressPackageStartupMessages(library(batchelor))
+        counts <- as.matrix(SummarizedExperiment::assay(sce, "X"))
+        split_idx <- split(seq_len(ncol(sce)), factor(meta[[batch_key]], levels = unique(meta[[batch_key]])))
+        mat_list  <- lapply(split_idx, function(idx) {
+            mat <- t(log1p(counts[, idx, drop = FALSE]))
+            colnames(mat) <- rownames(sce)
+            rownames(mat) <- colnames(sce)[idx]
+            mat
+        })
 
-        SummarizedExperiment::assay(sce, "counts") <- SummarizedExperiment::assay(sce, "X")
-        SummarizedExperiment::assay(sce, "logcounts") <- log1p(SummarizedExperiment::assay(sce, "X"))
+        mnn <- do.call(batchelor::reducedMNN, c(mat_list, list(k = 20)))
 
-        split_idx <- split(seq_len(ncol(sce)), meta[[batch_key]])
-        sce_list  <- lapply(split_idx, function(idx) sce[, idx])
-
-        mnn <- do.call(batchelor::fastMNN, c(sce_list, list(d = n_pcs)))
-
-        embedding <- reducedDim(mnn, "corrected")
+        embedding <- as.matrix(mnn$corrected)
         write.csv(embedding, file.path(output_dir, "embedding.csv"), quote = FALSE)
-        write.csv(data.frame(row.names = colnames(mnn)),
+        write.csv(data.frame(row.names = rownames(embedding)),
             file.path(output_dir, "obs.csv"), quote = FALSE)
 
         cat(sprintf("Done. fastMNN embedding: %d cells x %d dims\n",

--- a/omicsclaw/r_scripts/sc_seurat_preprocess.R
+++ b/omicsclaw/r_scripts/sc_seurat_preprocess.R
@@ -35,6 +35,13 @@ suppressPackageStartupMessages({
 
 if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
 
+.get_assay_matrix <- function(seurat_obj, assay_name, layer_name) {
+    if ("LayerData" %in% getNamespaceExports("SeuratObject")) {
+        return(as.matrix(SeuratObject::LayerData(seurat_obj, assay = assay_name, layer = layer_name)))
+    }
+    return(as.matrix(GetAssayData(seurat_obj, assay = assay_name, slot = layer_name)))
+}
+
 cat(sprintf("Loading data from %s...\n", h5ad_file))
 
 tryCatch({
@@ -102,7 +109,7 @@ tryCatch({
         row.names = FALSE, quote = FALSE)
 
     # Normalized expression matrix (genes x cells) — can be large
-    norm_mat <- as.matrix(GetAssayData(seurat_obj, assay = assay_name, slot = "data"))
+    norm_mat <- .get_assay_matrix(seurat_obj, assay_name, "data")
     write.csv(norm_mat, file.path(output_dir, "X_norm.csv"), quote = FALSE)
 
     # Metadata JSON

--- a/omicsclaw/r_scripts/sc_singler_annotate.R
+++ b/omicsclaw/r_scripts/sc_singler_annotate.R
@@ -26,6 +26,11 @@ suppressPackageStartupMessages({
 
 if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
 
+cache_dir <- file.path(path.expand("~"), ".cache", "omicsclaw", "experimenthub")
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+Sys.setenv(EXPERIMENT_HUB_CACHE = cache_dir)
+options(timeout = max(600, getOption("timeout")))
+
 tryCatch({
     cat(sprintf("Loading data from %s...\n", h5ad_file))
     sce <- readH5AD(h5ad_file)

--- a/skills/singlecell/_lib/ambient.py
+++ b/skills/singlecell/_lib/ambient.py
@@ -9,6 +9,7 @@ Adapted from validated reference scripts (remove_ambient_rna.py).
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -83,6 +84,11 @@ def run_cellbender(
     raw_h5 = Path(raw_h5)
     if not raw_h5.exists():
         raise FileNotFoundError(f"Raw H5 file not found: {raw_h5}")
+    if raw_h5.suffix.lower() != ".h5":
+        raise ValueError(
+            "CellBender currently requires a raw 10x .h5 input produced by cellranger count. "
+            "Processed .h5ad files are not accepted by this wrapper."
+        )
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -102,6 +108,27 @@ def run_cellbender(
             "Install: pip install cellbender\n"
             "See: https://cellbender.readthedocs.io/"
         )
+
+    env = os.environ.copy()
+    conda_prefix = env.get("CONDA_PREFIX")
+    if conda_prefix:
+        env["LD_LIBRARY_PATH"] = f"{conda_prefix}/lib:{env.get('LD_LIBRARY_PATH', '')}".rstrip(":")
+
+    if use_cuda:
+        try:
+            import torch
+
+            if not torch.cuda.is_available():
+                logger.info("CellBender CUDA requested but unavailable -- using CPU mode.")
+                use_cuda = False
+            else:
+                try:
+                    torch.cuda.get_device_capability(0)
+                except Exception as exc:  # pragma: no cover - runtime dependent
+                    logger.info("CellBender CUDA requested but unusable (%s) -- using CPU mode.", exc)
+                    use_cuda = False
+        except Exception:
+            use_cuda = False
 
     # Build CLI command
     cmd = [
@@ -127,7 +154,7 @@ def run_cellbender(
 
     logger.info("Running CellBender: %s", " ".join(cmd))
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
 
     if result.returncode != 0:
         # Log stderr for diagnostics

--- a/skills/singlecell/_lib/annotation.py
+++ b/skills/singlecell/_lib/annotation.py
@@ -13,9 +13,10 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
+from anndata import AnnData
 
 if TYPE_CHECKING:
-    from anndata import AnnData
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ def annotate_clusters_manual(
 def annotate_with_celltypist(
     adata: AnnData,
     model: str = "Immune_All_Low.pkl",
-    majority_voting: bool = True,
+    majority_voting: bool = False,
     annotation_key: str = "celltypist_annotation",
     inplace: bool = True,
 ) -> AnnData:
@@ -166,7 +167,12 @@ def annotate_with_celltypist(
 
     # Transfer probability matrix if available
     if hasattr(predictions, "probability_matrix"):
-        adata.obsm[f"{annotation_key}_prob"] = predictions.probability_matrix.values
+        prob_matrix = predictions.probability_matrix
+        adata.obsm[f"{annotation_key}_prob"] = prob_matrix.values
+        try:
+            adata.obs[f"{annotation_key}_score"] = prob_matrix.max(axis=1).to_numpy()
+        except Exception:
+            pass
 
     # Summary
     n_types = adata.obs[annotation_key].nunique()
@@ -182,6 +188,34 @@ def annotate_with_celltypist(
     _validate_celltypist_annotations(adata, annotation_key)
 
     return adata
+
+
+def validate_celltypist_input_matrix(adata: AnnData) -> tuple[bool, str]:
+    """Heuristically validate official CellTypist AnnData input expectations."""
+    matrix = adata.X
+    n_obs = min(500, adata.n_obs)
+    n_vars = min(500, adata.n_vars)
+    if hasattr(matrix, "toarray"):
+        matrix = matrix[:n_obs, :n_vars].toarray()
+    else:
+        matrix = np.asarray(matrix[:n_obs, :n_vars])
+
+    if matrix.size == 0:
+        return True, "empty matrix preview"
+    if np.nanmin(matrix) < 0:
+        return False, "CellTypist AnnData input should not contain negative expression values"
+
+    frac_integer = float(np.mean(np.isclose(matrix, np.round(matrix), atol=1e-6)))
+    max_value = float(np.nanmax(matrix))
+    median_row_sum = float(np.nanmedian(matrix.sum(axis=1)))
+
+    if frac_integer > 0.98 and max_value > 20 and median_row_sum > 50:
+        return False, (
+            "CellTypist official AnnData input expects log1p-normalized expression in X; "
+            "the current matrix still looks count-like"
+        )
+
+    return True, "matrix is compatible with CellTypist AnnData input expectations"
 
 
 def _validate_celltypist_annotations(
@@ -650,3 +684,17 @@ def compare_annotations(
     logger.info("Saved comparison heatmap: %s", fig_path)
 
     return confusion_norm
+
+
+
+def build_celltypist_input_adata(adata: AnnData):
+    """Return an AnnData view whose X matches CellTypist official input expectations."""
+    if adata.raw is not None and adata.raw.shape == adata.shape:
+        tmp = AnnData(X=adata.raw.X.copy(), obs=adata.obs.copy(), var=adata.raw.var.copy())
+        tmp.obs_names = adata.obs_names.copy()
+        tmp.var_names = adata.raw.var_names.copy()
+        return tmp, "adata.raw"
+    tmp = AnnData(X=adata.X.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+    tmp.obs_names = adata.obs_names.copy()
+    tmp.var_names = adata.var_names.copy()
+    return tmp, "adata.X"

--- a/skills/singlecell/_lib/grn.py
+++ b/skills/singlecell/_lib/grn.py
@@ -111,8 +111,16 @@ def prepare_expression_matrix(adata, layer: str | None = None) -> pd.DataFrame:
     """
     if layer is not None:
         X = adata.layers[layer]
+        var_names = adata.var_names
+    elif "counts" in adata.layers:
+        X = adata.layers["counts"]
+        var_names = adata.var_names
+    elif adata.raw is not None and adata.raw.shape == adata.shape:
+        X = adata.raw.X
+        var_names = adata.raw.var_names
     else:
         X = adata.X
+        var_names = adata.var_names
 
     if hasattr(X, "toarray"):
         X = X.toarray()
@@ -120,7 +128,7 @@ def prepare_expression_matrix(adata, layer: str | None = None) -> pd.DataFrame:
     df = pd.DataFrame(
         X,
         index=adata.obs_names,
-        columns=adata.var_names,
+        columns=var_names,
     )
 
     return df

--- a/skills/singlecell/_lib/integration.py
+++ b/skills/singlecell/_lib/integration.py
@@ -18,6 +18,7 @@ compare_integration_methods
 from __future__ import annotations
 
 import logging
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
@@ -31,6 +32,78 @@ if TYPE_CHECKING:
     from anndata import AnnData
 
 logger = logging.getLogger(__name__)
+
+
+def _trainer_device_kwargs(use_gpu: bool) -> dict[str, object]:
+    """Map the wrapper's boolean GPU preference onto current scvi-tools kwargs."""
+    if use_gpu:
+        return {"accelerator": "gpu", "devices": 1}
+    return {"accelerator": "cpu", "devices": 1}
+
+
+def _resolve_gpu_preference(use_gpu: bool) -> bool:
+    """Return a safe GPU preference for the current torch/runtime stack."""
+    if not use_gpu:
+        return False
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            logger.info("GPU requested but CUDA unavailable -- using CPU.")
+            return False
+        try:
+            torch.cuda.get_device_capability(0)
+        except Exception as exc:  # pragma: no cover - driver/runtime dependent
+            logger.info("GPU requested but CUDA driver/runtime is unusable (%s) -- using CPU.", exc)
+            return False
+        return True
+    except ImportError:
+        logger.info("PyTorch not found -- using CPU.")
+        return False
+
+
+def _force_torch_cpu_mode() -> None:
+    """Hide broken CUDA runtimes from Lightning when CPU execution is requested."""
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    try:
+        import torch
+
+        torch.cuda.is_available = lambda: False  # type: ignore[method-assign]
+        torch.cuda.device_count = lambda: 0  # type: ignore[method-assign]
+    except ImportError:
+        return
+
+
+def _history_series(history: dict, *keys: str):
+    for key in keys:
+        value = history.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _history_last_float(history_obj) -> float | None:
+    if history_obj is None:
+        return None
+    try:
+        if hasattr(history_obj, "iloc"):
+            value = history_obj.iloc[-1]
+            if hasattr(value, "iloc"):
+                value = value.iloc[-1]
+        else:
+            value = history_obj[-1]
+        return float(value)
+    except Exception:
+        return None
+
+
+def _history_length(history_obj) -> int:
+    if history_obj is None:
+        return 0
+    try:
+        return int(len(history_obj))
+    except Exception:
+        return 0
 
 # ---------------------------------------------------------------------------
 # Data preparation
@@ -281,16 +354,9 @@ def run_scvi_integration(
     )
 
     # -- GPU fallback ---------------------------------------------------------
-    if use_gpu:
-        try:
-            import torch
-
-            if not torch.cuda.is_available():
-                logger.info("GPU requested but CUDA unavailable -- using CPU.")
-                use_gpu = False
-        except ImportError:
-            logger.info("PyTorch not found -- using CPU.")
-            use_gpu = False
+    use_gpu = _resolve_gpu_preference(use_gpu)
+    if not use_gpu:
+        _force_torch_cpu_mode()
 
     # -- train ----------------------------------------------------------------
     logger.info(
@@ -303,18 +369,21 @@ def run_scvi_integration(
     model.train(
         max_epochs=max_epochs,
         early_stopping=early_stopping,
-        use_gpu=use_gpu,
         check_val_every_n_epoch=10,
         train_size=0.9,
+        **_trainer_device_kwargs(use_gpu),
     )
 
-    train_loss = model.history["elbo_train"][1:]
-    val_loss = model.history["elbo_validation"]
+    train_loss = _history_series(model.history, "elbo_train", "train_loss_epoch", "train_loss")
+    val_loss = _history_series(model.history, "elbo_validation", "validation_loss", "val_loss")
+    epochs_trained = _history_length(train_loss)
+    final_train_loss = _history_last_float(train_loss)
+    final_val_loss = _history_last_float(val_loss)
     logger.info(
         "Training complete: %d epochs, train_loss=%.2f, val_loss=%.2f",
-        len(train_loss),
-        float(train_loss.iloc[-1]),
-        float(val_loss.iloc[-1]),
+        epochs_trained,
+        final_train_loss if final_train_loss is not None else float("nan"),
+        final_val_loss if final_val_loss is not None else float("nan"),
     )
 
     # -- latent representation ------------------------------------------------
@@ -336,9 +405,9 @@ def run_scvi_integration(
         "n_layers": n_layers,
         "n_hidden": n_hidden,
         "max_epochs": max_epochs,
-        "epochs_trained": len(train_loss),
-        "final_train_loss": float(train_loss.iloc[-1]),
-        "final_val_loss": float(val_loss.iloc[-1]),
+        "epochs_trained": epochs_trained,
+        "final_train_loss": final_train_loss,
+        "final_val_loss": final_val_loss,
         "use_highly_variable": use_highly_variable,
         "n_genes": adata_input.n_vars,
     }
@@ -462,28 +531,20 @@ def run_scanvi_integration(
             n_latent=n_latent,
             n_layers=n_layers,
             n_hidden=n_hidden,
-            unlabeled_category=unlabeled_category,
         )
 
     # -- GPU fallback ---------------------------------------------------------
-    if use_gpu:
-        try:
-            import torch
-
-            if not torch.cuda.is_available():
-                logger.info("GPU requested but CUDA unavailable -- using CPU.")
-                use_gpu = False
-        except ImportError:
-            logger.info("PyTorch not found -- using CPU.")
-            use_gpu = False
+    use_gpu = _resolve_gpu_preference(use_gpu)
+    if not use_gpu:
+        _force_torch_cpu_mode()
 
     # -- train ----------------------------------------------------------------
     logger.info("Training scANVI (max_epochs=%d, gpu=%s) ...", max_epochs, use_gpu)
     model.train(
         max_epochs=max_epochs,
-        use_gpu=use_gpu,
         check_val_every_n_epoch=10,
         train_size=0.9,
+        **_trainer_device_kwargs(use_gpu),
     )
     logger.info("Training complete.")
 

--- a/skills/singlecell/_lib/io.py
+++ b/skills/singlecell/_lib/io.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from anndata import AnnData
 
 logger = logging.getLogger(__name__)
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_DATA_DIR = _PROJECT_ROOT / "data"
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +241,70 @@ def add_metadata(
 # Example / demo data
 # ---------------------------------------------------------------------------
 
+
+def _ensure_data_dir() -> Path:
+    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    return _DATA_DIR
+
+
+def _demo_candidates(dataset: str) -> list[Path]:
+    data_dir = _ensure_data_dir()
+    examples_dir = _PROJECT_ROOT / "examples"
+    if dataset == "pbmc3k_raw":
+        return [
+            data_dir / "pbmc3k_raw.h5ad",
+            examples_dir / "pbmc3k.h5ad",
+        ]
+    if dataset == "pbmc3k_processed":
+        return [
+            data_dir / "pbmc3k_processed.h5ad",
+            examples_dir / "pbmc3k_processed.h5ad",
+            examples_dir / "pbmc3k.h5ad",
+        ]
+    if dataset == "pbmc68k_reduced":
+        return [
+            data_dir / "pbmc68k_reduced.h5ad",
+        ]
+    raise ValueError(f"Unknown demo dataset: {dataset}")
+
+
+def load_repo_demo_data(dataset: str = "pbmc3k_raw") -> tuple[AnnData, Path | None]:
+    """Load repo-local demo data first, else download and persist under ``data/``.
+
+    Parameters
+    ----------
+    dataset
+        Supported values: ``pbmc3k_raw``, ``pbmc3k_processed``, ``pbmc68k_reduced``.
+
+    Returns
+    -------
+    tuple
+        ``(adata, path_used_or_written)``
+    """
+    import scanpy as sc
+
+    for candidate in _demo_candidates(dataset):
+        if candidate.exists():
+            logger.info("Loading local demo data: %s", candidate)
+            return sc.read_h5ad(candidate), candidate
+
+    logger.info("Local demo data for %s not found; downloading via scanpy", dataset)
+    if dataset == "pbmc3k_raw":
+        adata = sc.datasets.pbmc3k()
+        out_path = _ensure_data_dir() / "pbmc3k_raw.h5ad"
+    elif dataset == "pbmc3k_processed":
+        adata = sc.datasets.pbmc3k_processed()
+        out_path = _ensure_data_dir() / "pbmc3k_processed.h5ad"
+    elif dataset == "pbmc68k_reduced":
+        adata = sc.datasets.pbmc68k_reduced()
+        out_path = _ensure_data_dir() / "pbmc68k_reduced.h5ad"
+    else:  # pragma: no cover
+        raise ValueError(f"Unknown demo dataset: {dataset}")
+
+    adata.write_h5ad(out_path)
+    logger.info("Downloaded demo data saved to: %s", out_path)
+    return adata, out_path
+
 def load_example_data(dataset: str = "pbmc3k") -> AnnData:
     """Load example single-cell RNA-seq dataset.
 
@@ -256,11 +322,15 @@ def load_example_data(dataset: str = "pbmc3k") -> AnnData:
     logger.info("Loading %s example dataset ...", dataset)
 
     if dataset == "pbmc3k":
-        adata = sc.datasets.pbmc3k()
+        adata, _ = load_repo_demo_data("pbmc3k_raw")
+    elif dataset == "pbmc3k_processed":
+        adata, _ = load_repo_demo_data("pbmc3k_processed")
     elif dataset == "pbmc68k_reduced":
-        adata = sc.datasets.pbmc68k_reduced()
+        adata, _ = load_repo_demo_data("pbmc68k_reduced")
     else:
-        raise ValueError(f"Unknown dataset: {dataset}. Options: 'pbmc3k', 'pbmc68k_reduced'")
+        raise ValueError(
+            f"Unknown dataset: {dataset}. Options: 'pbmc3k', 'pbmc3k_processed', 'pbmc68k_reduced'"
+        )
 
     logger.info("Loaded: %d cells x %d genes", adata.n_obs, adata.n_vars)
     return adata

--- a/skills/singlecell/_lib/markers.py
+++ b/skills/singlecell/_lib/markers.py
@@ -32,7 +32,7 @@ def find_all_cluster_markers(
     min_in_group_fraction: float = 0.25,
     min_fold_change: float = 1.0,
     max_out_group_fraction: float = 0.5,
-    use_raw: bool = False,
+    use_raw: bool | None = None,
     layer: Optional[str] = None,
 ) -> pd.DataFrame:
     """Find marker genes for all clusters (one-vs-rest).
@@ -44,7 +44,7 @@ def find_all_cluster_markers(
     Parameters
     ----------
     adata
-        AnnData with normalized data.
+        AnnData with log-normalized data in ``adata.raw`` or ``adata.X``.
     cluster_key
         Column in ``adata.obs`` containing cluster labels.
     method
@@ -85,6 +85,9 @@ def find_all_cluster_markers(
     )
 
     # --- Run rank_genes_groups ---
+    if use_raw is None:
+        use_raw = adata.raw is not None and adata.raw.shape == adata.shape
+
     kwargs: dict = dict(
         groupby=cluster_key,
         method=method,
@@ -154,7 +157,7 @@ def find_markers_for_cluster(
     Parameters
     ----------
     adata
-        AnnData with normalized data.
+        AnnData with log-normalized data in ``adata.raw`` or ``adata.X``.
     cluster
         The specific cluster label to find markers for.
     cluster_key
@@ -270,7 +273,7 @@ def plot_top_markers_heatmap(
     n_top: int = 10,
     cluster_key: str = "leiden_0.8",
     figsize: tuple = (12, 8),
-    use_raw: bool = False,
+    use_raw: bool | None = None,
 ) -> None:
     """Plot a clustered heatmap of top marker genes using seaborn.
 

--- a/skills/singlecell/_lib/pseudobulk.py
+++ b/skills/singlecell/_lib/pseudobulk.py
@@ -296,8 +296,11 @@ tryCatch({{
         )
 
         results_df = pd.read_csv(output_dir / "deseq2_results.csv", index_col=0)
-        results_df.index.name = "gene"
-        results_df = results_df.reset_index()
+        if "gene" not in results_df.columns:
+            results_df.index.name = "gene"
+            results_df = results_df.reset_index()
+        else:
+            results_df = results_df.reset_index(drop=True)
         return results_df
 
 
@@ -402,8 +405,11 @@ def run_deseq2_analysis(
     # -- per cell-type DE -----------------------------------------------------
     counts_df = pseudobulk["counts"]
     pb_metadata = pseudobulk["metadata"].copy()
+    pb_metadata["_pb_index"] = pb_metadata.index.astype(str)
 
     pb_metadata = pb_metadata.merge(sample_metadata, left_on="sample", right_on="sample", how="left")
+    pb_metadata = pb_metadata.set_index("_pb_index")
+    pb_metadata.index.name = pseudobulk["metadata"].index.name
 
     celltypes = pb_metadata[celltype_key].unique()
     logger.info("Running DESeq2 for %d cell types ...", len(celltypes))

--- a/skills/singlecell/_lib/trajectory.py
+++ b/skills/singlecell/_lib/trajectory.py
@@ -225,11 +225,13 @@ def find_trajectory_genes(
 
     pseudotime = adata.obs[pseudotime_key].values
 
-    # Get expression matrix
-    if hasattr(adata.X, "toarray"):
-        X = adata.X.toarray()
+    # Get expression matrix; prefer log-normalized raw when available
+    matrix = adata.raw.X if adata.raw is not None and adata.raw.shape == adata.shape else adata.X
+    var_names = adata.raw.var_names if adata.raw is not None and adata.raw.shape == adata.shape else adata.var_names
+    if hasattr(matrix, "toarray"):
+        X = matrix.toarray()
     else:
-        X = adata.X
+        X = matrix
 
     logger.info(f"Finding trajectory genes (method={method}, n={n_genes})...")
 
@@ -237,7 +239,7 @@ def find_trajectory_genes(
     pvalues = []
     genes = []
 
-    for i, gene in enumerate(adata.var_names):
+    for i, gene in enumerate(var_names):
         gene_expr = X[:, i]
 
         # Skip genes with no variance
@@ -317,8 +319,8 @@ def run_velocity_analysis(
 
     logger.info(f"Running scVelo velocity analysis (mode={mode})...")
 
-    # Filter and normalize
-    scv.pp.filter_and_normalize(adata, min_shared_counts=20, n_top_genes=2000)
+    # Filter and normalize using the current scVelo API.
+    scv.pp.filter_and_normalize(adata, min_shared_counts=20)
 
     # Compute moments
     scv.pp.moments(adata, n_pcs=30, n_neighbors=30)

--- a/skills/singlecell/scrna/sc-ambient-removal/SKILL.md
+++ b/skills/singlecell/scrna/sc-ambient-removal/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: sc-ambient-removal
 description: >-
-  Remove ambient RNA contamination from single-cell data using CellBender,
-  SoupX, or simple subtraction methods.
-version: 0.4.0
+  Remove ambient RNA contamination from droplet-based single-cell RNA-seq using
+  a simple subtraction path, CellBender, or SoupX. The wrapper exposes only the
+  parameters that are actually wired into the current implementation.
+version: 0.5.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, ambient, cellbender, contamination, QC]
+tags: [singlecell, ambient, cellbender, soupx, qc]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -17,13 +18,38 @@ metadata:
       - "--method"
       - "--raw-h5"
       - "--raw-matrix-dir"
+    param_hints:
+      simple:
+        priority: "contamination"
+        params: ["contamination"]
+        defaults: {contamination: 0.05}
+        requires: ["count_like_matrix_in_X", "scanpy"]
+        tips:
+          - "--method simple: Python fallback that subtracts a global ambient profile from the matrix."
+          - "--contamination: Wrapper-level contamination fraction used directly in the subtraction formula."
+      cellbender:
+        priority: "raw_h5 -> expected_cells"
+        params: ["raw_h5", "expected_cells"]
+        defaults: {expected_cells: "input_n_obs"}
+        requires: ["cellbender", "10x_raw_h5"]
+        tips:
+          - "--raw-h5: Required for the CellBender path."
+          - "--expected-cells: Main CellBender size prior; defaults to the observed cell count when omitted."
+      soupx:
+        priority: "raw_matrix_dir -> filtered_matrix_dir"
+        params: ["raw_matrix_dir", "filtered_matrix_dir"]
+        defaults: {}
+        requires: ["SoupX_ready_R_environment", "10x_raw_and_filtered_matrix_dirs"]
+        tips:
+          - "--method soupx: Requires both raw and filtered 10x matrix directories."
+          - "If the required SoupX inputs are missing, OmicsClaw falls back to `simple`."
     saves_h5ad: true
+    requires_preprocessed: false
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🧹"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install:
@@ -38,119 +64,67 @@ metadata:
       - background RNA
 ---
 
-# 🧹 Single-Cell Ambient RNA Removal
-
-Remove ambient RNA contamination from droplet-based scRNA-seq data.
+# Single-Cell Ambient RNA Removal
 
 ## Why This Exists
 
-- **Without it**: Ambient RNA from lysed cells contaminates expression profiles
-- **With it**: Cleaner gene expression for better cell type annotation
-- **Why OmicsClaw**: Multiple methods with automatic contamination estimation
+- Without it: ambient transcripts from lysed cells bias downstream expression profiles.
+- With it: corrected counts are easier to use for annotation, marker discovery, and DE.
+- Why OmicsClaw: one wrapper exposes a fast Python fallback and two common method-specific entry paths.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **CellBender**: Deep learning-based ambient removal (recommended for 10X)
-2. **SoupX (R)**: Ambient RNA estimation using raw/filtered 10X matrix pairs
-3. **Simple subtraction**: Quick ambient profile subtraction
-4. **Contamination estimation**: Automatic or manual contamination fraction
+Implemented methods in the current wrapper:
 
-## Workflow
+1. `simple` - default Python subtraction path
+2. `cellbender` - deep generative correction when `--raw-h5` is provided
+3. `soupx` - R-backed 10x matrix correction when raw and filtered directories are provided
 
-1. **Load data**: Load raw or filtered count matrix
-2. **Estimate contamination**: Calculate ambient RNA fraction
-3. **Correct counts**: Remove ambient RNA contribution
-4. **Report**: Compare before/after counts
+The wrapper does not currently expose the full upstream CellBender or SoupX parameter surface.
+
+## Input Contract
+
+- Accepted inputs: `.h5ad` or 10x-like inputs required by the selected method
+- `simple`: needs an input AnnData matrix
+- `cellbender`: must receive a raw 10x `.h5` file from `cellranger count`; processed `.h5ad` is rejected by this wrapper
+- `soupx`: needs both `--raw-matrix-dir` and `--filtered-matrix-dir`
+
+## Workflow Summary
+
+1. Load AnnData or demo data.
+2. Validate the selected correction path.
+3. Run the requested method or fall back when required inputs are absent.
+4. Compare counts before and after correction.
+5. Write `corrected.h5ad`, figures, `report.md`, and `result.json`.
 
 ## CLI Reference
 
 ```bash
-# Basic usage with simple method
-python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py --input <data.h5ad> --output <dir>
+python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py \
+  --input <data.h5ad> --output <dir>
 
-# With CellBender (requires raw H5)
-python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py --raw-h5 <raw.h5> \
-  --output <dir> --method cellbender --expected-cells 10000
+python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py \
+  --method cellbender --raw-h5 <raw_feature_bc_matrix.h5> \
+  --expected-cells 10000 --output <dir>
 
-# With SoupX (requires raw + filtered 10X directories)
 python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py \
   --input <filtered.h5ad> --method soupx \
   --raw-matrix-dir raw_feature_bc_matrix/ \
   --filtered-matrix-dir filtered_feature_bc_matrix/ \
   --output <dir>
-
-# Specify contamination fraction
-python skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py --input <data.h5ad> \
-  --output <dir> --contamination 0.05
-
-# Demo mode
-python omicsclaw.py run sc-ambient-removal --demo
 ```
 
-## Methods
+## Output Contract
 
-### CellBender (Recommended)
-- Uses deep generative model
-- Requires raw Feature-Barcode Matrix
-- GPU recommended for speed
+Successful runs write:
 
-### Simple Subtraction
-- Estimates ambient profile from data
-- Fast, works with any count matrix
-- Good for quick cleanup
+- `corrected.h5ad`
+- `report.md`
+- `result.json`
+- `figures/counts_comparison.png`
+- `figures/count_distribution.png`
 
-### SoupX
-- Requires both `--raw-matrix-dir` and `--filtered-matrix-dir`
-- Best suited for 10x raw/filtered matrix pairs
-- Runs through the R bridge and writes the corrected counts back into AnnData
+## Current Limitations
 
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--method` | simple | cellbender, soupx, simple |
-| `--contamination` | 0.05 | Contamination fraction |
-| `--expected-cells` | None | Expected cells (CellBender) |
-| `--raw-h5` | None | Raw H5 file (CellBender) |
-| `--raw-matrix-dir` | None | 10x raw matrix directory for SoupX |
-| `--filtered-matrix-dir` | None | 10x filtered matrix directory for SoupX |
-
-## Example Queries
-
-- "Remove ambient RNA contamination"
-- "Run CellBender on my data"
-- "Clean up ambient RNA from 10X data"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── corrected.h5ad
-├── figures/
-│   ├── counts_comparison.png
-│   └── count_distribution.png
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
-
-## Dependencies
-
-**Required**: scanpy, numpy, pandas
-**Optional**: cellbender (for CellBender method), R + packages `SoupX` and `Seurat` (executed via native R scripts)
-
-## Citations
-
-- [CellBender](https://doi.org/10.1016/j.cels.2018.11.005) — Fleming et al.
-- [SoupX](https://doi.org/10.15252/msb.202110382) — Young & Behjati
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Query mentions "ambient RNA", "CellBender", "contamination"
-
-**Chaining partners**:
-- `sc-qc` — QC before ambient removal
-- `sc-filter` — Filter after ambient removal
+- The wrapper writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.
+- `simple` is an OmicsClaw fallback, not an upstream CellBender/SoupX equivalent.

--- a/skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py
+++ b/skills/singlecell/scrna/sc-ambient-removal/sc_ambient.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import tempfile
 import sys
 from pathlib import Path
 
@@ -20,16 +22,73 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib import ambient as sc_ambient_utils
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-ambient-removal"
+SKILL_NAME = "sc-ambient-removal"
 SKILL_VERSION = "0.4.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Ambient RNA contamination correction for droplet-based scRNA-seq.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "simple"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Ambient RNA contamination correction for droplet-based scRNA-seq.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "simple"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 METHOD_REGISTRY: dict[str, MethodConfig] = {
     "cellbender": MethodConfig(
@@ -49,6 +108,49 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
         dependencies=("scanpy",),
     ),
 }
+
+
+def _matrix_looks_count_like(matrix) -> bool:
+    sample = matrix
+    if hasattr(sample, "toarray"):
+        sample = sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])].toarray()
+    else:
+        sample = np.asarray(sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])])
+    if sample.size == 0:
+        return True
+    if np.nanmin(sample) < 0:
+        return False
+    frac_integer = float(np.mean(np.isclose(sample, np.round(sample), atol=1e-6)))
+    return frac_integer > 0.98
+
+
+def _get_count_like_matrix(adata):
+    if "counts" in adata.layers:
+        return adata.layers["counts"], "layers.counts"
+    if _matrix_looks_count_like(adata.X):
+        return adata.X, "adata.X"
+    raise ValueError("Ambient RNA removal requires raw count-like input; provide adata.layers['counts'] or count-like adata.X")
+
+
+def run_soupx(raw_matrix_dir: str, filtered_matrix_dir: str):
+    validate_r_environment(required_r_packages=["Seurat", "SoupX"])
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_soupx_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        runner.run_script(
+            "sc_soupx.R",
+            args=[raw_matrix_dir, filtered_matrix_dir, str(output_dir)],
+            expected_outputs=["corrected_counts.csv", "cells.csv", "genes.csv", "contamination.json"],
+            output_dir=output_dir,
+        )
+        corrected = pd.read_csv(output_dir / "corrected_counts.csv", index_col=0)
+        cells = pd.read_csv(output_dir / "cells.csv")["cell"].astype(str).tolist()
+        genes = pd.read_csv(output_dir / "genes.csv")["gene"].astype(str).tolist()
+        contamination = json.loads((output_dir / "contamination.json").read_text(encoding="utf-8"))["contamination"]
+    return corrected.T.to_numpy(dtype=np.float32), cells, genes, contamination
 
 
 def generate_ambient_figures(adata_before, adata_after, output_dir: Path) -> list[str]:
@@ -180,7 +282,8 @@ def main():
     if args.demo:
         logger.info("Generating synthetic demo data with ambient RNA...")
         try:
-            adata = sc.datasets.pbmc3k()
+            adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+            logger.info("Loaded demo dataset: %s", demo_path or "scanpy-pbmc3k")
         except Exception:
             np.random.seed(42)
             counts = np.random.negative_binomial(2, 0.02, size=(500, 1000))
@@ -207,6 +310,7 @@ def main():
     params = {
         "method": method,
         "expected_cells": args.expected_cells,
+        "raw_h5": args.raw_h5,
         "contamination": args.contamination,
         "raw_matrix_dir": args.raw_matrix_dir,
         "filtered_matrix_dir": args.filtered_matrix_dir,
@@ -214,19 +318,19 @@ def main():
 
     contamination_estimate = args.contamination
 
-    if method == "cellbender" and args.raw_h5:
+    if method == "cellbender":
+        if not args.raw_h5:
+            raise ValueError("CellBender requires --raw-h5 pointing to a raw 10x .h5 file.")
+        raw_h5 = Path(args.raw_h5)
+        if raw_h5.suffix.lower() != ".h5":
+            raise ValueError("CellBender only accepts raw 10x .h5 input in this wrapper; processed .h5ad is not supported.")
         logger.info("Running CellBender...")
-        try:
-            adata = sc_ambient_utils.run_cellbender(
-                raw_h5=args.raw_h5,
-                expected_cells=args.expected_cells or adata.n_obs,
-                output_dir=output_dir / "cellbender_output",
-            )
-            contamination_estimate = estimate_contamination_simple(adata)
-        except Exception as exc:
-            logger.warning("CellBender failed: %s. Falling back to simple subtraction.", exc)
-            method = "simple"
-            params["method"] = method
+        adata = sc_ambient_utils.run_cellbender(
+            raw_h5=raw_h5,
+            expected_cells=args.expected_cells or adata.n_obs,
+            output_dir=output_dir / "cellbender_output",
+        )
+        contamination_estimate = estimate_contamination_simple(adata)
 
     elif method == "soupx":
         if args.raw_matrix_dir and args.filtered_matrix_dir:
@@ -242,14 +346,15 @@ def main():
 
     if method == "simple":
         logger.info("Applying simple ambient subtraction (contamination=%s)", args.contamination)
-        ambient_profile = np.array(adata.X.mean(axis=0)).flatten()
+        count_matrix, expression_source = _get_count_like_matrix(adata)
+        ambient_profile = np.array(count_matrix.mean(axis=0)).flatten()
         ambient_profile = ambient_profile / max(ambient_profile.sum(), 1e-8)
-        corrected = adata.X.toarray() if hasattr(adata.X, "toarray") else np.asarray(adata.X).copy()
+        corrected = count_matrix.toarray() if hasattr(count_matrix, "toarray") else np.asarray(count_matrix).copy()
         corrected = corrected - args.contamination * ambient_profile
         corrected = np.maximum(corrected, 0)
-        adata.layers["counts"] = adata.X.copy()
+        adata.layers["counts"] = count_matrix.copy()
         adata.X = corrected.astype(np.float32)
-        adata.uns["ambient_correction"] = {"method": "simple", "contamination_fraction": args.contamination}
+        adata.uns["ambient_correction"] = {"method": "simple", "contamination_fraction": args.contamination, "expression_source": expression_source}
         contamination_estimate = args.contamination
 
     mean_after = np.array(adata.X.sum(axis=1)).flatten().mean()
@@ -265,12 +370,42 @@ def main():
     generate_ambient_figures(adata_before, adata, output_dir)
     write_ambient_report(output_dir, summary, params, input_file)
 
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(exist_ok=True)
+    cmd = f"python sc_ambient.py --output {output_dir} --method {method}"
+    if input_file:
+        cmd += f" --input {input_file}"
+    if args.raw_h5:
+        cmd += f" --raw-h5 {args.raw_h5}"
+    if args.raw_matrix_dir:
+        cmd += f" --raw-matrix-dir {args.raw_matrix_dir}"
+    if args.filtered_matrix_dir:
+        cmd += f" --filtered-matrix-dir {args.filtered_matrix_dir}"
+    if args.expected_cells is not None:
+        cmd += f" --expected-cells {args.expected_cells}"
+    if args.contamination is not None:
+        cmd += f" --contamination {args.contamination}"
+    (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
+
     output_h5ad = output_dir / "corrected.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata, SKILL_NAME, method, params)
     adata.write_h5ad(output_h5ad)
     logger.info("Saved to %s", output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     print(f"Success: {SKILL_NAME}")
     print(f"  Output: {output_dir}")

--- a/skills/singlecell/scrna/sc-batch-integration/SKILL.md
+++ b/skills/singlecell/scrna/sc-batch-integration/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: sc-batch-integration
 description: >-
-  Batch integration for multi-sample scRNA-seq using Harmony, scVI, Seurat CCA/RPCA,
-  BBKNN, and fastMNN. Remove technical variation while preserving biological differences.
-version: 0.4.0
+  Integrate multi-sample scRNA-seq data with Harmony, scVI, scANVI, BBKNN,
+  Scanorama, or supported R-backed integration methods.
+version: 0.5.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, batch-integration, Harmony, scVI, Seurat, BBKNN]
+tags: [singlecell, batch-integration, harmony, scvi, scanorama, bbknn]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -15,14 +15,71 @@ metadata:
       - "--method"
       - "--n-epochs"
       - "--no-gpu"
+    param_hints:
+      harmony:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["existing_PCA_or_computeable_PCA", "harmonypy"]
+        tips:
+          - "--method harmony: Default integration path in the current wrapper."
+      scvi:
+        priority: "batch_key -> n_epochs -> no_gpu"
+        params: ["batch_key", "n_epochs", "no_gpu"]
+        defaults: {batch_key: "batch", n_epochs: 400, no_gpu: false}
+        requires: ["scvi", "torch"]
+        tips:
+          - "--n-epochs: Main runtime/optimization knob for scVI."
+      scanvi:
+        priority: "batch_key -> n_epochs -> no_gpu"
+        params: ["batch_key", "n_epochs", "no_gpu"]
+        defaults: {batch_key: "batch", n_epochs: 200, no_gpu: false}
+        requires: ["scvi", "torch", "labels_in_obs"]
+        tips:
+          - "If no labels are available, the current wrapper falls back to `scvi`."
+      bbknn:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["bbknn", "existing_PCA_or_computeable_PCA"]
+        tips:
+          - "--method bbknn: Lightweight graph correction path."
+      scanorama:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["scanorama"]
+        tips:
+          - "--method scanorama: Panorama-stitching integration path."
+      fastmnn:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["R_batchelor_stack"]
+        tips:
+          - "--method fastmnn: R-backed batchelor fastMNN path via the shared H5AD bridge."
+      seurat_cca:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["R_Seurat_stack"]
+        tips:
+          - "--method seurat_cca: R-backed Seurat CCA integration path via the shared H5AD bridge."
+      seurat_rpca:
+        priority: "batch_key"
+        params: ["batch_key"]
+        defaults: {batch_key: "batch"}
+        requires: ["R_Seurat_stack"]
+        tips:
+          - "--method seurat_rpca: R-backed Seurat RPCA integration path via the shared H5AD bridge."
     legacy_aliases: [sc-integrate]
     saves_h5ad: true
+    requires_preprocessed: true
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🔗"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install:
@@ -32,257 +89,77 @@ metadata:
     trigger_keywords:
       - batch integration
       - batch effect
-      - Harmony
-      - scVI
-      - BBKNN
+      - harmony
+      - scvi
+      - bbknn
       - merge samples
 ---
 
-# 🔗 Single-Cell Batch Integration
-
-Integrate multiple scRNA-seq datasets to remove batch effects while preserving biological variation.
+# Single-Cell Batch Integration
 
 ## Why This Exists
 
-- **Without it**: Multi-sample analysis is dominated by technical batch effects
-- **With it**: Corrected embedding space where clusters reflect biology, not batches
-- **Why OmicsClaw**: Automated integration with method selection and evaluation metrics
+- Without it: technical batch structure dominates embeddings and cluster separation.
+- With it: integrated representations make cross-sample comparison easier.
+- Why OmicsClaw: one contract standardizes multiple integration backends and their diagnostics.
 
-## Tool Comparison
+## Scope Boundary
 
-| Tool | Speed | Scalability | Best For |
-|------|-------|-------------|----------|
-| Harmony | Fast | Good | Quick integration, most use cases |
-| scVI | Moderate | Excellent | Large datasets, deep learning |
-| Seurat CCA/RPCA | Moderate | Good | Conserved biology across batches |
-| fastMNN | Fast | Good | MNN-based correction |
-| BBKNN | Fast | Good | Lightweight, k-NN correction |
+Actively implemented methods in this wrapper:
 
-## Workflow
+1. `harmony`
+2. `scvi`
+3. `scanvi`
+4. `bbknn`
+5. `scanorama`
 
-1. **Calculate**: Prepare modalities and normalize batch representations.
-2. **Execute**: Run chosen integration mechanism across sample blocks.
-3. **Assess**: Quantify batch mixing versus bio-preservation.
-4. **Generate**: Save corrected matrices and compute UMAP graph.
-5. **Report**: Synthesize report with mixing scoring metadata.
+R-backed methods (require corresponding R packages):
+
+1. `fastmnn`
+2. `seurat_cca`
+3. `seurat_rpca`
+
+## Input Contract
+
+- Accepted input: preprocessed `.h5ad`
+- Required metadata: a batch column such as `batch`, `sample`, or `sample_id`
+- Expected state: normalized data plus PCA or data suitable for PCA recomputation
+- Matrix contract: `harmony`, `bbknn`, and `scanorama` work on normalized/PCA-ready representations; `scvi`, `scanvi`, `fastmnn`, `seurat_cca`, and `seurat_rpca` should preserve raw counts in `layers["counts"]` when available
+
+## Workflow Summary
+
+1. Validate batch labels and required dependencies.
+2. Run the selected integration backend.
+3. Rebuild neighbors/UMAP in the corrected space.
+4. Export batch-mixing tables and gallery figures.
+5. Write `processed.h5ad`, `report.md`, and `result.json`.
 
 ## CLI Reference
 
 ```bash
 python skills/singlecell/scrna/sc-batch-integration/sc_integrate.py \
-  --input <merged.h5ad> --method harmony --output <dir>
+  --input <merged.h5ad> --method harmony --batch-key sample_id --output <dir>
+
 python skills/singlecell/scrna/sc-batch-integration/sc_integrate.py \
-  --input <merged.h5ad> --method seurat_rpca --batch-key sample_id --output <dir>
+  --input <merged.h5ad> --method scvi --batch-key sample_id \
+  --n-epochs 400 --output <dir>
+
 python skills/singlecell/scrna/sc-batch-integration/sc_integrate.py \
-  --input <merged.h5ad> --method fastmnn --batch-key sample_id --output <dir>
-python omicsclaw.py run sc-batch-integration --demo
+  --input <merged.h5ad> --method scanorama --batch-key sample_id --output <dir>
 ```
 
-## Algorithm / Methodology
+## Output Contract
 
-### Harmony (Python — Scanpy)
+Successful runs write:
 
-**Goal:** Remove batch effects by iteratively correcting PCA embeddings.
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `figures/`
+- `tables/`
+- `reproducibility/commands.sh`
 
-```python
-import scanpy as sc
-import scanpy.external as sce
+## Current Limitations
 
-adata = sc.read_h5ad('merged.h5ad')
-
-# Standard preprocessing
-sc.pp.normalize_total(adata, target_sum=1e4)
-sc.pp.log1p(adata)
-sc.pp.highly_variable_genes(adata, batch_key='batch')
-adata = adata[:, adata.var.highly_variable]
-sc.pp.scale(adata)
-sc.tl.pca(adata)
-
-# Run Harmony
-sce.pp.harmony_integrate(adata, key='batch')
-
-# Use corrected embedding
-sc.pp.neighbors(adata, use_rep='X_pca_harmony')
-sc.tl.umap(adata)
-sc.tl.leiden(adata)
-```
-
-### Harmony (R — Seurat)
-
-```r
-library(Seurat)
-library(harmony)
-
-merged <- merge(sample1, y = list(sample2, sample3), add.cell.ids = c('S1', 'S2', 'S3'))
-merged <- NormalizeData(merged)
-merged <- FindVariableFeatures(merged)
-merged <- ScaleData(merged)
-merged <- RunPCA(merged)
-
-# Run Harmony on PCA embeddings
-merged <- RunHarmony(merged, group.by.vars = 'orig.ident', dims.use = 1:30)
-
-# Use harmony embeddings for downstream
-merged <- RunUMAP(merged, reduction = 'harmony', dims = 1:30)
-merged <- FindNeighbors(merged, reduction = 'harmony', dims = 1:30)
-merged <- FindClusters(merged, resolution = 0.5)
-```
-
-### scVI (Python)
-
-**Goal:** Integrate batches using a deep generative model that learns a shared latent space.
-
-```python
-import scvi
-import scanpy as sc
-
-adata = sc.read_h5ad('merged.h5ad')
-
-scvi.model.SCVI.setup_anndata(adata, batch_key='batch')
-model = scvi.model.SCVI(adata, n_latent=30, n_layers=2)
-model.train(max_epochs=100, early_stopping=True)
-
-adata.obsm['X_scVI'] = model.get_latent_representation()
-
-sc.pp.neighbors(adata, use_rep='X_scVI')
-sc.tl.umap(adata)
-sc.tl.leiden(adata)
-```
-
-#### scANVI (with Cell Type Labels)
-
-```python
-scvi.model.SCANVI.setup_anndata(adata, batch_key='batch', labels_key='cell_type',
-                                 unlabeled_category='Unknown')
-model = scvi.model.SCANVI(adata, n_latent=30)
-model.train(max_epochs=100)
-
-adata.obs['predicted_type'] = model.predict()
-```
-
-### Seurat CCA Integration (R)
-
-```r
-library(Seurat)
-
-obj_list <- SplitObject(merged, split.by = 'batch')
-obj_list <- lapply(obj_list, function(x) {
-    x <- NormalizeData(x)
-    x <- FindVariableFeatures(x, nfeatures = 2000)
-    return(x)
-})
-
-anchors <- FindIntegrationAnchors(object.list = obj_list, dims = 1:30)
-integrated <- IntegrateData(anchorset = anchors, dims = 1:30)
-
-DefaultAssay(integrated) <- 'integrated'
-integrated <- ScaleData(integrated)
-integrated <- RunPCA(integrated)
-integrated <- RunUMAP(integrated, dims = 1:30)
-```
-
-#### Seurat RPCA (Faster for Large Datasets)
-
-```r
-anchors <- FindIntegrationAnchors(object.list = obj_list, dims = 1:30, reduction = 'rpca')
-integrated <- IntegrateData(anchorset = anchors, dims = 1:30)
-```
-
-### Evaluate Integration
-
-#### Mixing Metrics (R)
-
-```r
-library(lisi)
-lisi_scores <- compute_lisi(Embeddings(merged, 'harmony'),
-                            merged@meta.data, c('batch', 'cell_type'))
-mean(lisi_scores$batch)      # Want high (batches mixed)
-mean(lisi_scores$cell_type)  # Want low (types preserved)
-```
-
-#### Silhouette Score (Python)
-
-```python
-from sklearn.metrics import silhouette_score
-
-batch_sil = silhouette_score(adata.obsm['X_scVI'], adata.obs['batch'])      # Want low
-celltype_sil = silhouette_score(adata.obsm['X_scVI'], adata.obs['cell_type'])  # Want high
-```
-
-## When to Use Each Method
-
-| Scenario | Recommended |
-|----------|-------------|
-| Quick integration, most cases | Harmony |
-| Large datasets (>500k cells) | scVI or Harmony |
-| Strong batch effects | scVI |
-| Reference mapping | Seurat anchors or scANVI |
-| Preserving rare populations | fastMNN |
-
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--method` | `harmony` | `harmony`, `scvi`, `scanvi`, `bbknn`, `scanorama`, `fastmnn`, `seurat_cca`, `seurat_rpca` |
-| `--batch-key` | `batch` | Column with batch labels |
-| `--n-epochs` | none | Training epochs for `scvi`/`scanvi` |
-| `--no-gpu` | false | Disable GPU for deep learning methods |
-
-## Example Queries
-
-- "Run Harmony integration on my cell clusters"
-- "Use scVI to eliminate technical batch effects"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── processed.h5ad
-├── figures/
-│   └── summary_plot.png
-├── tables/
-│   └── metrics.csv
-└── reproducibility/
-    ├── commands.sh
-    ├── requirements.txt
-    └── checksums.sha256
-```
-
-## Version Compatibility
-
-Reference examples tested with: scanpy 1.10+, scvi-tools 1.1+, anndata 0.10+
-
-## Dependencies
-
-**Required**: scanpy >= 1.9, anndata
-**Optional**: scvi-tools, harmonypy, bbknn, scanorama, R + packages `Seurat`, `batchelor`, and `harmony` (executed via native R scripts)
-
-## Runtime Notes
-
-- `fastmnn`, `seurat_cca`, and `seurat_rpca` are implemented through the shared R bridge.
-- `harmony` in this skill uses the Python `harmony-pytorch` path by default; the README installer also includes the R `harmony` package for Seurat workflows.
-
-## Citations
-
-- [Harmony](https://doi.org/10.1038/s41592-019-0619-0) — Korsunsky et al., Nature Methods 2019
-- [scVI](https://doi.org/10.1038/s41592-018-0229-2) — Lopez et al., Nature Methods 2018
-- [Seurat v3](https://doi.org/10.1016/j.cell.2019.05.031) — Stuart et al., Cell 2019
-- [BBKNN](https://doi.org/10.1093/bioinformatics/btz625) — Polanski et al., Bioinformatics 2020
-
-## Safety
-
-- **Local-first**: Strict offline processing without external upload.
-- **Disclaimer**: Requires OmicsClaw reporting structures and disclaimers.
-- **Audit trail**: Hyperparameters and operational flow states are logged fully.
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Automatically invoked dynamically based on tool metadata and user intent matching.
-
-**Chaining partners**:
-- `sc-preprocess` — QC before integration
-- `sc-annotate` — Annotation after integration
-- `sc-doublet` — Doublet removal before integration
+- `fastmnn`, `seurat_cca`, and `seurat_rpca` require a working R environment with batchelor or Seurat plus the H5AD bridge packages.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-batch-integration/sc_integrate.py
+++ b/skills/singlecell/scrna/sc-batch-integration/sc_integrate.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import logging
 import shlex
+import tempfile
 import sys
 from pathlib import Path
 
@@ -23,13 +24,22 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib.adata_utils import ensure_pca, store_analysis_metadata
 from skills.singlecell._lib import dimred as sc_dimred_utils
 from skills.singlecell._lib import integration as sc_integration_utils
 from skills.singlecell._lib.export import save_h5ad
 from skills.singlecell._lib.gallery import PlotSpec, VisualizationRecipe, render_plot_specs
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice, check_data_requirements
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -86,6 +96,57 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
 DEFAULT_METHOD = "harmony"
 
 
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text(
+        "\n".join(lines) + ("\n" if lines else ""),
+        encoding="utf-8",
+    )
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Batch integration for multi-sample scRNA-seq datasets.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", DEFAULT_METHOD),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Batch integration for multi-sample scRNA-seq datasets.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", DEFAULT_METHOD),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
+
+
 def integrate_harmony(adata, batch_key="batch", **kwargs):
     adata = sc_integration_utils.run_harmony_integration(
         adata,
@@ -114,7 +175,10 @@ def integrate_scanvi(adata, batch_key="batch", n_epochs=None, use_gpu=True, **kw
     labels_key = "cell_type" if "cell_type" in adata.obs.columns else "leiden" if "leiden" in adata.obs.columns else None
     if labels_key is None:
         logger.warning("scANVI requires labels; falling back to scVI latent integration")
-        return integrate_scvi(adata, batch_key=batch_key, n_epochs=n_epochs, use_gpu=use_gpu, **kwargs)
+        result = integrate_scvi(adata, batch_key=batch_key, n_epochs=n_epochs, use_gpu=use_gpu, **kwargs)
+        result["method"] = "scanvi_fallback_scvi"
+        result["requested_method"] = "scanvi"
+        return result
     adata = sc_integration_utils.run_scanvi_integration(
         adata,
         batch_key=batch_key,
@@ -145,17 +209,76 @@ def integrate_scanorama(adata, batch_key="batch", **kwargs):
     for batch in adata.obs[batch_key].unique():
         batches.append(adata[adata.obs[batch_key] == batch].copy())
     corrected = scanorama.correct_scanpy(batches, return_dimred=True)
-    adata.obsm["X_scanorama"] = np.concatenate(corrected[1])
+    embedding_frames = []
+    for corrected_batch in corrected:
+        embedding = corrected_batch.obsm.get("X_scanorama")
+        if embedding is None:
+            raise RuntimeError("Scanorama did not produce 'X_scanorama' embeddings")
+        frame = pd.DataFrame(embedding, index=corrected_batch.obs_names)
+        embedding_frames.append(frame)
+    combined = pd.concat(embedding_frames, axis=0)
+    combined = combined.loc[adata.obs_names]
+    adata.obsm["X_scanorama"] = combined.to_numpy(dtype=float)
     sc.pp.neighbors(adata, use_rep="X_scanorama")
     sc.tl.umap(adata)
     return {"method": "scanorama", "embedding_key": "X_scanorama", "n_batches": int(adata.obs[batch_key].nunique())}
 
 
+def _build_r_integration_export_adata(adata):
+    if "counts" in adata.layers:
+        matrix = adata.layers["counts"]
+    elif adata.raw is not None and adata.raw.shape == adata.shape:
+        matrix = adata.raw.X
+    else:
+        matrix = adata.X
+    export = sc.AnnData(X=matrix.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+    export.obs_names = adata.obs_names.copy()
+    export.var_names = adata.var_names.copy()
+    return export
+
+
 def integrate_r_method(adata, *, method: str, batch_key: str):
-    raise RuntimeError(
-        f"R-backed integration method '{method}' is declared but not bundled in the current wrapper. "
-        "Use harmony, scvi, scanvi, bbknn, or scanorama in this build."
-    )
+    if method == "fastmnn":
+        required_packages = ["batchelor", "SingleCellExperiment", "zellkonverter"]
+    else:
+        required_packages = ["Seurat", "SingleCellExperiment", "zellkonverter"]
+    validate_r_environment(required_r_packages=required_packages)
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    export = _build_r_integration_export_adata(adata)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_sc_integrate_r_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export.write_h5ad(input_h5ad)
+        expected = ["embedding.csv", "obs.csv"] if method == "fastmnn" else ["embedding.csv", "umap.csv", "obs.csv"]
+        runner.run_script(
+            "sc_seurat_integrate.R",
+            args=[str(input_h5ad), str(output_dir), method, batch_key, "2000", "30"],
+            expected_outputs=expected,
+            output_dir=output_dir,
+        )
+        embedding = pd.read_csv(output_dir / "embedding.csv", index_col=0)
+        obs_df = pd.read_csv(output_dir / "obs.csv", index_col=0)
+        obs_df.index = obs_df.index.astype(str)
+        ordered = [cell for cell in adata.obs_names if str(cell) in obs_df.index and str(cell) in embedding.index.astype(str)]
+        if not ordered:
+            raise RuntimeError(f"R integration method '{method}' returned no overlapping cells")
+        embedding.index = embedding.index.astype(str)
+        adata = adata[ordered].copy()
+        adata.obs = adata.obs.join(obs_df, how="left", rsuffix="_r")
+        key = f"X_{method}"
+        adata.obsm[key] = embedding.loc[ordered].to_numpy(dtype=float)
+        if method != "fastmnn":
+            umap_df = pd.read_csv(output_dir / "umap.csv", index_col=0)
+            umap_df.index = umap_df.index.astype(str)
+            adata.obsm["X_umap"] = umap_df.loc[ordered].to_numpy(dtype=float)
+        else:
+            sc.pp.neighbors(adata, use_rep=key)
+            sc.tl.umap(adata)
+        sc.pp.neighbors(adata, use_rep=key)
+        return adata, {"method": method, "embedding_key": key, "n_batches": int(adata.obs[batch_key].nunique())}
 
 
 _METHOD_DISPATCH = {
@@ -547,6 +670,10 @@ def write_reproducibility(output_dir: Path, params: dict, *, demo_mode: bool = F
     for key, value in params.items():
         command += f" --{key.replace('_', '-')} {shlex.quote(str(value))}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{command}\n", encoding="utf-8")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib", "seaborn"],
+    )
 
 
 def main():
@@ -564,15 +691,12 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-        if demo_path.exists():
-            adata = sc.read_h5ad(demo_path)
-        else:
-            logger.warning("Local demo data not found, downloading from scanpy")
-            adata = sc.datasets.pbmc3k()
+        adata, _ = sc_io.load_repo_demo_data("pbmc3k_raw")
+        adata.layers["counts"] = adata.X.copy()
         sc.pp.normalize_total(adata)
         sc.pp.log1p(adata)
-        sc.pp.highly_variable_genes(adata, n_top_genes=2000)
+        adata.raw = adata.copy()
+        sc.pp.highly_variable_genes(adata, n_top_genes=2000, layer="counts", flavor="seurat_v3")
         sc.pp.pca(adata)
         adata.obs[args.batch_key] = np.random.choice(["batch1", "batch2"], adata.n_obs)
         input_file = None
@@ -586,6 +710,7 @@ def main():
     method = validate_method_choice(args.method, METHOD_REGISTRY, fallback=DEFAULT_METHOD)
     cfg = METHOD_REGISTRY[method]
     check_data_requirements(adata, cfg)
+    sc_integration_utils.setup_for_integration(adata, batch_key=args.batch_key, inplace=True)
 
     kwargs = {"batch_key": args.batch_key}
     if cfg.supports_gpu:
@@ -599,7 +724,7 @@ def main():
         summary = _METHOD_DISPATCH[method](adata, **kwargs)
 
     summary["n_cells"] = int(adata.n_obs)
-    params = {"method": method, "batch_key": args.batch_key}
+    params = {"method": method, "batch_key": args.batch_key, "counts_layer": "counts" if "counts" in adata.layers else None, "raw_available": adata.raw is not None}
     if args.n_epochs is not None:
         params["n_epochs"] = args.n_epochs
 
@@ -629,6 +754,12 @@ def main():
         },
     }
     write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     print(f"Success: {SKILL_NAME}")
     print(f"  Output: {output_dir}")

--- a/skills/singlecell/scrna/sc-cell-annotation/SKILL.md
+++ b/skills/singlecell/scrna/sc-cell-annotation/SKILL.md
@@ -1,28 +1,57 @@
 ---
 name: sc-cell-annotation
 description: >-
-  Automated cell type annotation using marker genes, CellTypist, SingleR, or scmap.
-  Supports custom references and marker gene lists.
-version: 0.4.0
+  Annotate cell types from preprocessed scRNA-seq data using marker scoring,
+  CellTypist, SingleR, or scmap through the shared Python/R backends.
+version: 0.5.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, annotation, cell-type, CellTypist, SingleR, scmap]
+tags: [singlecell, annotation, celltypist, singler, scmap]
 metadata:
   omicsclaw:
     domain: singlecell
     allowed_extra_flags:
       - "--cluster-key"
       - "--method"
+      - "--model"
       - "--reference"
-      - "--species"
+    param_hints:
+      markers:
+        priority: "cluster_key"
+        params: ["cluster_key"]
+        defaults: {cluster_key: "leiden"}
+        requires: ["cluster_labels_in_obs"]
+        tips:
+          - "--method markers: Fully implemented Python path using built-in marker scoring."
+      celltypist:
+        priority: "model"
+        params: ["model"]
+        defaults: {model: "Immune_All_Low"}
+        requires: ["celltypist", "normalized_expression_matrix"]
+        tips:
+          - "--model: CellTypist model name or model file stem."
+      singler:
+        priority: "reference"
+        params: ["reference"]
+        defaults: {reference: "HPCA"}
+        requires: ["R_SingleR_stack"]
+        tips:
+          - "--method singler: SingleR reference-based annotation through the shared R bridge."
+      scmap:
+        priority: "reference"
+        params: ["reference"]
+        defaults: {reference: "HPCA"}
+        requires: ["R_scmap_stack"]
+        tips:
+          - "--method scmap: scmap cluster projection through the shared R bridge."
     legacy_aliases: [sc-annotate]
     saves_h5ad: true
+    requires_preprocessed: true
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🏷️"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install:
@@ -32,199 +61,71 @@ metadata:
     trigger_keywords:
       - cell type annotation
       - annotate cells
-      - CellTypist
-      - SingleR
+      - celltypist
+      - singler
       - marker gene annotation
 ---
 
-# 🏷️ Single-Cell Annotation
-
-You are **SC Annotate**, a specialised OmicsClaw agent for automated cell type annotation in single-cell data. Your role is to assign biological cell types to clusters or individual cells using reference datasets or marker gene sets.
+# Single-Cell Cell Annotation
 
 ## Why This Exists
 
-- **Without it**: Manual marker-based annotation is subjective, requires extensive literature review, and is highly time-consuming.
-- **With it**: Automated, reproducible cell type labelling using curated reference data and probabilistic models in minutes.
-- **Why OmicsClaw**: Provides a unified interface across multiple annotation paradigms (marker-based, model-based, reference-based) enabling consensus annotation.
+- Without it: users hand-label clusters inconsistently or rely on opaque defaults.
+- With it: annotation method, reference choice, and output columns are standardized.
+- Why OmicsClaw: one wrapper unifies marker-based and reference-style entry paths.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **Marker-based annotation**: Assign cell types from known marker gene sets (e.g., PanglaoDB, CellMarker).
-2. **CellTypist integration**: Leverage large-scale pre-trained logistic regression models for immune and pan-tissue data.
-3. **Reference-based transfer**: Transfer labels from celldex-style references through the R bridge (SingleR).
-4. **Compatibility alias**: `scmap` is exposed as a CLI-compatible R path and currently reuses the SingleR/celldex bridge.
+Implemented methods:
 
-## Input Formats
+1. `markers`
+2. `celltypist`
+3. `singler`
+4. `scmap`
 
-| Format | Extension | Required Fields | Example |
-|--------|-----------|-----------------|---------|
-| AnnData (preprocessed) | `.h5ad` | `X` (normalized), PCA, clustering | `preprocessed.h5ad` |
-| Marker list | `.csv`/`.json` | Gene to Cell Type mapping | `immune_markers.json` |
+## Input Contract
 
-## Workflow
+- Accepted input: preprocessed `.h5ad`
+- Typical requirements: log-normalized expression and cluster labels such as `leiden`
+- Preferred matrix source: `adata.raw` when present and aligned; otherwise `adata.X`
+- Output labels are written to `obs["cell_type"]`
 
-1. **Validate**: Check for normalized counts, highly variable genes, and existing clusters.
-2. **Score**: Run the selected annotation engine (CellTypist, SingleR, or Marker scoring).
-3. **Assign**: Resolve labels per cell or aggregate majority votes per cluster.
-4. **Generate**: Save annotated h5ad, UMAP plots colored by cell type, and prediction probabilities.
-5. **Report**: Write `report.md` detailing the used reference, predicted fractions, and confidence.
+## Workflow Summary
+
+1. Validate required cluster/reference metadata.
+2. Run the selected annotation backend.
+3. Standardize output columns such as `cell_type` and `annotation_method`.
+4. Export figures, tables, and the annotated AnnData object.
+5. Record method/reference settings in `result.json`.
 
 ## CLI Reference
 
 ```bash
-# Standard marker-based annotation
 python skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py \
-  --input <processed.h5ad> --method markers --cluster-key leiden --output <report_dir>
+  --input <processed.h5ad> --method markers --cluster-key leiden --output <dir>
 
-# CellTypist immune model
 python skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py \
-  --input <processed.h5ad> --method celltypist --model Immune_All_Low --output <report_dir>
+  --input <processed.h5ad> --method celltypist \
+  --model Immune_All_Low --output <dir>
 
-# SingleR via celldex
 python skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py \
-  --input <processed.h5ad> --method singler --reference HPCA --output <report_dir>
-
-# Demo mode
-python omicsclaw.py run sc-cell-annotation --demo
+  --input <processed.h5ad> --method singler \
+  --reference HPCA --output <dir>
 ```
 
-## Algorithm / Methodology
+## Output Contract
 
-### 1. Model-based Annotation (CellTypist - Python)
+Successful runs write:
 
-**Goal:** Annotate cells using a pre-trained logistic regression classifier.
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `figures/`
+- `tables/`
+- `reproducibility/commands.sh`
 
-```python
-import scanpy as sc
-import celltypist
-from celltypist import models
+## Current Limitations
 
-# Load data and ensure target is normalized to 10k counts
-adata = sc.read_h5ad('processed.h5ad')
-sc.pp.normalize_total(adata, target_sum=1e4)
-sc.pp.log1p(adata)
-
-# Download and load model (e.g., Immune_All_Low)
-models.download_models(force_update=False)
-model = models.Model.load(model='Immune_All_Low.pkl')
-
-# Annotate
-predictions = celltypist.annotate(adata, model=model, majority_voting=True)
-
-# Transfer labels to AnnData
-adata.obs['celltypist_prediction'] = predictions.predicted_labels.predicted_labels
-adata.obs['celltypist_majority_voting'] = predictions.predicted_labels.majority_voting
-```
-
-### 2. Marker-based Scoring (Scanpy - Python)
-
-**Goal:** Score clusters based on known marker gene expression.
-
-```python
-import scanpy as sc
-import pandas as pd
-
-# Define markers
-marker_genes_dict = {
-    'B cells': ['CD79A', 'MS4A1'],
-    'T cells': ['CD3D', 'CD3E', 'CD8A', 'CD4'],
-    'NK cells': ['GNLY', 'NKG7'],
-    'Monocytes': ['CD14', 'LYZ']
-}
-
-# Calculate marker gene scores per cell
-for cell_type, markers in marker_genes_dict.items():
-    sc.tl.score_genes(adata, gene_list=markers, score_name=f'{cell_type}_score')
-
-# Assign cluster labels based on highest mean score per cluster
-cluster_scores = adata.obs.groupby('leiden')[[f'{ct}_score' for ct in marker_genes_dict.keys()]].mean()
-cluster_annotations = cluster_scores.idxmax(axis=1).str.replace('_score', '')
-adata.obs['cell_type'] = adata.obs['leiden'].map(cluster_annotations)
-```
-
-### 3. Reference-based Transfer (SingleR - R)
-
-**Goal:** Compare query expression profile to reference transcriptomes.
-
-```r
-library(SingleR)
-library(celldex)
-library(Seurat)
-
-# Load reference dataset
-ref <- celldex::HumanPrimaryCellAtlasData()
-
-# Query data from Seurat
-query_counts <- GetAssayData(seurat_obj, assay = "RNA", slot = "data")
-
-# Run SingleR
-pred <- SingleR(test = query_counts, ref = ref, labels = ref$label.main)
-
-# Add to Seurat object
-seurat_obj$SingleR_labels <- pred$labels
-```
-
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--method` | `markers` | Annotation method: `markers`, `celltypist`, `singler`, `scmap` |
-| `--model` | `Immune_All_Low` | Pre-trained model name for CellTypist |
-| `--reference` | `HPCA` | celldex reference for `singler`/`scmap` |
-| `--cluster-key` | `leiden` | Cluster column for marker mode |
-
-## Example Queries
-
-- "Annotate this PBMC dataset using the CellTypist immune model"
-- "Use this marker gene JSON to label the clusters in my h5ad file"
-- "Run SingleR against the Human Primary Cell Atlas for these cells"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── annotated.h5ad
-├── figures/
-│   ├── umap_celltype.png
-│   ├── celltypist_probabilities.png
-│   └── marker_dotplot.png
-├── tables/
-│   └── annotations.csv
-└── reproducibility/
-    ├── commands.sh
-    ├── requirements.txt
-    └── checksums.sha256
-```
-
-## Dependencies
-
-**Required**: scanpy >= 1.9, pandas, anndata
-**Optional**: celltypist (Python), R + packages `SingleR` and `celldex` (executed via native R scripts)
-
-## Runtime Notes
-
-- `singler` is the main implemented R backend.
-- `scmap` is currently a compatibility alias that reuses the same SingleR/celldex bridge because no native scmap reference script is bundled in this repo.
-
-## Safety
-
-- **Local-first**: No data upload. Pre-trained models are downloaded locally.
-- **Disclaimer**: Every report includes the OmicsClaw disclaimer regarding automated assertions.
-- **Audit trail**: Log all model definitions and threshold selections.
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Presence of "annotate", "cell type", "CellTypist" in query.
-
-**Chaining partners**:
-- `sc-preprocess`: Pre-requisite for annotation (clusters and UMAP required).
-- `sc-de`: Compute differentials between newly annotated cell types.
-
-## Citations
-
-- [CellTypist](https://www.science.org/doi/10.1126/science.abl5197) — Dominguez Conde et al., Science 2022
-- [SingleR](https://doi.org/10.1038/s41590-018-0276-y) — Aran et al., Nature Immunology 2019
-- [Scanpy](https://scanpy.readthedocs.io/) — Wolf et al., Genome Biology 2018
+- `singler` requires an R environment with `SingleR`, `celldex`, `SingleCellExperiment`, and `zellkonverter`.
+- `scmap` requires an R environment with `scmap`, `celldex`, `SingleCellExperiment`, and `zellkonverter`.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py
+++ b/skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import logging
 import shlex
+import tempfile
 import sys
 from pathlib import Path
 
@@ -22,12 +23,21 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_footer, generate_report_header, write_result_json
+from omicsclaw.common.report import (
+    generate_report_footer,
+    generate_report_header,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib.adata_utils import store_analysis_metadata
 from skills.singlecell._lib import annotation as sc_annotation_utils
 from skills.singlecell._lib.export import save_h5ad
 from skills.singlecell._lib.gallery import PlotSpec, VisualizationRecipe, render_plot_specs
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -35,6 +45,57 @@ logger = logging.getLogger(__name__)
 SKILL_NAME = "sc-cell-annotation"
 SKILL_VERSION = "0.4.0"
 SCRIPT_REL_PATH = "skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text(
+        "\n".join(lines) + ("\n" if lines else ""),
+        encoding="utf-8",
+    )
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell type annotation for preprocessed scRNA-seq datasets.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "markers"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell type annotation for preprocessed scRNA-seq datasets.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "markers"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 METHOD_REGISTRY: dict[str, MethodConfig] = {
     "markers": MethodConfig(
@@ -54,7 +115,7 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
     ),
     "scmap": MethodConfig(
         name="scmap",
-        description="scmap-compatible R annotation path",
+        description="scmap cluster projection (R)",
         dependencies=(),
     ),
 }
@@ -75,10 +136,58 @@ PBMC_MARKERS = {
 # ---------------------------------------------------------------------------
 
 
+def _record_annotation_execution(
+    adata,
+    *,
+    requested_method: str,
+    actual_method: str,
+    fallback_reason: str = "",
+) -> None:
+    adata.obs["annotation_requested_method"] = requested_method
+    adata.obs["annotation_actual_method"] = actual_method
+    adata.obs["annotation_method"] = actual_method
+    adata.uns["annotation_runtime"] = {
+        "requested_method": requested_method,
+        "actual_method": actual_method,
+        "used_fallback": bool(fallback_reason),
+        "fallback_reason": fallback_reason,
+    }
+
+
+def _annotation_summary(
+    adata,
+    *,
+    requested_method: str,
+    actual_method: str,
+    fallback_reason: str = "",
+    expression_source: str | None = None,
+) -> dict:
+    counts = adata.obs["cell_type"].astype(str).value_counts().to_dict()
+    summary = {
+        "method": actual_method,
+        "requested_method": requested_method,
+        "actual_method": actual_method,
+        "used_fallback": bool(fallback_reason),
+        "fallback_reason": fallback_reason,
+        "n_cell_types": len(counts),
+        "cell_type_counts": {str(k): int(v) for k, v in counts.items()},
+    }
+    if expression_source:
+        summary["expression_source"] = expression_source
+    return summary
+
+
+def _marker_expression_source(adata) -> tuple[str, object]:
+    if adata.raw is not None and adata.raw.shape == adata.shape:
+        return "adata.raw", adata.raw
+    return "adata.X", adata
+
+
 def annotate_markers(adata, markers=None, cluster_key: str = "leiden"):
     """Marker-based annotation."""
     if markers is None:
         markers = PBMC_MARKERS
+    expression_source, expr = _marker_expression_source(adata)
 
     if cluster_key not in adata.obs:
         logger.warning("No %s found, running clustering", cluster_key)
@@ -87,6 +196,7 @@ def annotate_markers(adata, markers=None, cluster_key: str = "leiden"):
         cluster_key = "leiden"
 
     cluster_annotations = {}
+    expr_var_names = expr.var_names
     for cluster in adata.obs[cluster_key].astype(str).unique():
         cluster_mask = adata.obs[cluster_key].astype(str) == cluster
         cluster_data = adata[cluster_mask]
@@ -94,10 +204,13 @@ def annotate_markers(adata, markers=None, cluster_key: str = "leiden"):
         best_type = "Unknown"
         best_score = 0.0
         for cell_type, marker_genes in markers.items():
-            available = [g for g in marker_genes if g in adata.var_names]
+            available = [g for g in marker_genes if g in expr_var_names]
             if not available:
                 continue
-            scores = np.asarray(cluster_data[:, available].X.mean()).item()
+            if expression_source == "adata.raw":
+                scores = np.asarray(cluster_data.raw[:, available].X.mean()).item()
+            else:
+                scores = np.asarray(cluster_data[:, available].X.mean()).item()
             if scores > best_score:
                 best_score = float(scores)
                 best_type = cell_type
@@ -105,81 +218,152 @@ def annotate_markers(adata, markers=None, cluster_key: str = "leiden"):
         cluster_annotations[cluster] = best_type
 
     adata.obs["cell_type"] = adata.obs[cluster_key].astype(str).map(cluster_annotations)
-    adata.obs["annotation_method"] = "markers"
+    adata.obs["annotation_score"] = np.nan
+    _record_annotation_execution(
+        adata,
+        requested_method="markers",
+        actual_method="markers",
+    )
     logger.info("Annotated %d clusters", len(cluster_annotations))
-
-    cell_type_counts = adata.obs["cell_type"].value_counts().to_dict()
-    return {
-        "method": "markers",
-        "n_cell_types": len(cell_type_counts),
-        "cell_type_counts": {str(k): int(v) for k, v in cell_type_counts.items()},
-    }
+    return _annotation_summary(
+        adata,
+        requested_method="markers",
+        actual_method="markers",
+        expression_source=expression_source,
+    )
 
 
 def annotate_celltypist(adata, model: str = "Immune_All_Low"):
-    """CellTypist annotation."""
+    """CellTypist annotation with explicit fallback recording."""
+    celltypist_input, expression_source = sc_annotation_utils.build_celltypist_input_adata(adata)
+    is_valid, reason = sc_annotation_utils.validate_celltypist_input_matrix(celltypist_input)
+    if not is_valid:
+        logger.warning("CellTypist input validation failed: %s", reason)
+        annotate_markers(adata)
+        _record_annotation_execution(
+            adata,
+            requested_method="celltypist",
+            actual_method="markers",
+            fallback_reason=reason,
+        )
+        summary = _annotation_summary(
+            adata,
+            requested_method="celltypist",
+            actual_method="markers",
+            fallback_reason=reason,
+            expression_source=expression_source,
+        )
+        return summary
+
     try:
         model_name = model if model.endswith(".pkl") else f"{model}.pkl"
         sc_annotation_utils.annotate_with_celltypist(
-            adata,
+            celltypist_input,
             model=model_name,
             annotation_key="cell_type",
             inplace=True,
         )
-        adata.obs["annotation_method"] = "celltypist"
-        counts = adata.obs["cell_type"].astype(str).value_counts().to_dict()
-        return {
-            "method": "celltypist",
-            "n_cell_types": len(counts),
-            "cell_type_counts": {str(k): int(v) for k, v in counts.items()},
-        }
+        adata.obs["cell_type"] = celltypist_input.obs["cell_type"].values
+        if "cell_type_score" in celltypist_input.obs.columns:
+            adata.obs["annotation_score"] = pd.to_numeric(celltypist_input.obs["cell_type_score"], errors="coerce").values
+        if "cell_type_prob" in celltypist_input.obsm:
+            adata.obsm["cell_type_prob"] = celltypist_input.obsm["cell_type_prob"]
+        _record_annotation_execution(
+            adata,
+            requested_method="celltypist",
+            actual_method="celltypist",
+        )
+        return _annotation_summary(
+            adata,
+            requested_method="celltypist",
+            actual_method="celltypist",
+            expression_source=expression_source,
+        )
     except Exception as exc:
+        reason = str(exc)
         logger.warning("CellTypist annotation unavailable (%s); falling back to marker-based annotation", exc)
-        summary = annotate_markers(adata)
-        summary["method"] = "celltypist"
-        adata.obs["annotation_method"] = "celltypist"
+        annotate_markers(adata)
+        _record_annotation_execution(
+            adata,
+            requested_method="celltypist",
+            actual_method="markers",
+            fallback_reason=reason,
+        )
+        summary = _annotation_summary(
+            adata,
+            requested_method="celltypist",
+            actual_method="markers",
+            fallback_reason=reason,
+            expression_source=expression_source,
+        )
         return summary
 
 
-def _apply_r_annotations(adata, df: pd.DataFrame, *, method_name: str) -> dict:
+def _apply_r_annotations(adata, df: pd.DataFrame, *, requested_method: str, actual_method: str) -> dict:
     df = df.copy()
     if df.empty:
-        raise RuntimeError(f"R annotation method '{method_name}' returned no predictions")
+        raise RuntimeError(f"R annotation method '{requested_method}' returned no predictions")
     df.index = df.index.astype(str)
     df = df.reindex(adata.obs_names)
     labels = df["pruned_label"].fillna(df["cell_type"]).astype(str)
     adata.obs["cell_type"] = labels.values
     if "score" in df.columns:
         adata.obs["annotation_score"] = pd.to_numeric(df["score"], errors="coerce").values
-    adata.obs["annotation_method"] = method_name
-    counts = adata.obs["cell_type"].value_counts().to_dict()
-    return {
-        "method": method_name,
-        "n_cell_types": len(counts),
-        "cell_type_counts": {str(k): int(v) for k, v in counts.items()},
-    }
+    _record_annotation_execution(
+        adata,
+        requested_method=requested_method,
+        actual_method=actual_method,
+    )
+    return _annotation_summary(adata, requested_method=requested_method, actual_method=actual_method)
 
 
 def annotate_singler(adata, reference: str = "HPCA"):
     """SingleR annotation via the shared R bridge."""
-    logger.warning("SingleR bridge is not bundled in the current wrapper; using marker-based fallback")
-    summary = annotate_markers(adata)
-    summary["method"] = "singler"
-    adata.obs["annotation_method"] = "singler"
+    validate_r_environment(required_r_packages=["SingleR", "celldex", "SingleCellExperiment", "zellkonverter"])
+    export_adata, expression_source = sc_annotation_utils.build_celltypist_input_adata(adata)
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_singler_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export_adata.write_h5ad(input_h5ad)
+        runner.run_script(
+            "sc_singler_annotate.R",
+            args=[str(input_h5ad), str(output_dir), reference],
+            expected_outputs=["singler_results.csv"],
+            output_dir=output_dir,
+        )
+        df = pd.read_csv(output_dir / "singler_results.csv", index_col=0)
+    summary = _apply_r_annotations(adata, df, requested_method="singler", actual_method="singler")
+    summary["expression_source"] = expression_source
+    summary["reference"] = reference
     return summary
 
 
 def annotate_scmap(adata, reference: str = "HPCA"):
-    """scmap-compatible R annotation path.
-
-    The provided reference bundle includes SingleR helpers but not scmap itself, so
-    this uses the same Seurat/celldex-backed bridge while keeping the method name
-    exposed to the CLI.
-    """
-    logger.warning("scmap bridge is not bundled in the current wrapper; using marker-based fallback")
-    summary = annotate_markers(adata)
-    summary["method"] = "scmap"
-    adata.obs["annotation_method"] = "scmap"
+    """scmap annotation via the shared R bridge."""
+    validate_r_environment(required_r_packages=["scmap", "celldex", "SingleCellExperiment", "zellkonverter"])
+    export_adata, expression_source = sc_annotation_utils.build_celltypist_input_adata(adata)
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_scmap_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export_adata.write_h5ad(input_h5ad)
+        runner.run_script(
+            "sc_scmap_annotate.R",
+            args=[str(input_h5ad), str(output_dir), reference],
+            expected_outputs=["scmap_results.csv"],
+            output_dir=output_dir,
+        )
+        df = pd.read_csv(output_dir / "scmap_results.csv", index_col=0)
+    summary = _apply_r_annotations(adata, df, requested_method="scmap", actual_method="scmap")
+    summary["expression_source"] = expression_source
+    summary["reference"] = reference
     return summary
 
 
@@ -481,6 +665,10 @@ def write_reproducibility(output_dir: Path, params: dict, *, demo_mode: bool = F
     for key, value in params.items():
         command += f" --{key.replace('_', '-')} {shlex.quote(str(value))}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{command}\n", encoding="utf-8")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
 
 def main():
@@ -498,12 +686,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-        if demo_path.exists():
-            adata = sc.read_h5ad(demo_path)
-        else:
-            logger.warning("Local demo data not found, downloading from scanpy")
-            adata = sc.datasets.pbmc3k_processed()
+        adata, _ = sc_io.load_repo_demo_data("pbmc3k_processed")
         input_file = None
     else:
         if not args.input_path:
@@ -526,14 +709,22 @@ def main():
     write_report(output_dir, summary, input_file, params, gallery_context=gallery_context)
     write_reproducibility(output_dir, params, demo_mode=args.demo)
 
-    store_analysis_metadata(adata, SKILL_NAME, method, params)
+    params["requested_method"] = method
+    params["actual_method"] = summary.get("actual_method", method)
+    if summary.get("fallback_reason"):
+        params["fallback_reason"] = summary["fallback_reason"]
+    store_analysis_metadata(adata, SKILL_NAME, summary.get("actual_method", method), params)
     output_h5ad = output_dir / "processed.h5ad"
     save_h5ad(adata, output_h5ad)
     logger.info("Saved to %s", output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
     result_data = {
-        "method": method,
+        "method": summary.get("actual_method", method),
+        "requested_method": summary.get("requested_method", method),
+        "actual_method": summary.get("actual_method", method),
+        "used_fallback": summary.get("used_fallback", False),
+        "fallback_reason": summary.get("fallback_reason", ""),
         "params": params,
         **summary,
         "visualization": {
@@ -545,6 +736,12 @@ def main():
         },
     }
     write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     print(f"Success: {SKILL_NAME}")
     print(f"  Output: {output_dir}")

--- a/skills/singlecell/scrna/sc-cell-communication/SKILL.md
+++ b/skills/singlecell/scrna/sc-cell-communication/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sc-cell-communication
 description: >-
-  Cell-cell communication analysis for single-cell RNA-seq using a built-in ligand-receptor scorer,
-  LIANA+, or CellChat via the R bridge.
-version: 0.1.0
+  Cell-cell communication analysis for annotated scRNA-seq data using a built-in
+  ligand-receptor scorer, LIANA, or a CellChat R path.
+version: 0.2.0
 author: OmicsClaw Team
 license: MIT
 tags: [singlecell, communication, ligand-receptor, liana, cellchat]
@@ -14,6 +14,28 @@ metadata:
       - "--cell-type-key"
       - "--method"
       - "--species"
+    param_hints:
+      builtin:
+        priority: "cell_type_key -> species"
+        params: ["cell_type_key", "species"]
+        defaults: {cell_type_key: "cell_type", species: "human"}
+        requires: ["cell_type_labels_in_obs"]
+        tips:
+          - "--method builtin: Default lightweight scorer with a small curated ligand-receptor list."
+      liana:
+        priority: "cell_type_key -> species"
+        params: ["cell_type_key", "species"]
+        defaults: {cell_type_key: "cell_type", species: "human"}
+        requires: ["liana", "cell_type_labels_in_obs"]
+        tips:
+          - "--method liana: Uses LIANA rank aggregation when the Python package is installed."
+      cellchat_r:
+        priority: "cell_type_key -> species"
+        params: ["cell_type_key", "species"]
+        defaults: {cell_type_key: "cell_type", species: "human"}
+        requires: ["R_CellChat_stack", "cell_type_labels_in_obs"]
+        tips:
+          - "--method cellchat_r: R-backed CellChat path."
     saves_h5ad: true
     requires_preprocessed: true
     trigger_keywords:
@@ -24,32 +46,63 @@ metadata:
       - liana
 ---
 
-# Single-Cell Communication
+# Single-Cell Cell Communication
 
-This skill identifies ligand-receptor interactions between annotated cell populations in scRNA-seq data.
+## Why This Exists
 
-## Methods
+- Without it: ligand-receptor analysis is hard to standardize across tools.
+- With it: the same cell-type labels can be reused across built-in and external communication backends.
+- Why OmicsClaw: one output contract captures interactions, top pairs, and summary figures.
 
-- `builtin`: lightweight Python fallback with a curated ligand-receptor set
-- `liana`: LIANA+ consensus ranking when the Python package is available
-- `cellchat_r`: CellChat via native R script (requires R + CellChat package)
+## Scope Boundary
 
-## Input
+Implemented entry paths:
 
-- Preprocessed `.h5ad` with a cell type column such as `cell_type`, `leiden`, or `louvain`
+1. `builtin`
+2. `liana`
+3. `cellchat_r`
 
-## Output
+The wrapper assumes you already have biologically meaningful labels in `obs`.
 
-- `report.md`
-- `result.json`
-- `processed.h5ad`
-- `tables/lr_interactions.csv`
-- `tables/top_interactions.csv`
-- communication figures in `figures/`
+## Input Contract
 
-## Example
+- Accepted input: preprocessed `.h5ad`
+- Required column: a label column such as `cell_type`, `leiden`, or another supplied `--cell-type-key`
+
+## Workflow Summary
+
+1. Validate the cell-type key.
+2. Run the selected communication backend.
+3. Rank interactions and extract top pairs.
+4. Write interaction tables and summary plots.
+5. Save `processed.h5ad`, `report.md`, and `result.json`.
+
+## CLI Reference
 
 ```bash
-python omicsclaw.py run sc-cell-communication --input data.h5ad --cell-type-key cell_type --output out/
-python omicsclaw.py run sc-cell-communication --method cellchat_r --input data.h5ad --cell-type-key cell_type --output out/
+python omicsclaw.py run sc-cell-communication \
+  --input data.h5ad --cell-type-key cell_type --output out/
+
+python omicsclaw.py run sc-cell-communication \
+  --method liana --input data.h5ad --cell-type-key cell_type --output out/
+
+python omicsclaw.py run sc-cell-communication \
+  --method cellchat_r --input data.h5ad --cell-type-key cell_type --output out/
 ```
+
+## Output Contract
+
+Successful runs write:
+
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `tables/lr_interactions.csv`
+- `tables/top_interactions.csv`
+- `figures/interaction_heatmap.png`
+- `figures/top_interactions.png`
+
+## Current Limitations
+
+- The built-in method uses a small curated ligand-receptor set and is intentionally lightweight.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-cell-communication/sc_cell_communication.py
+++ b/skills/singlecell/scrna/sc-cell-communication/sc_cell_communication.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import tempfile
 import logging
 import sys
 from pathlib import Path
@@ -14,15 +15,25 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scanpy as sc
+from pandas.errors import EmptyDataError
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_footer, generate_report_header, write_result_json
+from omicsclaw.common.report import (
+    generate_report_footer,
+    generate_report_header,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib.adata_utils import store_analysis_metadata
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 from skills.singlecell._lib.viz_utils import save_figure
 
@@ -52,6 +63,54 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
 
 DEFAULT_METHOD = "builtin"
 
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell-cell communication analysis for annotated scRNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", DEFAULT_METHOD),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell-cell communication analysis for annotated scRNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", DEFAULT_METHOD),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
+
 BUILTIN_LR = [
     ("TGFB1", "TGFBR1"),
     ("TGFB1", "TGFBR2"),
@@ -66,6 +125,41 @@ BUILTIN_LR = [
     ("JAG1", "NOTCH1"),
     ("DLL4", "NOTCH1"),
 ]
+
+
+def _build_cellchat_input_adata(adata):
+    if adata.raw is not None and adata.raw.shape == adata.shape:
+        export = sc.AnnData(X=adata.raw.X.copy(), obs=adata.obs.copy(), var=adata.raw.var.copy())
+        export.obs_names = adata.obs_names.copy()
+        export.var_names = adata.raw.var_names.copy()
+        return export, "adata.raw"
+    return adata.copy(), "adata.X"
+
+
+def run_cellchat(adata, *, cell_type_key: str, species: str) -> pd.DataFrame:
+    validate_r_environment(required_r_packages=["CellChat", "SingleCellExperiment", "zellkonverter"])
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=7200)
+    export, source = _build_cellchat_input_adata(adata)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_cellchat_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export.write_h5ad(input_h5ad)
+        runner.run_script(
+            "sc_cellchat.R",
+            args=[str(input_h5ad), str(output_dir), cell_type_key, species],
+            expected_outputs=["cellchat_results.csv"],
+            output_dir=output_dir,
+        )
+        try:
+            df = pd.read_csv(output_dir / "cellchat_results.csv")
+        except EmptyDataError:
+            df = pd.DataFrame(columns=["ligand", "receptor", "source", "target", "score", "pvalue", "pathway"])
+    if not df.empty:
+        df["expression_source"] = source
+    return df
 
 
 def _group_means(adata, cell_type_key: str) -> pd.DataFrame:
@@ -270,6 +364,10 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
         f" --species {params.get('species', 'human')}"
     )
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
 
 def main():
@@ -286,7 +384,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        adata = sc.datasets.pbmc3k_processed()
+        adata, _ = sc_io.load_repo_demo_data("pbmc3k_processed")
         if args.cell_type_key not in adata.obs.columns:
             fallback_key = "louvain" if "louvain" in adata.obs else "leiden"
             adata.obs[args.cell_type_key] = adata.obs[fallback_key].astype(str)
@@ -308,14 +406,21 @@ def main():
     adata.write_h5ad(output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
+    result_data = {"params": params}
     write_result_json(
         output_dir,
         SKILL_NAME,
         SKILL_VERSION,
         {k: v for k, v in summary.items() if k not in {"lr_df", "top_df"}},
-        {"params": params},
+        result_data,
         checksum,
     )
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": {k: v for k, v in summary.items() if k not in {"lr_df", "top_df"}},
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
     store_analysis_metadata(adata, SKILL_NAME, method, params)
 
     print(f"Success: {SKILL_NAME}")

--- a/skills/singlecell/scrna/sc-de/SKILL.md
+++ b/skills/singlecell/scrna/sc-de/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: sc-de
 description: >-
-  Differential expression analysis for single-cell data — marker gene discovery
-  using Wilcoxon, t-test, MAST compatibility, or DESeq2 pseudobulk analysis via R.
-version: 0.4.0
+  Differential expression for single-cell RNA-seq using Scanpy marker tests or
+  an R-backed DESeq2 pseudobulk path. The wrapper separates exploratory
+  cluster-level marker ranking from sample-aware pseudobulk analysis.
+version: 0.5.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, differential-expression, markers, Wilcoxon, MAST, pseudo-bulk]
+tags: [singlecell, differential-expression, markers, wilcoxon, deseq2]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -18,14 +19,43 @@ metadata:
       - "--method"
       - "--n-top-genes"
       - "--sample-key"
+    param_hints:
+      wilcoxon:
+        priority: "groupby -> n_top_genes -> group1/group2"
+        params: ["groupby", "n_top_genes", "group1", "group2"]
+        defaults: {groupby: "leiden", n_top_genes: 10}
+        requires: ["preprocessed_anndata", "scanpy"]
+        tips:
+          - "--method wilcoxon: Default exploratory marker-ranking path."
+      t-test:
+        priority: "groupby -> n_top_genes -> group1/group2"
+        params: ["groupby", "n_top_genes", "group1", "group2"]
+        defaults: {groupby: "leiden", n_top_genes: 10}
+        requires: ["preprocessed_anndata", "scanpy"]
+        tips:
+          - "--method t-test: Parametric alternative to Wilcoxon."
+      mast:
+        priority: "groupby -> group1/group2 -> n_top_genes"
+        params: ["groupby", "group1", "group2", "n_top_genes"]
+        defaults: {groupby: "leiden", n_top_genes: 10}
+        requires: ["R_MAST_stack", "log_normalized_expression_matrix"]
+        tips:
+          - "--method mast: R-backed MAST hurdle-model path on log-normalized expression."
+      deseq2_r:
+        priority: "groupby -> group1/group2 -> sample_key -> celltype_key"
+        params: ["groupby", "group1", "group2", "sample_key", "celltype_key"]
+        defaults: {sample_key: "sample_id", celltype_key: "cell_type"}
+        requires: ["raw_counts_or_raw_layer", "biological_replicates", "R_DESeq2_stack"]
+        tips:
+          - "--method deseq2_r: Sample-aware pseudobulk path."
+          - "--group1 and --group2 are required for the DESeq2 path."
     saves_h5ad: true
     requires_preprocessed: true
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🧬"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install:
@@ -35,196 +65,72 @@ metadata:
     trigger_keywords:
       - differential expression
       - marker genes
-      - DE analysis
-      - Wilcoxon
-      - MAST
-      - group comparison
+      - de analysis
+      - wilcoxon
       - pseudo-bulk
 ---
 
-# 🧬 Single-Cell Differential Expression
-
-You are **SC DE**, the differential expression and marker gene discovery skill for single-cell data. Your role is to identify genes that define cell populations or respond to experimental conditions.
+# Single-Cell Differential Expression
 
 ## Why This Exists
 
-- **Without it**: Users manually configure DE tests with inconsistent parameters, often overlooking fold-change artifacts in log-normalized single-cell data.
-- **With it**: One command securely discovers robust markers per cluster or between any two biological groups using statistically sound methods.
-- **Why OmicsClaw**: Standardized reporting includes Volcano plots, MA plots, and ranked marker tables out-of-the-box. Includes advanced pseudo-bulk testing for multi-sample designs.
+- Without it: users mix exploratory marker tests with replicate-aware inference and misread the results.
+- With it: the wrapper makes the statistical path explicit and preserves the public DE contract.
+- Why OmicsClaw: one interface covers quick Scanpy ranking and the heavier pseudobulk route.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **Cluster-vs-rest markers**: Identify defining genes for every cell cluster (Wilcoxon, t-test, or MAST).
-2. **Two-group pairwise comparison**: Compute DEGs between two conditions (e.g., Control vs Treatment) within specific cell types.
-3. **Pseudo-bulk DE**: Aggregate counts across cells per sample/bio-rep for robust condition testing (DESeq2/edgeR integration).
-4. **Comprehensive Visualisation**: Dotplots, Volcano plots, rank-genes group plots, and heatmaps.
+Implemented methods:
 
-## Input Formats
+1. `wilcoxon`
+2. `t-test`
+3. `mast` for R-backed hurdle-model DE
+4. `deseq2_r` for pseudobulk DE
 
-| Format | Extension | Required Fields | Example |
-|--------|-----------|-----------------|---------|
-| AnnData (preprocessed) | `.h5ad` | `X` (log1p normalized), `.raw` (raw counts needed for pseudo-bulk/MAST) | `annotated.h5ad` |
+## Input Contract
 
-## Workflow
+- Accepted input: preprocessed `.h5ad`
+- `wilcoxon`, `t-test`, and `mast` expect log-normalized expression, preferably in `adata.raw`
+- `deseq2_r` expects raw counts, preferably in `layers["counts"]`; it may read `adata.X` only when `X` itself is still an unnormalized count matrix, plus `group1`, `group2`, `sample_key`, and `celltype_key`
+- All methods require a grouping column in `obs`
 
-1. **Validate**: Verify if grouping variables exist and data matrices contain expected values.
-2. **Execute**: Run selected DE statistical test.
-3. **Filter**: Apply Log2FC and p-value Thresholds to identify significant up/down genes.
-4. **Generate**: Save updated h5ad, generate plots (Volcano, dotplot).
-5. **Report**: Write `report.md` with top hit summarization.
+## Workflow Summary
+
+1. Validate the requested DE mode.
+2. Run Scanpy ranking or pseudobulk DESeq2.
+3. Export full and top-hit tables.
+4. Save `processed.h5ad`, `report.md`, and `result.json`.
+5. Record the chosen method and grouping variables for downstream traceability.
 
 ## CLI Reference
 
 ```bash
-# Cluster vs Rest (FindAllMarkers)
 python skills/singlecell/scrna/sc-de/sc_de.py \
-  --input <processed.h5ad> --groupby leiden --output <dir>
+  --input <processed.h5ad> --groupby leiden --method wilcoxon --output <dir>
 
-# Pairwise comparison within a cell type
 python skills/singlecell/scrna/sc-de/sc_de.py \
-  --input <annotated.h5ad> --output <dir> --groupby condition \
-  --group1 Treatment --group2 Control
+  --input <processed.h5ad> --groupby condition \
+  --group1 treated --group2 control --method t-test --output <dir>
 
-# Pseudobulk DESeq2 through the R bridge
 python skills/singlecell/scrna/sc-de/sc_de.py \
-  --input <annotated.h5ad> --output <dir> --method deseq2_r \
-  --groupby condition --group1 Treatment --group2 Control \
-  --sample-key sample_id --celltype-key cell_type
-
-# Demo mode
-python omicsclaw.py run sc-de --demo
+  --input <processed.h5ad> --method deseq2_r \
+  --groupby condition --group1 treated --group2 control \
+  --sample-key sample_id --celltype-key cell_type --output <dir>
 ```
 
-## Algorithm / Methodology
+## Output Contract
 
-### 1. Cluster vs Rest (Scanpy - Python)
+Successful runs write:
 
-**Goal:** Identify marker genes for each cluster against all other cells using Wilcoxon Rank-Sum.
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `tables/de_full.csv`
+- `tables/markers_top.csv`
+- `reproducibility/commands.sh`
 
-```python
-import scanpy as sc
+## Current Limitations
 
-# Ensure data is log1p normalized
-adata = sc.read_h5ad('annotated.h5ad')
-
-# Compute marker genes
-sc.tl.rank_genes_groups(adata, groupby='cell_type', method='wilcoxon')
-
-# Visualise results
-sc.pl.rank_genes_groups(adata, n_genes=20, sharey=False)
-sc.pl.rank_genes_groups_dotplot(adata, n_genes=4)
-```
-
-### 2. Pairwise Condition Testing (Scanpy - Python)
-
-**Goal:** Compare two conditions (Treatment vs Control) constrained to a specific cell subset.
-
-```python
-import scanpy as sc
-
-adata = sc.read_h5ad('annotated.h5ad')
-
-# Filter to specific cell type
-adata_sub = adata[adata.obs['cell_type'] == 'CD8 T cells'].copy()
-
-# Run differential expression
-sc.tl.rank_genes_groups(adata_sub, groupby='condition', 
-                        groups=['Treatment'], reference='Control', method='wilcoxon')
-
-# Extract result dataframe
-import pandas as pd
-result = sc.get.rank_genes_groups_df(adata_sub, group='Treatment')
-sig_degs = result[(result['pvals_adj'] < 0.05) & (result['logfoldchanges'].abs() > 0.5)]
-```
-
-### 3. Pseudo-bulk DE (Python/R integration)
-
-**Goal:** Address biological replicates properly by aggregating counts at the sample level before DE testing.
-
-```python
-import scanpy as sc
-import decoupler as dc
-
-adata = sc.read_h5ad('annotated.h5ad')
-
-# Pseudo-bulking by Sample, condition, and cell_type
-pdata = dc.get_pseudobulk(
-    adata,
-    sample_col='sample_id',
-    groups_col='cell_type',
-    mode='sum',
-    min_cells=10,
-    min_counts=1000
-)
-
-# Run DESeq2 or edgeR equivalent via PyDESeq2 or standard formulas
-# (Pseudo-code for edgeR/DESeq2 workflow follows from pdata)
-```
-
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--groupby` | `leiden` | Column in `.obs` defining the groups |
-| `--method` | `wilcoxon` | Test: `wilcoxon`, `t-test`, `mast`, or `deseq2_r` |
-| `--group1` | none | Pairwise group A (e.g. Treatment) |
-| `--group2` | none | Pairwise group B (reference, e.g. Control) |
-| `--sample-key` | `sample_id` | Sample/replicate column for `deseq2_r` |
-| `--celltype-key` | `cell_type` | Cell type column for `deseq2_r` |
-
-## Example Queries
-
-- "Find marker genes for all clusters in this h5ad"
-- "Compute differential expression between Tumor and Normal states for B cells"
-- "Run a Wilcoxon test on the 'condition' column comparing DrugA to Vehicle"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── figures/
-│   ├── marker_dotplot.png
-│   ├── volcano_plot.png
-│   └── rank_genes_groups.png
-├── tables/
-│   ├── markers_top.csv
-│   └── de_full_statistics.csv
-└── reproducibility/
-    ├── commands.sh
-    ├── requirements.txt
-    └── checksums.sha256
-```
-
-## Dependencies
-
-**Required**: scanpy >= 1.9, pandas, matplotlib
-**Optional**: R + packages `DESeq2`, `muscat`, `SingleCellExperiment` (executed via native R scripts)
-
-## Runtime Notes
-
-- `mast` is currently a compatibility option in the Python path and falls back to Wilcoxon.
-- `deseq2_r` is the implemented replicate-aware pseudobulk backend and requires both `--group1` and `--group2`.
-
-## Safety
-
-- **Local-first**: No data upload. 
-- **Disclaimer**: Every DE report includes the OmicsClaw disclaimer regarding valid statistical assertions.
-- **Audit trail**: Log the exact p-value and Log2FC formulas applied in the bundle.
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Expressions like "DE", "differential expression", "compare condition", "find markers".
-
-**Chaining partners**:
-- `sc-annotate`: Requires cell types to exist before performing meaningful condition comparisons.
-- `sc-communication`: Identify DE ligands or receptors.
-
-## Citations
-
-- [Scanpy](https://scanpy.readthedocs.io/) — Wolf et al., Genome Biology 2018
-- [Wilcoxon rank-sum](https://en.wikipedia.org/wiki/Mann–Whitney_U_test)
-- [MAST](https://doi.org/10.1186/s13059-015-0844-5) — Finak et al., Genome Biology 2015
-- [Decoupler (Pseudo-bulk)](https://doi.org/10.1093/bioinformatics/btac212) — Badia-i-Mompel et al., Bioinformatics 2022
+- `mast` requires an R environment with `MAST`, `SingleCellExperiment`, and `zellkonverter`.
+- `deseq2_r` requires an R environment with `DESeq2`, `SingleCellExperiment`, and `zellkonverter`.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-de/sc_de.py
+++ b/skills/singlecell/scrna/sc-de/sc_de.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import argparse
 import logging
+import tempfile
 import sys
 from pathlib import Path
 
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import scanpy as sc
 
@@ -19,9 +21,19 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib.adata_utils import store_analysis_metadata
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from skills.singlecell._lib.pseudobulk import aggregate_to_pseudobulk, run_deseq2_analysis
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 from skills.singlecell._lib.viz_utils import save_figure
 
@@ -44,8 +56,8 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
     ),
     "mast": MethodConfig(
         name="mast",
-        description="MAST-style compatibility path (falls back to Wilcoxon in Python)",
-        dependencies=("scanpy",),
+        description="MAST hurdle-model differential expression (R)",
+        dependencies=(),
     ),
     "deseq2_r": MethodConfig(
         name="deseq2_r",
@@ -55,27 +67,109 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
 }
 
 
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Differential expression analysis for single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "wilcoxon"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Differential expression analysis for single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "wilcoxon"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
+
+
 def run_de_scanpy(adata, groupby="leiden", method="wilcoxon", group1=None, group2=None):
-    if groupby not in adata.obs.columns:
-        raise ValueError(f"Column '{groupby}' not found in adata.obs")
+    resolved_groupby = groupby
+    if resolved_groupby not in adata.obs.columns:
+        if resolved_groupby == "leiden" and "louvain" in adata.obs.columns:
+            logger.warning("Column 'leiden' not found; falling back to legacy 'louvain' for DE demo compatibility")
+            resolved_groupby = "louvain"
+        else:
+            raise ValueError(f"Column '{groupby}' not found in adata.obs")
 
     effective_method = method
-    if method == "mast":
-        logger.warning("MAST is not implemented in the Python path; falling back to Wilcoxon")
-        effective_method = "wilcoxon"
+    use_raw = adata.raw is not None and adata.raw.shape == adata.shape
 
     if group1 and group2:
-        sc.tl.rank_genes_groups(adata, groupby=groupby, groups=[group1], reference=group2, method=effective_method, pts=True)
+        sc.tl.rank_genes_groups(adata, groupby=resolved_groupby, groups=[group1], reference=group2, method=effective_method, pts=True, use_raw=use_raw)
     else:
-        sc.tl.rank_genes_groups(adata, groupby=groupby, method=effective_method, pts=True)
+        sc.tl.rank_genes_groups(adata, groupby=resolved_groupby, method=effective_method, pts=True, use_raw=use_raw)
 
     result_df = sc.get.rank_genes_groups_df(adata, group=None)
     n_groups = len(result_df["group"].unique()) if "group" in result_df.columns else 0
     return result_df, {
         "method": method,
+        "groupby": resolved_groupby,
         "n_groups": n_groups,
         "n_genes_tested": int(adata.n_vars),
     }
+
+
+def _matrix_looks_count_like(matrix) -> bool:
+    sample = matrix
+    if hasattr(sample, "shape") and len(sample.shape) == 2:
+        sample = sample[: min(sample.shape[0], 256), : min(sample.shape[1], 256)]
+    if hasattr(sample, "toarray"):
+        sample = sample.toarray()
+    arr = np.asarray(sample)
+    if arr.size == 0:
+        return False
+    if np.any(~np.isfinite(arr)) or np.any(arr < 0):
+        return False
+    return np.allclose(arr, np.round(arr), atol=1e-8)
+
+
+def _resolve_deseq2_count_source(adata) -> tuple[str | None, str]:
+    if "counts" in adata.layers:
+        return "counts", "layers.counts"
+
+    matrix_contract = adata.uns.get("omicsclaw_matrix_contract", {}) if isinstance(getattr(adata, "uns", {}), dict) else {}
+    if matrix_contract.get("X") == "raw_counts":
+        return None, "adata.X"
+
+    if _matrix_looks_count_like(adata.X):
+        return None, "adata.X"
+
+    raise ValueError(
+        "deseq2_r requires raw counts in adata.layers['counts'] or an unnormalized count-like adata.X matrix"
+    )
 
 
 def run_de_deseq2_r_method(adata, *, condition_key: str, group1: str, group2: str, sample_key: str, celltype_key: str):
@@ -86,21 +180,90 @@ def run_de_deseq2_r_method(adata, *, condition_key: str, group1: str, group2: st
     if celltype_key not in adata.obs.columns:
         raise ValueError(f"celltype_key '{celltype_key}' not found in adata.obs")
 
-    full_df = run_pseudobulk_deseq2(
+    layer, expression_source = _resolve_deseq2_count_source(adata)
+
+    pb = aggregate_to_pseudobulk(
         adata,
-        condition_key=condition_key,
-        case_label=group1,
-        reference_label=group2,
         sample_key=sample_key,
         celltype_key=celltype_key,
+        layer=layer,
     )
-    if full_df.empty:
+    if pb["counts"].empty:
+        raise RuntimeError("Pseudobulk aggregation returned no sample-celltype combinations")
+
+    sample_meta = adata.obs[[sample_key, condition_key]].drop_duplicates().rename(columns={sample_key: "sample"})
+    de_results = run_deseq2_analysis(
+        pb,
+        sample_meta,
+        formula="~ condition",
+        contrast=["condition", group1, group2],
+        celltype_key="celltype",
+        use_rpy2=True,
+    )
+    if not de_results:
         raise RuntimeError("R pseudobulk DESeq2 returned no results")
+
+    frames = []
+    for cell_type, df in de_results.items():
+        tmp = df.copy()
+        tmp["cell_type"] = cell_type
+        frames.append(tmp)
+    full_df = pd.concat(frames, ignore_index=True)
     n_groups = full_df["cell_type"].nunique() if "cell_type" in full_df.columns else 0
     return full_df, {
         "method": "deseq2_r",
         "n_groups": int(n_groups),
         "n_genes_tested": int(full_df["gene"].nunique()) if "gene" in full_df.columns else 0,
+        "expression_source": expression_source,
+    }
+
+
+def run_de_mast_method(adata, *, groupby: str, group1: str | None, group2: str | None):
+    resolved_groupby = groupby
+    if resolved_groupby not in adata.obs.columns:
+        if resolved_groupby == "leiden" and "louvain" in adata.obs.columns:
+            logger.warning("Column 'leiden' not found; falling back to legacy 'louvain' for MAST demo compatibility")
+            resolved_groupby = "louvain"
+        else:
+            raise ValueError(f"Column '{groupby}' not found in adata.obs")
+    validate_r_environment(required_r_packages=["MAST", "SingleCellExperiment", "zellkonverter"])
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    if adata.raw is not None and adata.raw.shape == adata.shape:
+        export = sc.AnnData(X=adata.raw.X.copy(), obs=adata.obs.copy(), var=adata.raw.var.copy())
+        export.obs_names = adata.obs_names.copy()
+        export.var_names = adata.raw.var_names.copy()
+        expression_source = "adata.raw"
+    else:
+        export = sc.AnnData(X=adata.X.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+        export.obs_names = adata.obs_names.copy()
+        export.var_names = adata.var_names.copy()
+        expression_source = "adata.X"
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_mast_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export.write_h5ad(input_h5ad)
+        args = [str(input_h5ad), str(output_dir), resolved_groupby]
+        if group1:
+            args.append(group1)
+        if group2:
+            args.append(group2)
+        runner.run_script(
+            "sc_mast_de.R",
+            args=args,
+            expected_outputs=["mast_results.csv"],
+            output_dir=output_dir,
+        )
+        full_df = pd.read_csv(output_dir / "mast_results.csv")
+    n_groups = full_df["group"].nunique() if "group" in full_df.columns else 0
+    return full_df, {
+        "method": "mast",
+        "groupby": resolved_groupby,
+        "n_groups": int(n_groups),
+        "n_genes_tested": int(full_df["gene"].nunique()) if "gene" in full_df.columns else 0,
+        "expression_source": expression_source,
     }
 
 
@@ -157,6 +320,10 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
         if v is not None:
             cmd += f" --{k.replace('_', '-')} {v}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
 
 def main():
@@ -164,7 +331,7 @@ def main():
     parser.add_argument("--input", dest="input_path")
     parser.add_argument("--output", dest="output_dir", required=True)
     parser.add_argument("--demo", action="store_true")
-    parser.add_argument("--groupby", default="louvain", help="Group column for Scanpy DE or condition column for deseq2_r")
+    parser.add_argument("--groupby", default="leiden", help="Group column for Scanpy DE or condition column for deseq2_r")
     parser.add_argument("--method", default="wilcoxon", choices=list(METHOD_REGISTRY.keys()))
     parser.add_argument("--n-top-genes", type=int, default=10)
     parser.add_argument("--group1", default=None)
@@ -177,12 +344,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-        if demo_path.exists():
-            adata = sc.read_h5ad(demo_path)
-        else:
-            logger.warning("Local demo data not found, downloading from scanpy")
-            adata = sc.datasets.pbmc3k_processed()
+        adata, _ = sc_io.load_repo_demo_data("pbmc3k_processed")
         input_file = None
     else:
         if not args.input_path:
@@ -208,6 +370,11 @@ def main():
         full_df.to_csv(tables_dir / "de_full.csv", index=False)
         sig_df = full_df.sort_values("padj", na_position="last")
         sig_df.to_csv(tables_dir / "markers_top.csv", index=False)
+    elif method == "mast":
+        full_df, summary = run_de_mast_method(adata, groupby=args.groupby, group1=args.group1, group2=args.group2)
+        top_df = full_df.sort_values(["padj", "pvalue"], na_position="last").groupby("group").head(args.n_top_genes)
+        full_df.to_csv(tables_dir / "de_full.csv", index=False)
+        top_df.to_csv(tables_dir / "markers_top.csv", index=False)
     else:
         full_df, summary = run_de_scanpy(adata, args.groupby, method, args.group1, args.group2)
         top_df = full_df.groupby("group").head(args.n_top_genes)
@@ -217,13 +384,14 @@ def main():
 
     summary["n_cells"] = int(adata.n_obs)
     params = {
-        "groupby": args.groupby,
+        "groupby": summary.get("groupby", args.groupby),
         "method": method,
         "n_top_genes": args.n_top_genes,
         "group1": args.group1,
         "group2": args.group2,
         "sample_key": args.sample_key,
         "celltype_key": args.celltype_key,
+        "expression_source": summary.get("expression_source", ("adata.raw" if (adata.raw is not None and adata.raw.shape == adata.shape and method != "deseq2_r") else ("layers.counts" if "counts" in adata.layers else "adata.X"))),
     }
 
     write_report(output_dir, summary, input_file, params)
@@ -233,7 +401,14 @@ def main():
     logger.info("Saved to %s", output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
     store_analysis_metadata(adata, SKILL_NAME, method, params)
 
     print(f"Success: {SKILL_NAME}")

--- a/skills/singlecell/scrna/sc-doublet-detection/SKILL.md
+++ b/skills/singlecell/scrna/sc-doublet-detection/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: sc-doublet-detection
 description: >-
-  Doublet detection and removal using Scrublet (Python), DoubletFinder (R),
-  and scDblFinder (R). Essential QC step before clustering.
-version: 0.4.0
+  Detect putative doublets in single-cell RNA-seq data using Scrublet,
+  DoubletFinder, or scDblFinder. The wrapper standardizes output columns and
+  keeps the public parameter surface compact.
+version: 0.5.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, doublet, Scrublet, DoubletFinder, scDblFinder, QC]
+tags: [singlecell, doublet, scrublet, doubletfinder, scdblfinder, qc]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -14,14 +15,38 @@ metadata:
       - "--expected-doublet-rate"
       - "--method"
       - "--threshold"
+    param_hints:
+      scrublet:
+        priority: "expected_doublet_rate -> threshold"
+        params: ["expected_doublet_rate", "threshold"]
+        defaults: {expected_doublet_rate: 0.06}
+        requires: ["scrublet", "count_like_matrix_in_X"]
+        tips:
+          - "--method scrublet: Python-native default path."
+          - "--threshold: Optional manual cutoff overriding Scrublet's automatic decision boundary."
+      doubletfinder:
+        priority: "expected_doublet_rate"
+        params: ["expected_doublet_rate"]
+        defaults: {expected_doublet_rate: 0.06}
+        requires: ["R_doubletfinder_stack"]
+        tips:
+          - "--method doubletfinder: R-backed path."
+          - "If the R runtime fails, the current wrapper falls back to `scdblfinder`."
+      scdblfinder:
+        priority: "expected_doublet_rate"
+        params: ["expected_doublet_rate"]
+        defaults: {expected_doublet_rate: 0.06}
+        requires: ["R_scdblfinder_stack"]
+        tips:
+          - "--method scdblfinder: Fast R/Bioconductor path with the cleanest current wrapper contract."
     legacy_aliases: [sc-doublet]
     saves_h5ad: true
+    requires_preprocessed: false
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "👥"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install:
@@ -31,232 +56,69 @@ metadata:
     trigger_keywords:
       - doublet detection
       - doublet removal
-      - Scrublet
-      - DoubletFinder
-      - scDblFinder
+      - scrublet
+      - doubletfinder
+      - scdblfinder
 ---
 
-# 👥 Single-Cell Doublet Detection
-
-Detect and remove doublets (multiple cells captured in one droplet) from scRNA-seq data. Essential QC step before clustering.
+# Single-Cell Doublet Detection
 
 ## Why This Exists
 
-- **Without it**: Doublets create artificial intermediate cell populations in clustering
-- **With it**: Automated detection with configurable thresholds and method comparison
-- **Why OmicsClaw**: Multiple methods with automatic expected rate calculation
+- Without it: artificial multiplets can form misleading intermediate clusters.
+- With it: cells are annotated with standardized doublet scores and labels before downstream analysis.
+- Why OmicsClaw: one wrapper normalizes three common entry paths into the same output columns.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **Scrublet** (Python): Simulation-based scoring via synthetic doublet comparison
-2. **DoubletFinder** (R): pANN-based classification with parameter sweep optimization
-3. **scDblFinder** (R, recommended): Fast gradient-boosted classifier, highest accuracy
+Implemented methods:
 
-## Workflow
+1. `scrublet` - Python-native default
+2. `doubletfinder` - R-backed path
+3. `scdblfinder` - R-backed path
 
-1. **Calculate Metrics**: Compute underlying simulation graphs of multiplets.
-2. **Score**: Attribute probabilistic doublet value to all single droplets.
-3. **Threshold**: Execute distribution breakpoint testing.
-4. **Filter**: Clear invalid multi-cells from AnnData.
-5. **Report**: Detail retained singles versus computed doublets.
+The wrapper writes classification columns but does not automatically drop doublets from the AnnData object.
+
+## Input Contract
+
+- Accepted input: `.h5ad`
+- Expected data state: count-like matrix in `X`
+- Useful upstream step: run this before final clustering and annotation
+
+## Workflow Summary
+
+1. Load AnnData or demo data.
+2. Run the selected detector.
+3. Write `doublet_score`, `predicted_doublet`, and `doublet_classification` into `obs`.
+4. Export figures, summary tables, and `processed.h5ad`.
+5. Record the chosen method and thresholds in `result.json`.
 
 ## CLI Reference
 
 ```bash
 python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
   --input <data.h5ad> --output <dir>
+
 python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
   --input <data.h5ad> --method scdblfinder --output <dir>
-python omicsclaw.py run sc-doublet-detection --demo
+
+python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
+  --input <data.h5ad> --method scrublet \
+  --expected-doublet-rate 0.08 --threshold 0.25 --output <dir>
 ```
 
-## Algorithm / Methodology
+## Output Contract
 
-### Scrublet (Python)
+Successful runs write:
 
-**Goal:** Detect and score doublets using simulated doublet profiles.
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `figures/doublet_histogram.png`
+- `figures/umap_doublets.png` when a UMAP is available or can be computed
+- `tables/summary.csv`
 
-```python
-import scrublet as scr
-import scanpy as sc
-import numpy as np
+## Current Limitations
 
-adata = sc.read_10x_mtx('filtered_feature_bc_matrix/')
-
-scrub = scr.Scrublet(adata.X, expected_doublet_rate=0.06)
-doublet_scores, predicted_doublets = scrub.scrub_doublets(
-    min_counts=2, min_cells=3,
-    min_gene_variability_pctl=85, n_prin_comps=30
-)
-
-adata.obs['doublet_score'] = doublet_scores
-adata.obs['predicted_doublet'] = predicted_doublets
-
-print(f'Detected {predicted_doublets.sum()} doublets ({100*predicted_doublets.mean():.1f}%)')
-```
-
-#### Visualize and Filter
-
-```python
-# Score histogram
-scrub.plot_histogram()
-
-# UMAP with doublet scores
-sc.pp.normalize_total(adata, target_sum=1e4)
-sc.pp.log1p(adata)
-sc.pp.highly_variable_genes(adata)
-sc.pp.pca(adata)
-sc.pp.neighbors(adata)
-sc.tl.umap(adata)
-sc.pl.umap(adata, color=['doublet_score', 'predicted_doublet'], save='_doublets.pdf')
-
-# Filter doublets
-adata_filtered = adata[~adata.obs['predicted_doublet']].copy()
-print(f'Kept {adata_filtered.n_obs} cells after doublet removal')
-```
-
-#### Manual Threshold
-
-```python
-threshold = 0.25
-predicted_doublets = doublet_scores > threshold
-adata.obs['predicted_doublet'] = predicted_doublets
-```
-
-### DoubletFinder (R)
-
-**Goal:** Detect doublets using pANN-based classification with optimal pK parameter.
-
-```r
-library(Seurat)
-library(DoubletFinder)
-
-seurat_obj <- NormalizeData(seurat_obj)
-seurat_obj <- FindVariableFeatures(seurat_obj)
-seurat_obj <- ScaleData(seurat_obj)
-seurat_obj <- RunPCA(seurat_obj)
-seurat_obj <- RunUMAP(seurat_obj, dims = 1:20)
-seurat_obj <- FindNeighbors(seurat_obj, dims = 1:20)
-seurat_obj <- FindClusters(seurat_obj, resolution = 0.5)
-
-# Parameter sweep for optimal pK
-sweep.res <- paramSweep(seurat_obj, PCs = 1:20, sct = FALSE)
-sweep.stats <- summarizeSweep(sweep.res, GT = FALSE)
-bcmvn <- find.pK(sweep.stats)
-optimal_pk <- as.numeric(as.character(bcmvn$pK[which.max(bcmvn$BCmetric)]))
-
-# Run DoubletFinder
-nExp_poi <- round(0.06 * nrow(seurat_obj@meta.data))
-seurat_obj <- doubletFinder(seurat_obj, PCs = 1:20, pN = 0.25, pK = optimal_pk,
-                             nExp = nExp_poi, reuse.pANN = FALSE, sct = FALSE)
-
-# Filter doublets
-df_col <- grep('DF.classifications', colnames(seurat_obj@meta.data), value = TRUE)
-seurat_obj <- subset(seurat_obj, cells = colnames(seurat_obj)[seurat_obj@meta.data[[df_col]] == 'Singlet'])
-```
-
-### scDblFinder (R — Recommended)
-
-**Goal:** Detect doublets using fast gradient-boosted classifier.
-
-```r
-library(scDblFinder)
-library(SingleCellExperiment)
-
-sce <- as.SingleCellExperiment(seurat_obj)
-sce <- scDblFinder(sce)
-
-table(sce$scDblFinder.class)
-
-# Transfer results back to Seurat
-seurat_obj$scDblFinder_class <- sce$scDblFinder.class
-seurat_obj$scDblFinder_score <- sce$scDblFinder.score
-seurat_obj <- subset(seurat_obj, subset = scDblFinder_class == 'singlet')
-```
-
-#### Multi-Sample Processing
-
-```r
-sce <- scDblFinder(sce, samples = 'sample_id')
-```
-
-## Expected Doublet Rates
-
-| Cells Loaded | Expected Rate |
-|--------------|---------------|
-| 1,000 | ~0.8% |
-| 2,000 | ~1.6% |
-| 5,000 | ~4.0% |
-| 10,000 | ~8.0% |
-| 15,000 | ~12% |
-
-Formula: `rate ≈ cells_loaded / 1000 * 0.008`
-
-## Method Comparison
-
-| Method | Speed | Accuracy | Language |
-|--------|-------|----------|----------|
-| Scrublet | Fast | Good | Python |
-| DoubletFinder | Slow | Good | R |
-| scDblFinder | Fast | Excellent | R |
-
-## Heterotypic vs Homotypic Doublets
-
-- **Heterotypic**: Two different cell types — easier to detect (intermediate expression)
-- **Homotypic**: Same cell type — harder to detect (may have higher total counts)
-
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--method` | `scrublet` | scrublet, doubletfinder, scdblfinder |
-| `--expected-doublet-rate` | `0.06` | Expected doublet rate |
-| `--threshold` | `auto` | Doublet score threshold |
-
-## Example Queries
-
-- "Perform doublet detection with scDblFinder"
-- "Filter multiplets from this H5AD via Scrublet"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── processed.h5ad
-├── figures/
-│   └── summary_plot.png
-├── tables/
-│   └── metrics.csv
-└── reproducibility/
-    ├── commands.sh
-    ├── requirements.txt
-    └── checksums.sha256
-```
-
-## Dependencies
-
-**Required**: scanpy, numpy
-**Optional**: scrublet, R + packages `DoubletFinder`, `scDblFinder`, `Seurat`, and `SingleCellExperiment` (executed via native R scripts)
-
-## Citations
-
-- [Scrublet](https://doi.org/10.1016/j.cels.2018.11.005) — Wolock et al., Cell Systems 2019
-- [DoubletFinder](https://doi.org/10.1016/j.cels.2019.03.003) — McGinnis et al., Cell Systems 2019
-- [scDblFinder](https://doi.org/10.12688/f1000research.73600.2) — Germain et al., F1000Research 2022
-
-## Safety
-
-- **Local-first**: Strict offline processing without external upload.
-- **Disclaimer**: Requires OmicsClaw reporting structures and disclaimers.
-- **Audit trail**: Hyperparameters and operational flow states are logged fully.
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Automatically invoked dynamically based on tool metadata and user intent matching.
-
-**Chaining partners**:
-- `sc-preprocess` — QC after doublet removal
-- `sc-integrate` — Integration after cleaning
+- The wrapper now writes README and notebook-style reproducibility artifacts when notebook export dependencies are available.
+- `doubletfinder` can fall back to `scdblfinder` at runtime if the R path fails.

--- a/skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py
+++ b/skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import argparse
 import logging
+import tempfile
 import sys
 from pathlib import Path
+import h5py
 
 import matplotlib
 matplotlib.use("Agg")
@@ -20,17 +22,74 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from omicsclaw.common.checksums import sha256_file
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from skills.singlecell._lib import io as sc_io
 from skills.singlecell._lib.adata_utils import store_analysis_metadata
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
 
 from skills.singlecell._lib.viz_utils import save_figure
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "sc-doublet"
+SKILL_NAME = "sc-doublet-detection"
 SKILL_VERSION = "0.4.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Doublet detection and scoring for single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "scrublet"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Doublet detection and scoring for single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "scrublet"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 METHOD_REGISTRY: dict[str, MethodConfig] = {
     "scrublet": MethodConfig(
@@ -51,11 +110,88 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
 }
 
 
+def _matrix_looks_count_like(matrix) -> bool:
+    sample = matrix
+    if hasattr(sample, "toarray"):
+        sample = sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])].toarray()
+    else:
+        sample = np.asarray(sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])])
+    if sample.size == 0:
+        return True
+    if np.nanmin(sample) < 0:
+        return False
+    frac_integer = float(np.mean(np.isclose(sample, np.round(sample), atol=1e-6)))
+    return frac_integer > 0.98
+
+
+def _get_count_like_matrix(adata):
+    if "counts" in adata.layers:
+        return adata.layers["counts"], "layers.counts"
+    if _matrix_looks_count_like(adata.X):
+        return adata.X, "adata.X"
+    raise ValueError("Doublet detection requires raw count-like input; provide adata.layers['counts'] or count-like adata.X")
+
+
+def _build_count_like_export_adata(adata):
+    matrix, source = _get_count_like_matrix(adata)
+    export = sc.AnnData(X=matrix.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+    export.obs_names = adata.obs_names.copy()
+    export.var_names = adata.var_names.copy()
+    return export, source
+
+
+def _run_r_doublet_script(adata, *, script_name: str, output_csv: str, expected_doublet_rate: float, required_packages: list[str]):
+    validate_r_environment(required_r_packages=required_packages)
+    scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
+    runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
+    export, source = _build_count_like_export_adata(adata)
+    with tempfile.TemporaryDirectory(prefix="omicsclaw_doublet_r_") as tmpdir:
+        tmpdir = Path(tmpdir)
+        input_h5ad = tmpdir / "input.h5ad"
+        output_dir = tmpdir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        export.write_h5ad(input_h5ad)
+        with h5py.File(input_h5ad, "a") as handle:
+            if "layers" in handle and len(handle["layers"].keys()) == 0:
+                del handle["layers"]
+        runner.run_script(
+            script_name,
+            args=[str(input_h5ad), str(output_dir), str(expected_doublet_rate)],
+            expected_outputs=[output_csv],
+            output_dir=output_dir,
+        )
+        df = pd.read_csv(output_dir / output_csv, index_col=0)
+    return df, source
+
+
+def run_doubletfinder(adata, expected_doublet_rate=0.06):
+    df, _ = _run_r_doublet_script(
+        adata,
+        script_name="sc_doubletfinder.R",
+        output_csv="doubletfinder_results.csv",
+        expected_doublet_rate=expected_doublet_rate,
+        required_packages=["Seurat", "DoubletFinder", "SingleCellExperiment", "zellkonverter"],
+    )
+    return df
+
+
+def run_scdblfinder(adata, expected_doublet_rate=0.06):
+    df, _ = _run_r_doublet_script(
+        adata,
+        script_name="sc_scdblfinder.R",
+        output_csv="scdblfinder_results.csv",
+        expected_doublet_rate=expected_doublet_rate,
+        required_packages=["scDblFinder", "SingleCellExperiment", "zellkonverter"],
+    )
+    return df
+
+
 def detect_doublets_scrublet(adata, expected_doublet_rate=0.06, threshold=None):
     import scrublet as scr
 
-    logger.info("Running Scrublet (expected_rate=%s)", expected_doublet_rate)
-    scrub = scr.Scrublet(adata.X, expected_doublet_rate=expected_doublet_rate)
+    counts_matrix, source = _get_count_like_matrix(adata)
+    logger.info("Running Scrublet (expected_rate=%s, source=%s)", expected_doublet_rate, source)
+    scrub = scr.Scrublet(counts_matrix, expected_doublet_rate=expected_doublet_rate)
     doublet_scores, predicted_doublets = scrub.scrub_doublets(
         min_counts=2, min_cells=3, min_gene_variability_pctl=85, n_prin_comps=30
     )
@@ -73,6 +209,7 @@ def detect_doublets_scrublet(adata, expected_doublet_rate=0.06, threshold=None):
         "n_doublets": n_doublets,
         "doublet_rate": float(n_doublets / adata.n_obs),
         "expected_rate": expected_doublet_rate,
+        "expression_source": source,
     }
 
 
@@ -190,6 +327,10 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
     for k, v in params.items():
         cmd += f" --{k.replace('_', '-')} {v}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
 
 def main():
@@ -206,12 +347,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-        if demo_path.exists():
-            adata = sc.read_h5ad(demo_path)
-        else:
-            logger.warning("Local demo data not found, downloading from scanpy")
-            adata = sc.datasets.pbmc3k()
+        adata = sc_io.load_repo_demo_data("pbmc3k_raw")[0]
         input_file = None
     else:
         if not args.input_path:
@@ -231,13 +367,20 @@ def main():
     generate_figures(adata, output_dir)
     write_report(output_dir, summary, input_file, params)
 
+    store_analysis_metadata(adata, SKILL_NAME, method, params)
     output_h5ad = output_dir / "processed.h5ad"
     adata.write_h5ad(output_h5ad)
     logger.info("Saved to %s", output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
-    store_analysis_metadata(adata, SKILL_NAME, method, params)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     print(f"Success: {SKILL_NAME}")
     print(f"  Output: {output_dir}")

--- a/skills/singlecell/scrna/sc-doublet-detection/tests/test_sc_doublet.py
+++ b/skills/singlecell/scrna/sc-doublet-detection/tests/test_sc_doublet.py
@@ -55,5 +55,5 @@ def test_demo_result_json(tmp_output):
         cwd=str(SKILL_SCRIPT.parent),
     )
     data = json.loads((tmp_output / "result.json").read_text())
-    assert data["skill"] == "sc-doublet"
+    assert data["skill"] == "sc-doublet-detection"
     assert "summary" in data

--- a/skills/singlecell/scrna/sc-filter/SKILL.md
+++ b/skills/singlecell/scrna/sc-filter/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: sc-filter
 description: >-
-  Filter cells and genes based on QC metrics. Supports custom thresholds
-  and tissue-specific presets.
-version: 0.2.0
+  Filter cells and genes from single-cell RNA-seq AnnData objects using
+  QC-derived thresholds or tissue presets. This wrapper removes low-quality
+  cells/genes but does not normalize, cluster, or annotate the dataset.
+version: 0.3.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, filter, QC, preprocessing]
+tags: [singlecell, filter, qc, preprocessing]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -18,13 +19,23 @@ metadata:
       - "--min-counts"
       - "--min-genes"
       - "--tissue"
+    param_hints:
+      threshold_filtering:
+        priority: "tissue -> min_genes/max_mt_percent -> min_cells -> count caps"
+        params: ["tissue", "min_genes", "max_genes", "min_counts", "max_counts", "max_mt_percent", "min_cells"]
+        defaults: {min_genes: 200, max_mt_percent: 20.0, min_cells: 3}
+        requires: ["qc_metrics_in_obs_or_count_like_matrix_in_X", "scanpy"]
+        tips:
+          - "--tissue: Wrapper-level preset that overrides the default QC thresholds with OmicsClaw tissue heuristics."
+          - "--min-genes / --max-mt-percent: Main cell-retention controls."
+          - "--min-cells: Gene-level retention threshold applied after cell filtering."
     saves_h5ad: true
+    requires_preprocessed: false
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🔍"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install: []
@@ -33,108 +44,88 @@ metadata:
       - cell filtering
       - gene filtering
       - remove low quality
-      - QC filtering
+      - qc filtering
       - tissue-specific thresholds
 ---
 
-# 🔍 Single-Cell Filter
-
-Filter cells and genes based on QC metrics with support for tissue-specific thresholds.
+# Single-Cell Filter
 
 ## Why This Exists
 
-- **Without it**: Low-quality cells and genes contaminate downstream analysis
-- **With it**: Automated filtering with configurable or tissue-specific thresholds
-- **Why OmicsClaw**: Tissue-specific presets (PBMC, brain, tumor, etc.)
+- Without it: downstream clustering and DE are distorted by low-quality droplets and low-information genes.
+- With it: one run applies explicit QC cutoffs and records how many cells/genes were removed.
+- Why OmicsClaw: tissue presets and a stable output contract make filtering easier to reproduce.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **Cell filtering**: Remove cells by gene counts, UMI counts, MT%
-2. **Gene filtering**: Remove genes expressed in too few cells
-3. **Tissue presets**: Pre-configured thresholds for common tissues
-4. **Before/after comparison**: Visualize impact of filtering
+This skill currently exposes one public workflow: `threshold_filtering`.
 
-## Workflow
+This skill does:
 
-1. **Load QC metrics**: Calculate or load existing QC metrics
-2. **Apply filters**: Filter by customizable thresholds
-3. **Filter genes**: Remove low-expression genes
-4. **Report**: Generate summary statistics and comparison plots
+1. use existing QC metrics or compute the ones needed for thresholding
+2. filter cells by genes, counts, and mitochondrial percentage
+3. filter genes by minimum detected-cell count
+4. export filtered AnnData, figures, tables, and a report
+
+This skill does not:
+
+1. normalize counts
+2. run HVG, PCA, UMAP, or clustering
+3. remove doublets or ambient RNA
+
+## Input Contract
+
+- Accepted input: `.h5ad`
+- Expected data state: raw-count-like or QC-annotated AnnData
+- Important columns when present: `n_genes_by_counts`, `total_counts`, `pct_counts_mt`
+- If QC metrics are missing, the wrapper computes the minimum needed metrics before filtering
+
+## Workflow Summary
+
+1. Load AnnData and inspect available QC columns.
+2. Apply optional tissue preset.
+3. Filter cells by configured thresholds.
+4. Filter genes by `min_cells`.
+5. Write `filtered.h5ad`, figures, `tables/filter_stats.csv`, `report.md`, and `result.json`.
 
 ## CLI Reference
 
 ```bash
-# Basic usage
-python skills/singlecell/scrna/sc-filter/sc_filter.py --input <data.h5ad> --output <dir>
+python skills/singlecell/scrna/sc-filter/sc_filter.py \
+  --input <data.h5ad> --output <dir>
 
-# With tissue-specific thresholds
-python skills/singlecell/scrna/sc-filter/sc_filter.py --input <data.h5ad> --output <dir> --tissue pbmc
+python skills/singlecell/scrna/sc-filter/sc_filter.py \
+  --input <data.h5ad> --tissue pbmc --output <dir>
 
-# Custom thresholds
-python skills/singlecell/scrna/sc-filter/sc_filter.py --input <data.h5ad> --output <dir> \
-  --min-genes 200 --max-genes 6000 --max-mt-percent 15
-
-# Demo mode
-python omicsclaw.py run sc-filter --demo
+python skills/singlecell/scrna/sc-filter/sc_filter.py \
+  --input <data.h5ad> --min-genes 200 --max-genes 6000 \
+  --max-mt-percent 15 --min-cells 3 --output <dir>
 ```
 
-## Tissue-Specific Thresholds
+## Public Parameters
 
-| Tissue | Min Genes | Max Genes | Max MT% |
-|--------|-----------|-----------|---------|
-| PBMC | 200 | 6000 | 5% |
-| Brain | 500 | 8000 | 10% |
-| Tumor | 200 | 8000 | 20% |
-| Heart | 300 | 7000 | 15% |
-| Liver | 300 | 7000 | 15% |
-| Kidney | 300 | 7000 | 15% |
-| Lung | 200 | 7000 | 15% |
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--min-genes` | `200` | Minimum detected genes per retained cell |
+| `--max-genes` | none | Optional upper gene-count cap |
+| `--min-counts` | none | Optional lower UMI-count cap |
+| `--max-counts` | none | Optional upper UMI-count cap |
+| `--max-mt-percent` | `20.0` | Maximum mitochondrial percentage |
+| `--min-cells` | `3` | Minimum number of cells expressing a retained gene |
+| `--tissue` | none | OmicsClaw preset thresholds such as `pbmc`, `brain`, or `tumor` |
 
-## Parameters
+## Output Contract
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--min-genes` | 200 | Minimum genes per cell |
-| `--max-genes` | None | Maximum genes per cell |
-| `--min-counts` | None | Minimum UMIs per cell |
-| `--max-counts` | None | Maximum UMIs per cell |
-| `--max-mt-percent` | 20.0 | Maximum mitochondrial % |
-| `--min-cells` | 3 | Minimum cells per gene |
-| `--tissue` | None | Use tissue-specific thresholds |
+Successful runs write:
 
-## Example Queries
+- `filtered.h5ad`
+- `report.md`
+- `result.json`
+- `figures/`
+- `tables/filter_stats.csv`
+- `reproducibility/commands.sh`
 
-- "Filter cells using PBMC thresholds"
-- "Remove low-quality cells with MT% > 15"
-- "Filter genes expressed in < 3 cells"
+## Current Limitations
 
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── filtered.h5ad
-├── figures/
-│   ├── filter_comparison.png
-│   └── filter_summary.png
-├── tables/
-│   └── filter_stats.csv
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
-
-## Dependencies
-
-**Required**: scanpy, numpy, pandas
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Query mentions "filter cells", "filter genes", "remove cells"
-- Query mentions tissue-specific QC thresholds
-
-**Chaining partners**:
-- `sc-qc` — Calculate QC metrics before filtering
-- `sc-preprocessing` — Continue with normalization after filtering
+- This wrapper now writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.
+- Threshold presets are OmicsClaw wrapper defaults, not upstream standard recommendations for every tissue.

--- a/skills/singlecell/scrna/sc-filter/sc_filter.py
+++ b/skills/singlecell/scrna/sc-filter/sc_filter.py
@@ -31,7 +31,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
 from omicsclaw.common.checksums import sha256_file
 from skills.singlecell._lib.viz_utils import save_figure
 from skills.singlecell._lib import io as sc_io
@@ -40,8 +46,56 @@ from skills.singlecell._lib import qc as sc_qc_utils
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-filter"
+SKILL_NAME = "sc-filter"
 SKILL_VERSION = "0.2.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell and gene filtering based on single-cell QC metrics.",
+            result_payload=result_payload,
+            preferred_method="threshold_filtering",
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Cell and gene filtering based on single-cell QC metrics.",
+            result_payload=result_payload,
+            preferred_method="threshold_filtering",
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 
 def filter_cells_and_genes(
@@ -286,15 +340,17 @@ def write_filter_report(output_dir: Path, summary: dict, params: dict, input_fil
 
 def generate_demo_data():
     """Generate demo data with QC metrics."""
-    import scanpy as sc
-
     logger.info("Generating demo data...")
-
-    # Try scanpy's built-in dataset
     try:
-        adata = sc.datasets.pbmc3k()
-        logger.info(f"Loaded pbmc3k: {adata.n_obs} cells x {adata.n_vars} genes")
+        adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+        logger.info(
+            "Loaded demo dataset: %s (%d cells x %d genes)",
+            demo_path or "scanpy-pbmc3k",
+            adata.n_obs,
+            adata.n_vars,
+        )
     except Exception:
+        import scanpy as sc
         # Synthetic fallback
         np.random.seed(42)
         n_cells, n_genes = 500, 1000
@@ -394,6 +450,8 @@ def main():
 
     # Save filtered data
     output_h5ad = output_dir / "filtered.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata_filtered, SKILL_NAME, "threshold_filtering", params)
     adata_filtered.write_h5ad(output_h5ad)
     logger.info(f"Saved: {output_h5ad}")
 
@@ -409,10 +467,21 @@ def main():
         cmd += f" --tissue {args.tissue}"
 
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
     # Result.json
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     # Summary
     print(f"\n{'='*60}")

--- a/skills/singlecell/scrna/sc-grn/SKILL.md
+++ b/skills/singlecell/scrna/sc-grn/SKILL.md
@@ -1,8 +1,13 @@
 ---
 name: sc-grn
 description: >-
-  Gene regulatory network inference using pySCENIC (GRNBoost2, cisTarget, AUCell)
-version: 0.1.0
+  Infer gene regulatory networks from scRNA-seq using the pySCENIC workflow:
+  GRNBoost2 for adjacency inference, cisTarget-style motif pruning, and AUCell
+  regulon scoring.
+version: 0.2.0
+author: OmicsClaw
+license: MIT
+tags: [singlecell, grn, pyscenic, regulon, transcription-factor]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -13,6 +18,15 @@ metadata:
       - "--n-top-targets"
       - "--seed"
       - "--tf-list"
+    param_hints:
+      pyscenic_workflow:
+        priority: "tf_list -> db -> motif -> n_top_targets -> n_jobs"
+        params: ["tf_list", "db", "motif", "n_top_targets", "n_jobs", "seed"]
+        defaults: {n_top_targets: 50, n_jobs: 4, seed: 42}
+        requires: ["preprocessed_anndata", "pyscenic", "arboreto", "TF_list", "cisTarget_database", "motif_annotations"]
+        tips:
+          - "--tf-list, --db, and --motif are the core external resources for a full pySCENIC run."
+          - "--n-top-targets: Wrapper-level export cap for the top targets retained per regulon."
     saves_h5ad: true
     requires_preprocessed: true
     trigger_keywords:
@@ -25,170 +39,62 @@ metadata:
       - grnboost
 ---
 
-# sc-grn — Gene Regulatory Network Inference
+# Single-Cell GRN
 
-## Purpose
+## Why This Exists
 
-Infer gene regulatory networks from single-cell RNA-seq data using **pySCENIC**:
+- Without it: regulon analysis requires several external resources and multi-step orchestration.
+- With it: pySCENIC-style GRN outputs are standardized into one wrapper contract.
+- Why OmicsClaw: tables, figures, and AnnData outputs are bundled together.
 
-- **GRNBoost2** — co-expression network inference between TFs and target genes
-- **cisTarget** — motif enrichment and pruning to identify direct targets
-- **AUCell** — regulon activity scoring per cell
+## Scope Boundary
 
-Identify master regulators and their target genes driving cell states.
+This skill currently exposes one public workflow: `pyscenic_workflow`.
 
-## When to Use
+That workflow covers:
 
-- Identifying master regulators of cell types/states
-- Understanding transcriptional programs
-- Finding candidate TFs for perturbation experiments
-- Linking TFs to phenotype
+1. GRNBoost2 adjacency inference
+2. motif-based pruning
+3. AUCell regulon scoring
 
-## Requirements
+## Input Contract
 
-### Input Data
-- AnnData with preprocessed gene expression
-- Standard preprocessing (normalize, log1p, HVG)
+- Accepted input: preprocessed `.h5ad`
+- Required external resources: TF list, cisTarget database files, and motif annotations
 
-### Python Dependencies
-- `arboreto` — GRNBoost2 implementation
-- `pyscenic` — cisTarget + AUCell
+## Workflow Summary
 
-### External Databases (Required for Full Analysis)
+1. Load preprocessed expression data.
+2. Run adjacency inference.
+3. Prune candidate targets with motif evidence.
+4. Score regulon activity per cell.
+5. Export `adata_with_grn.h5ad`, tables, figures, `report.md`, and `result.json`.
 
-| Database | Description | Source |
-|----------|-------------|--------|
-| TF list | List of TF gene symbols | [pySCENIC resources](https://github.com/aertslab/pySCENIC/tree/master/resources) |
-| cisTarget DB | Motif-to-gene mappings | [cisTarget DBs](https://resources.aertslab.org/cistarget/) |
-| Motif annotations | TF-to-motif mappings | [motif2TF](https://resources.aertslab.org/cistarget/motif2tf/) |
-
-#### Example Database Files
+## CLI Reference
 
 ```bash
-# Download for human (hg38)
-wget https://raw.githubusercontent.com/aertslab/pySCENIC/master/resources/hs_hgnc_tfs.txt
-wget https://resources.aertslab.org/cistarget/databases/homo_sapiens/hg38/refseq_r80/mc9nr/gene_based/hg38__refseq_r80__mc9nr_gg6_500bp_upstream.feather
-wget https://resources.aertslab.org/cistarget/motif2tf/motifs-v9-nr.hgnc-m0.001-o0.0.tbl
-```
-
-## Usage
-
-### CLI
-
-```bash
-# Full workflow with all databases
 python omicsclaw.py run sc-grn \
-    --input preprocessed.h5ad \
-    --output results/ \
-    --tf-list hs_hgnc_tfs.txt \
-    --db "hg38*.feather" \
-    --motif motifs-v9-nr.hgnc-m0.001-o0.0.tbl
-
-# Demo mode (GRNBoost2 only, no external DBs)
-python omicsclaw.py run sc-grn --demo --output /tmp/grn_demo/
+  --input <processed.h5ad> \
+  --tf-list <tfs.txt> \
+  --db '<db_glob>' \
+  --motif <motif.tbl> \
+  --output <dir>
 ```
 
-### Parameters
+## Output Contract
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--input` | required | Input AnnData file (.h5ad) |
-| `--output` | required | Output directory |
-| `--demo` | false | Run demo mode (GRNBoost2 only) |
-| `--tf-list` | required | TF list file (one per line) |
-| `--db` | required | Glob pattern for cisTarget databases |
-| `--motif` | required | Motif annotations file |
-| `--n-top-targets` | 50 | Max targets per regulon |
-| `--n-jobs` | 4 | Parallel jobs |
-| `--seed` | 42 | Random seed |
+Successful runs write:
 
-## Output Structure
+- `adata_with_grn.h5ad`
+- `report.md`
+- `result.json`
+- `tables/grn_adjacencies.csv`
+- `tables/grn_regulons.csv`
+- `tables/grn_regulon_targets.csv`
+- `tables/grn_auc_matrix.csv`
+- `figures/`
 
-```
-output_dir/
-├── adata_with_grn.h5ad           # AnnData with regulon activity scores
-├── report.md                      # Analysis report
-├── result.json                    # Machine-readable results
-├── figures/
-│   ├── regulon_activity_umap.png  # Top regulons on UMAP
-│   ├── regulon_heatmap.png        # Regulon activity heatmap
-│   └── regulon_network.png        # TF-target network diagram
-├── tables/
-│   ├── grn_adjacencies.csv        # All TF-target adjacencies
-│   ├── grn_regulons.csv           # Regulon summary
-│   ├── grn_regulon_targets.csv    # TF-target pairs
-│   └── grn_auc_matrix.csv         # AUCell activity scores
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
+## Current Limitations
 
-## Methods
-
-### GRNBoost2 (Co-expression)
-
-Gradient boosting-based method that learns feature importance between TF expression
-and target gene expression across cells.
-
-- **Input**: Expression matrix + TF list
-- **Output**: TF-target adjacencies with importance scores
-- **Limitation**: Co-expression ≠ direct regulation
-
-### cisTarget (Motif Pruning)
-
-Prunes co-expression network to direct targets using motif enrichment:
-1. For each TF, get top co-expressed targets
-2. Check if targets share enriched motifs
-3. Keep only targets with the TF's motif in regulatory regions
-
-- **Input**: Adjacencies + cisTarget DB + motif annotations
-- **Output**: Pruned regulons with NES scores
-
-### AUCell (Activity Scoring)
-
-Calculates regulon activity per cell by computing area under the recovery curve
-of gene expression rankings.
-
-- **Input**: Expression matrix + regulons
-- **Output**: AUC score matrix (cells × regulons)
-
-## Interpretation
-
-1. **Regulon activity UMAP**: Shows which TFs are active in which cell types
-2. **Heatmap**: Cluster-level regulon activity patterns
-3. **Network diagram**: TF-target relationships
-4. **High NES**: Strong motif enrichment → likely direct targets
-
-## Tips
-
-- Use appropriate species-specific databases
-- Filter low-quality cells first with `sc-qc` and `sc-filter`
-- Combine with `sc-cell-annotation` to link regulons to cell types
-- Run demo mode first to test installation
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| arboreto not installed | `pip install arboreto` |
-| GRNBoost2 fails (dask error) | Auto-fallback to correlation-based GRN |
-| Database files missing | Download from resources.aertslab.org |
-| Slow GRNBoost2 | Reduce n_jobs if memory-limited |
-| Too few regulons | Check TF list matches your species |
-
-### Known Issue: dask/arboreto Compatibility
-
-arboreto 0.1.6 (2020) may be incompatible with dask 2024.x due to API changes.
-When GRNBoost2 fails, the skill automatically falls back to **correlation-based GRN inference** (Spearman correlation).
-
-For full pySCENIC support with GRNBoost2, you may need:
-```bash
-pip install "dask==2021.11.2" "distributed==2021.11.2"
-```
-However, this may conflict with other packages like squidpy or spatialdata.
-
-## References
-
-- Aibar et al. (2017) SCENIC: Single-cell regulatory network inference and clustering
-- Van de Sande et al. (2020) pySCENIC
-- Moerman et al. (2019) GRNBoost2
+- This skill depends on external pySCENIC resources and does not download them automatically.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-grn/sc_grn.py
+++ b/skills/singlecell/scrna/sc-grn/sc_grn.py
@@ -39,7 +39,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
 from omicsclaw.common.checksums import sha256_file
 from skills.singlecell._lib.viz_utils import save_figure
 from skills.singlecell._lib import io as sc_io
@@ -48,8 +54,56 @@ from skills.singlecell._lib import grn as sc_grn_utils
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-grn"
+SKILL_NAME = "sc-grn"
 SKILL_VERSION = "0.1.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Gene regulatory network inference with pySCENIC-style workflow.",
+            result_payload=result_payload,
+            preferred_method="pyscenic",
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Gene regulatory network inference with pySCENIC-style workflow.",
+            result_payload=result_payload,
+            preferred_method="pyscenic",
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 # Database download instructions
 DB_DOWNLOAD_INSTRUCTIONS = """
@@ -499,6 +553,8 @@ def main():
 
     # Save data
     output_h5ad = output_dir / "adata_with_grn.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata, SKILL_NAME, "pyscenic", params)
     adata.write_h5ad(output_h5ad)
     logger.info(f"Saved: {output_h5ad}")
 
@@ -516,10 +572,21 @@ def main():
     if args.motif_annotations:
         cmd += f" --motif {args.motif_annotations}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["anndata", "numpy", "pandas", "matplotlib", "arboreto", "pyscenic"],
+    )
 
     # Result.json
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     # Summary
     print(f"\n{'='*60}")

--- a/skills/singlecell/scrna/sc-markers/SKILL.md
+++ b/skills/singlecell/scrna/sc-markers/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: sc-markers
 description: >-
-  Find marker genes for cell clusters using Wilcoxon, t-test, or logistic
-  regression. Essential for cell type annotation.
-version: 0.2.0
+  Find cluster marker genes from single-cell data using Scanpy-backed Wilcoxon,
+  t-test, or logistic-regression ranking.
+version: 0.4.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, markers, differential expression, annotation]
+tags: [singlecell, markers, differential-expression, annotation]
 metadata:
   omicsclaw:
     domain: singlecell
@@ -15,14 +15,35 @@ metadata:
       - "--method"
       - "--n-genes"
       - "--n-top"
+    param_hints:
+      wilcoxon:
+        priority: "groupby -> n_genes -> n_top"
+        params: ["groupby", "n_genes", "n_top"]
+        defaults: {groupby: "leiden", n_top: 10}
+        requires: ["cluster_labels_in_obs", "scanpy"]
+        tips:
+          - "--method wilcoxon: Default non-parametric marker ranking path."
+      t-test:
+        priority: "groupby -> n_genes -> n_top"
+        params: ["groupby", "n_genes", "n_top"]
+        defaults: {groupby: "leiden", n_top: 10}
+        requires: ["cluster_labels_in_obs", "scanpy"]
+        tips:
+          - "--method t-test: Parametric alternative for well-behaved inputs."
+      logreg:
+        priority: "groupby -> n_genes -> n_top"
+        params: ["groupby", "n_genes", "n_top"]
+        defaults: {groupby: "leiden", n_top: 10}
+        requires: ["cluster_labels_in_obs", "scanpy"]
+        tips:
+          - "--method logreg: Classification-style ranking path."
     saves_h5ad: true
     requires_preprocessed: true
     requires:
-      bins:
-        - python3
+      bins: [python3]
       env: []
       config: []
-    emoji: "🎯"
+    emoji: "S"
     homepage: https://github.com/OmicsClaw/OmicsClaw
     os: [macos, linux]
     install: []
@@ -34,126 +55,64 @@ metadata:
       - cell type markers
 ---
 
-# 🎯 Single-Cell Marker Genes
-
-Identify marker genes that distinguish cell clusters.
+# Single-Cell Markers
 
 ## Why This Exists
 
-- **Without it**: Manual inspection of cluster-specific genes
-- **With it**: Automated marker identification with statistical testing
-- **Why OmicsClaw**: Multiple methods with comprehensive visualizations
+- Without it: users manually inspect cluster genes without a stable statistical contract.
+- With it: marker ranking, top tables, and standard plots are generated in one run.
+- Why OmicsClaw: the wrapper keeps cluster-level marker discovery separate from broader DE workflows.
 
-## Core Capabilities
+## Scope Boundary
 
-1. **Wilcoxon test**: Non-parametric rank-sum test (default)
-2. **t-test**: Parametric differential expression
-3. **Logistic regression**: Classification-based markers
-4. **Visualization**: Heatmaps, dot plots, volcano plots
+Implemented methods:
 
-## Workflow
+1. `wilcoxon`
+2. `t-test`
+3. `logreg`
 
-1. **Load clustered data**: Input should have cluster assignments
-2. **Find markers**: Run statistical test per cluster
-3. **Filter results**: By fold change, p-value, expression fraction
-4. **Visualize**: Generate summary figures and tables
+This skill is cluster-marker focused; for condition-aware DE use `sc-de`.
+
+## Input Contract
+
+- Accepted input: preprocessed `.h5ad`
+- Required metadata: a grouping column such as `leiden`
+
+## Workflow Summary
+
+1. Load clustered AnnData.
+2. Rank genes for each cluster with the selected method.
+3. Export full and top marker tables.
+4. Generate heatmap, dotplot, and volcano-style summaries.
+5. Save `adata_with_markers.h5ad`, `report.md`, and `result.json`.
 
 ## CLI Reference
 
 ```bash
-# Basic usage
-python skills/singlecell/scrna/sc-markers/sc_markers.py --input <data.h5ad> --output <dir> --groupby leiden
+python skills/singlecell/scrna/sc-markers/sc_markers.py \
+  --input <data.h5ad> --groupby leiden --output <dir>
 
-# With specific method
-python skills/singlecell/scrna/sc-markers/sc_markers.py --input <data.h5ad> --output <dir> \
-  --groupby leiden --method t-test
+python skills/singlecell/scrna/sc-markers/sc_markers.py \
+  --input <data.h5ad> --groupby leiden --method t-test --output <dir>
 
-# Limit number of genes
-python skills/singlecell/scrna/sc-markers/sc_markers.py --input <data.h5ad> --output <dir> \
-  --groupby leiden --n-genes 100
-
-# Demo mode
-python omicsclaw.py run sc-markers --demo
+python skills/singlecell/scrna/sc-markers/sc_markers.py \
+  --input <data.h5ad> --groupby leiden --n-genes 100 --n-top 10 --output <dir>
 ```
 
-## Methods
+## Output Contract
 
-### Wilcoxon (Default)
-- Non-parametric Mann-Whitney U test
-- Robust to outliers
-- Best for most use cases
+Successful runs write:
 
-### t-test
-- Parametric test
-- Assumes normal distribution
-- More sensitive to fold changes
+- `adata_with_markers.h5ad`
+- `report.md`
+- `result.json`
+- `figures/markers_heatmap.png`
+- `figures/markers_dotplot.png`
+- `figures/volcano_plots.png`
+- `tables/cluster_markers_all.csv`
+- `tables/cluster_markers_top10.csv`
 
-### Logistic Regression
-- Multiclass classification
-- Good for overlapping populations
-- Computationally intensive
+## Current Limitations
 
-## Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--groupby` | leiden | Column with cluster assignments |
-| `--method` | wilcoxon | wilcoxon, t-test, logreg |
-| `--n-genes` | None | Genes per cluster (None = all) |
-| `--n-top` | 10 | Top markers for visualization |
-
-## Example Queries
-
-- "Find marker genes for my clusters"
-- "Identify differentially expressed genes by cluster"
-- "What markers define each cell type?"
-
-## Output Structure
-
-```
-output_dir/
-├── report.md
-├── result.json
-├── adata_with_markers.h5ad
-├── figures/
-│   ├── markers_heatmap.png
-│   ├── markers_dotplot.png
-│   └── volcano_plots.png
-├── tables/
-│   ├── cluster_markers_all.csv
-│   └── cluster_markers_top10.csv
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
-
-## Marker Table Columns
-
-| Column | Description |
-|--------|-------------|
-| group | Cluster ID |
-| names | Gene name |
-| scores | Test statistic score |
-| pvals | Raw p-value |
-| pvals_adj | Adjusted p-value (FDR) |
-| logfoldchanges | Log2 fold change |
-
-## Interpretation
-
-- **LogFC > 1**: Gene upregulated in this cluster
-- **pvals_adj < 0.05**: Statistically significant
-- **scores**: Higher = more cluster-specific
-
-## Dependencies
-
-**Required**: scanpy, numpy, pandas, seaborn
-
-## Integration with Orchestrator
-
-**Trigger conditions**:
-- Query mentions "marker genes", "find markers", "differential expression"
-- Query asks about cluster-specific genes
-
-**Chaining partners**:
-- `sc-preprocessing` — Requires clustered data
-- `sc-cell-annotation` — Use markers for annotation
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.
+- Marker ranking is cluster-centric and does not replace replicate-aware DE analysis.

--- a/skills/singlecell/scrna/sc-markers/sc_markers.py
+++ b/skills/singlecell/scrna/sc-markers/sc_markers.py
@@ -31,7 +31,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
 from omicsclaw.common.checksums import sha256_file
 from skills.singlecell._lib.method_config import (
     MethodConfig,
@@ -44,8 +50,56 @@ from skills.singlecell._lib import markers as sc_markers_utils
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-markers"
+SKILL_NAME = "sc-markers"
 SKILL_VERSION = "0.3.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Marker gene discovery for clustered single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "wilcoxon"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Marker gene discovery for clustered single-cell RNA-seq data.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "wilcoxon"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 # ---------------------------------------------------------------------------
 # Method registry
@@ -221,7 +275,8 @@ def generate_demo_data():
     logger.info("Generating demo data with clusters...")
 
     try:
-        adata = sc.datasets.pbmc3k()
+        adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+        logger.info("Loaded demo dataset: %s", demo_path or "scanpy-pbmc3k")
         # Quick preprocessing
         sc.pp.filter_cells(adata, min_genes=200)
         sc.pp.filter_genes(adata, min_cells=3)
@@ -245,7 +300,7 @@ def generate_demo_data():
         logger.info(f"Generated: {adata.n_obs} cells x {adata.n_vars} genes, {adata.obs['leiden'].nunique()} clusters")
     except Exception as e:
         # Synthetic fallback
-        logger.warning(f"Failed to load pbmc3k: {e}. Generating synthetic data.")
+        logger.warning(f"Failed to load local/scanpy pbmc3k: {e}. Generating synthetic data.")
         np.random.seed(42)
         n_cells, n_genes = 500, 1000
         counts = np.random.negative_binomial(2, 0.02, size=(n_cells, n_genes))
@@ -307,12 +362,16 @@ def main():
     # Validate method & check dependencies
     method = validate_method_choice(args.method, METHOD_REGISTRY)
 
+    use_raw_markers = adata.raw is not None and adata.raw.shape == adata.shape
+
     # Parameters
     params = {
         "groupby": args.groupby,
         "method": method,
         "n_genes": args.n_genes,
         "n_top": args.n_top,
+        "use_raw": use_raw_markers,
+        "expression_source": "adata.raw" if use_raw_markers else "adata.X",
     }
 
     # Find markers
@@ -322,6 +381,7 @@ def main():
         cluster_key=args.groupby,
         method=method,
         n_genes=args.n_genes,
+        use_raw=use_raw_markers,
     )
 
     n_clusters = markers['group'].nunique()
@@ -372,6 +432,8 @@ def main():
         del adata.uns['rank_genes_groups_filtered']
 
     output_h5ad = output_dir / "adata_with_markers.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata, SKILL_NAME, args.method, params)
     adata.write_h5ad(output_h5ad)
     logger.info(f"Saved: {output_h5ad}")
 
@@ -383,10 +445,21 @@ def main():
     if input_file:
         cmd += f" --input {input_file}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib", "seaborn"],
+    )
 
     # Result.json
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     # Summary
     print(f"\n{'='*60}")

--- a/skills/singlecell/scrna/sc-preprocessing/sc_preprocess.py
+++ b/skills/singlecell/scrna/sc-preprocessing/sc_preprocess.py
@@ -803,11 +803,8 @@ def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary
 
 def get_demo_data():
     logger.info("Generating demo single-cell data")
-    demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-    if demo_path.exists():
-        return sc.read_h5ad(demo_path), None
-    logger.warning("Local demo data not found, downloading from scanpy")
-    return sc.datasets.pbmc3k(), None
+    adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+    return adata, demo_path
 
 
 def build_summary(adata, method: str) -> dict:
@@ -899,6 +896,14 @@ def main():
             n_neighbors=int(effective_params["n_neighbors"]),
             leiden_resolution=float(effective_params["leiden_resolution"]),
         )
+
+    adata.uns["omicsclaw_matrix_contract"] = {
+        "X": "scaled_expression" if method == "scanpy" else "normalized_expression",
+        "raw": "log1p_normalized_expression" if adata.raw is not None else None,
+        "layers": {"counts": "raw_counts" if "counts" in adata.layers else None},
+        "primary_cluster_key": "leiden",
+        "preprocess_method": method,
+    }
 
     summary = build_summary(adata, method)
     effective_params = finalize_effective_params(adata, effective_params, summary)

--- a/skills/singlecell/scrna/sc-pseudotime/SKILL.md
+++ b/skills/singlecell/scrna/sc-pseudotime/SKILL.md
@@ -1,18 +1,33 @@
 ---
 name: sc-pseudotime
 description: >-
-  Pseudotime and trajectory analysis using PAGA, Diffusion Map, and DPT
-version: 0.1.0
+  Trajectory analysis for single-cell RNA-seq using the current Scanpy-based
+  DPT workflow, plus a configurable correlation method for ranking
+  trajectory-associated genes.
+version: 0.3.0
+author: OmicsClaw
+license: MIT
+tags: [singlecell, trajectory, pseudotime, paga, dpt]
 metadata:
   omicsclaw:
     domain: singlecell
     allowed_extra_flags:
       - "--cluster-key"
+      - "--corr-method"
       - "--method"
       - "--n-dcs"
       - "--n-genes"
       - "--root-cell"
       - "--root-cluster"
+    param_hints:
+      dpt:
+        priority: "cluster_key -> root_cluster/root_cell -> n_dcs -> n_genes -> corr_method"
+        params: ["cluster_key", "root_cluster", "root_cell", "n_dcs", "n_genes", "corr_method"]
+        defaults: {cluster_key: "leiden", n_dcs: 10, n_genes: 50, corr_method: "pearson"}
+        requires: ["neighbors_graph", "cluster_labels_in_obs", "scanpy"]
+        tips:
+          - "--method dpt: Public analysis method for the current wrapper."
+          - "--corr-method: Used only for ranking trajectory genes after pseudotime has been estimated."
     saves_h5ad: true
     requires_preprocessed: true
     trigger_keywords:
@@ -25,127 +40,64 @@ metadata:
       - diffusion map
 ---
 
-# sc-pseudotime — Pseudotime Trajectory Analysis
+# Single-Cell Pseudotime
 
-## Purpose
+## Why This Exists
 
-Infer temporal ordering and trajectory structure of single-cell data using:
-- **PAGA** (Partition-based Graph Abstraction) — cluster connectivity
-- **Diffusion Map** — non-linear dimensionality reduction
-- **DPT** (Diffusion Pseudotime) — pseudotemporal ordering
+- Without it: users often conflate trajectory estimation with downstream gene ranking.
+- With it: the wrapper separates the trajectory method from the trajectory-gene correlation method.
+- Why OmicsClaw: one contract bundles PAGA, diffusion map, DPT, and export tables.
 
-This is a core trajectory analysis skill that works with standard scanpy preprocessing.
+## Scope Boundary
 
-## When to Use
+Implemented analysis method:
 
-- Lineage tracing and developmental biology studies
-- Cell differentiation trajectory inference
-- Identifying trajectory-associated genes
-- Understanding cell state transitions
+1. `dpt`
 
-## Requirements
+Separate post-hoc trajectory-gene ranking methods:
 
-- **Input**: AnnData with:
-  - Preprocessed data (normalized, log-transformed)
-  - PCA computed
-  - Neighbor graph computed
-  - Cluster labels (e.g., `leiden`)
+1. `pearson`
+2. `spearman`
 
-- **Dependencies**:
-  - scanpy (required)
-  - numpy, pandas, scipy (required)
+## Input Contract
 
-## Usage
+- Accepted input: preprocessed `.h5ad`
+- Required metadata: a cluster column such as `leiden`
+- Expected upstream state: neighbor graph available or recomputable
 
-### CLI
+## Workflow Summary
+
+1. Validate cluster labels and graph availability.
+2. Run PAGA.
+3. Run diffusion map and DPT pseudotime.
+4. Rank trajectory-associated genes with `--corr-method`.
+5. Save `adata_with_trajectory.h5ad`, figures, tables, `report.md`, and `result.json`.
+
+## CLI Reference
 
 ```bash
-# Basic usage
-python omicsclaw.py run sc-pseudotime --input preprocessed.h5ad --output results/
+python skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py \
+  --input <data.h5ad> --method dpt --cluster-key leiden --output <dir>
 
-# With specific root cluster
-python omicsclaw.py run sc-pseudotime --input data.h5ad --output results/ --root-cluster "0"
-
-# Demo mode
-python omicsclaw.py run sc-pseudotime --demo --output /tmp/pseudotime_demo/
+python skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py \
+  --input <data.h5ad> --method dpt --root-cluster 0 \
+  --n-dcs 10 --n-genes 50 --corr-method spearman --output <dir>
 ```
 
-### Parameters
+## Output Contract
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--input` | required | Input AnnData file (.h5ad) |
-| `--output` | required | Output directory |
-| `--demo` | false | Run with synthetic demo data |
-| `--cluster-key` | `leiden` | Key for cluster labels |
-| `--root-cluster` | auto | Root cluster for pseudotime |
-| `--root-cell` | auto | Root cell index (overrides --root-cluster) |
-| `--n-dcs` | 10 | Number of diffusion components |
-| `--n-genes` | 50 | Number of trajectory genes to find |
-| `--method` | pearson | Correlation method (pearson/spearman) |
+Successful runs write:
 
-## Output Structure
+- `adata_with_trajectory.h5ad`
+- `report.md`
+- `result.json`
+- `tables/trajectory_genes.csv`
+- `figures/paga_graph.png`
+- `figures/pseudotime_umap.png`
+- `figures/diffusion_components*.png`
+- `figures/trajectory_gene_heatmap.png`
 
-```
-output_dir/
-├── adata_with_trajectory.h5ad    # AnnData with pseudotime + diffmap
-├── report.md                      # Analysis report
-├── result.json                    # Machine-readable results
-├── figures/
-│   ├── paga_graph.png            # PAGA connectivity graph
-│   ├── pseudotime_umap.png       # Pseudotime on UMAP
-│   ├── diffusion_components.png  # Diffusion map components
-│   └── trajectory_gene_heatmap.png
-├── tables/
-│   └── trajectory_genes.csv      # Genes correlated with pseudotime
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
+## Current Limitations
 
-## Methods
-
-### PAGA (Partition-based Graph Abstraction)
-
-PAGA estimates the connectivity between clusters by quantifying how much the single-cell graph
-connectivity at each cluster resolution is preserved at a coarser resolution.
-
-- **Input**: Neighbor graph + cluster labels
-- **Output**: Weighted graph of cluster connectivities
-- **Interpretation**: Thick edges indicate strong connectivity (likely transition path)
-
-### Diffusion Map
-
-Diffusion maps provide a non-linear dimensionality reduction that preserves the underlying
-manifold structure of single-cell data.
-
-- **Input**: PCA-reduced data
-- **Output**: Diffusion components (DC1, DC2, ...)
-- **Interpretation**: Cells close in diffusion space are transcriptionally similar
-
-### DPT (Diffusion Pseudotime)
-
-DPT uses random walks on the diffusion graph to estimate pseudotemporal ordering of cells
-from a root cell.
-
-- **Input**: Diffusion map + root cell
-- **Output**: Pseudotime values [0, 1]
-- **Interpretation**: 0 = root state, 1 = terminal state
-
-## Interpretation
-
-1. **PAGA graph**: Look for linear chains (lineages) or branching points (bifurcations)
-2. **Pseudotime UMAP**: Gradient from root (0) to terminal (1) cells
-3. **Trajectory genes**: Genes correlated with pseudotime may be drivers of transition
-
-## Tips
-
-- Choose root cluster/cell based on known biology (e.g., stem cells, early progenitors)
-- Use `sc-velocity` for RNA velocity-based trajectory if spliced/unspliced data available
-- Combine with `sc-grn` to find TFs driving trajectory transitions
-
-## References
-
-- Wolf et al. (2019) PAGA: graph abstraction reconciles clustering with trajectory inference
-- Haghverdi et al. (2016) Diffusion maps for high-dimensional single-cell data
-- Haghverdi et al. (2016) Diffusion pseudotime
+- Only the DPT trajectory path is implemented in the current wrapper.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py
+++ b/skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py
@@ -35,7 +35,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
 from omicsclaw.common.checksums import sha256_file
 from skills.singlecell._lib.method_config import (
     MethodConfig,
@@ -48,8 +54,56 @@ from skills.singlecell._lib import trajectory as sc_traj
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-pseudotime"
+SKILL_NAME = "sc-pseudotime"
 SKILL_VERSION = "0.2.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="PAGA and DPT-based pseudotime trajectory analysis for scRNA-seq.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "dpt"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="PAGA and DPT-based pseudotime trajectory analysis for scRNA-seq.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "dpt"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 # ---------------------------------------------------------------------------
 # Method registry
@@ -193,10 +247,12 @@ def write_pseudotime_report(
 
     body_lines.extend([
         "## Parameters\n",
+        f"- `--method`: {params.get('method', 'dpt')}",
         f"- `--cluster-key`: {params.get('cluster_key', 'leiden')}",
         f"- `--root-cluster`: {params.get('root_cluster', 'auto')}",
         f"- `--n-dcs`: {params.get('n_dcs', 10)}",
         f"- `--n-genes`: {params.get('n_genes', 50)}",
+        f"- `--corr-method`: {params.get('corr_method', 'pearson')}",
         "",
         "## Output Files\n",
         "- `adata_with_trajectory.h5ad` — AnnData with pseudotime and diffusion map",
@@ -226,7 +282,8 @@ def generate_demo_data():
     logger.info("Generating demo data with trajectory structure...")
 
     try:
-        adata = sc.datasets.pbmc3k()
+        adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+        logger.info("Loaded demo dataset: %s", demo_path or "scanpy-pbmc3k")
         # Quick preprocessing
         sc.pp.filter_cells(adata, min_genes=200)
         sc.pp.filter_genes(adata, min_cells=3)
@@ -249,7 +306,7 @@ def generate_demo_data():
 
         logger.info(f"Generated: {adata.n_obs} cells x {adata.n_vars} genes, {adata.obs['leiden'].nunique()} clusters")
     except Exception as e:
-        logger.warning(f"Failed to load pbmc3k: {e}. Generating synthetic data.")
+        logger.warning(f"Failed to load local/scanpy pbmc3k: {e}. Generating synthetic data.")
         np.random.seed(42)
         n_cells, n_genes = 500, 1000
         counts = np.random.negative_binomial(2, 0.02, size=(n_cells, n_genes))
@@ -280,10 +337,25 @@ def main():
     parser.add_argument("--root-cell", type=int, default=None, help="Root cell index")
     parser.add_argument("--n-dcs", type=int, default=10, help="Number of diffusion components")
     parser.add_argument("--n-genes", type=int, default=50, help="Number of trajectory genes")
-    parser.add_argument("--analysis-method", default="dpt", choices=list(METHOD_REGISTRY.keys()),
-                        help="Trajectory analysis method (default: dpt)")
-    parser.add_argument("--method", default="pearson", choices=["pearson", "spearman"],
-                        help="Correlation method for trajectory genes")
+    parser.add_argument(
+        "--method",
+        dest="analysis_method",
+        default="dpt",
+        choices=list(METHOD_REGISTRY.keys()),
+        help="Trajectory analysis method (default: dpt)",
+    )
+    parser.add_argument(
+        "--analysis-method",
+        dest="analysis_method",
+        choices=list(METHOD_REGISTRY.keys()),
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--corr-method",
+        default="pearson",
+        choices=["pearson", "spearman"],
+        help="Correlation method for trajectory gene ranking",
+    )
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
@@ -322,13 +394,13 @@ def main():
 
     # Parameters
     params = {
-        "analysis_method": analysis_method,
+        "method": analysis_method,
         "cluster_key": args.cluster_key,
         "root_cluster": args.root_cluster,
         "root_cell": args.root_cell,
         "n_dcs": args.n_dcs,
         "n_genes": args.n_genes,
-        "method": args.method,
+        "corr_method": args.corr_method,
     }
 
     # Step 1: PAGA analysis
@@ -355,12 +427,13 @@ def main():
         adata,
         pseudotime_key="dpt_pseudotime",
         n_genes=args.n_genes,
-        method=args.method,
+        method=args.corr_method,
     )
 
     # Summary
     n_clusters = adata.obs[args.cluster_key].nunique()
     summary = {
+        "method": analysis_method,
         "n_clusters": int(n_clusters),
         "n_trajectory_genes": len(trajectory_genes),
         "root_cell": int(dpt_result["root_cells"][0]) if dpt_result["root_cells"] else None,
@@ -388,6 +461,8 @@ def main():
 
     # Save data
     output_h5ad = output_dir / "adata_with_trajectory.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata, SKILL_NAME, analysis_method, params)
     adata.write_h5ad(output_h5ad)
     logger.info(f"Saved: {output_h5ad}")
 
@@ -400,12 +475,26 @@ def main():
         cmd += f" --input {input_file}"
     if args.root_cluster:
         cmd += f" --root-cluster {args.root_cluster}"
-    cmd += f" --n-dcs {args.n_dcs} --n-genes {args.n_genes} --method {args.method}"
+    cmd += (
+        f" --n-dcs {args.n_dcs} --n-genes {args.n_genes}"
+        f" --method {analysis_method} --corr-method {args.corr_method}"
+    )
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+    )
 
     # Result.json
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     # Summary
     print(f"\n{'='*60}")

--- a/skills/singlecell/scrna/sc-qc/sc_qc.py
+++ b/skills/singlecell/scrna/sc-qc/sc_qc.py
@@ -480,20 +480,12 @@ def generate_demo_data(species: str = "human"):
 
     logger.info("Generating synthetic demo data...")
 
-    # Try to load from local demo data first
-    demo_path = _PROJECT_ROOT / "examples" / "pbmc3k.h5ad"
-    if demo_path.exists():
-        logger.info(f"Loading local demo data: {demo_path}")
-        return sc.read_h5ad(demo_path), None
-
-    # Fall back to scanpy's built-in dataset
-    logger.info("Downloading pbmc3k from scanpy datasets...")
     try:
-        adata = sc.datasets.pbmc3k()
-        logger.info(f"Loaded pbmc3k: {adata.n_obs} cells x {adata.n_vars} genes")
-        return adata, None
+        adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+        logger.info(f"Loaded demo data: {demo_path or 'scanpy-pbmc3k'}")
+        return adata, demo_path
     except Exception as e:
-        logger.warning(f"Failed to load pbmc3k: {e}")
+        logger.warning(f"Failed to load local/scanpy pbmc3k: {e}")
         # Generate synthetic data as last resort
         logger.info("Generating synthetic data...")
 

--- a/skills/singlecell/scrna/sc-velocity/SKILL.md
+++ b/skills/singlecell/scrna/sc-velocity/SKILL.md
@@ -1,14 +1,42 @@
 ---
 name: sc-velocity
 description: >-
-  RNA velocity analysis using scVelo for estimating cell state transitions
-version: 0.1.0
+  RNA velocity analysis for scRNA-seq using scVelo stochastic, dynamical, or
+  steady-state modes. The wrapper now accepts both `--method` and `--mode` as
+  public aliases for the velocity backend.
+version: 0.3.0
+author: OmicsClaw
+license: MIT
+tags: [singlecell, velocity, scvelo, latent-time, dynamics]
 metadata:
   omicsclaw:
     domain: singlecell
     allowed_extra_flags:
       - "--method"
+      - "--mode"
       - "--n-jobs"
+    param_hints:
+      scvelo_stochastic:
+        priority: "n_jobs"
+        params: ["n_jobs"]
+        defaults: {n_jobs: 4}
+        requires: ["scvelo", "layers.spliced", "layers.unspliced"]
+        tips:
+          - "--method scvelo_stochastic or --mode stochastic: default velocity path."
+      scvelo_dynamical:
+        priority: "n_jobs"
+        params: ["n_jobs"]
+        defaults: {n_jobs: 4}
+        requires: ["scvelo", "layers.spliced", "layers.unspliced"]
+        tips:
+          - "--method scvelo_dynamical or --mode dynamical: computes latent time when the fit succeeds."
+      scvelo_steady_state:
+        priority: "n_jobs"
+        params: ["n_jobs"]
+        defaults: {n_jobs: 4}
+        requires: ["scvelo", "layers.spliced", "layers.unspliced"]
+        tips:
+          - "--method scvelo_steady_state or --mode steady_state: steady-state approximation path."
     saves_h5ad: true
     requires_preprocessed: true
     trigger_keywords:
@@ -21,131 +49,65 @@ metadata:
       - velocity pseudotime
 ---
 
-# sc-velocity — RNA Velocity Analysis
+# Single-Cell Velocity
 
-## Purpose
+## Why This Exists
 
-Estimate the future state of cells by analyzing spliced and unspliced mRNA counts using **scVelo**:
+- Without it: velocity analyses are hard to standardize because they require special input layers and backend-specific wording.
+- With it: velocity backend selection and output naming are consistent across runs.
+- Why OmicsClaw: one wrapper captures velocity figures, latent-time summaries, and method provenance.
 
-- **Velocity estimation** — direction and speed of transcriptional change
-- **Velocity graph** — cell-to-cell transition probabilities
-- **Latent time** — global transcriptomic time (dynamical mode only)
+## Scope Boundary
 
-RNA velocity provides dynamic information beyond static snapshots.
+Implemented backends:
 
-## When to Use
+1. `scvelo_stochastic`
+2. `scvelo_dynamical`
+3. `scvelo_steady_state`
 
-- Developmental biology and lineage tracing
-- Cell state transition analysis
-- Identifying direction of differentiation
-- Validating pseudotime trajectories
+Public alias behavior:
 
-## Requirements
+1. `--method scvelo_dynamical`
+2. `--mode dynamical`
 
-- **Input**: AnnData with:
-  - `layers["spliced"]` — spliced mRNA counts
-  - `layers["unspliced"]` — unspliced mRNA counts
-  - Preprocessed (normalized, log-transformed)
+Both point to the same backend selection logic.
 
-- **Dependencies**:
-  - scvelo (required)
-  - scanpy, numpy, scipy
+## Input Contract
 
-### Generating Spliced/Unspliced Data
+- Accepted input: `.h5ad`
+- Required layers: `layers["spliced"]` and `layers["unspliced"]`
+- Expected upstream state: normalized/preprocessed single-cell AnnData
 
-For 10X data, use one of:
-- **velocyto**: `velocyto run10x sample_name/ refdata-cellranger-mm10-3.0.0/genes/genes.gtf`
-- **kb-python**: `kb count -i index.idx -g t2g.txt -x 10xv2 -o output --lamanno`
+## Workflow Summary
 
-## Usage
+1. Validate scVelo availability and required layers.
+2. Run the selected velocity backend.
+3. Generate stream, magnitude, and optional latent-time plots.
+4. Save `adata_with_velocity.h5ad`, `report.md`, and `result.json`.
+5. Record both the public method id and the internal mode used.
 
-### CLI
+## CLI Reference
 
 ```bash
-# Basic usage (stochastic mode)
-python omicsclaw.py run sc-velocity --input data_with_spliced.h5ad --output results/
+python skills/singlecell/scrna/sc-velocity/sc_velocity.py \
+  --input <data.h5ad> --method scvelo_stochastic --output <dir>
 
-# Dynamical mode (slower, computes latent time)
-python omicsclaw.py run sc-velocity --input data.h5ad --output results/ --mode dynamical
-
-# Demo mode (synthetic data)
-python omicsclaw.py run sc-velocity --demo --output /tmp/velocity_demo/
+python skills/singlecell/scrna/sc-velocity/sc_velocity.py \
+  --input <data.h5ad> --mode dynamical --n-jobs 8 --output <dir>
 ```
 
-### Parameters
+## Output Contract
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--input` | required | Input AnnData with spliced/unspliced layers |
-| `--output` | required | Output directory |
-| `--demo` | false | Run with synthetic demo data |
-| `--mode` | stochastic | Velocity mode: stochastic, dynamical, steady_state |
-| `--n-jobs` | 4 | Number of parallel jobs |
+Successful runs write:
 
-### Modes
+- `adata_with_velocity.h5ad`
+- `report.md`
+- `result.json`
+- `figures/velocity_stream.png`
+- `figures/velocity_magnitude_umap.png`
+- `figures/latent_time_umap.png` when latent time is available
 
-| Mode | Speed | Features | When to Use |
-|------|-------|----------|-------------|
-| `stochastic` | Fast | Velocity vectors | Quick analysis, large datasets |
-| `dynamical` | Slow | Velocity + latent time | Full trajectory, publication |
-| `steady_state` | Fastest | Basic velocity | Very large datasets |
+## Current Limitations
 
-## Output Structure
-
-```
-output_dir/
-├── adata_with_velocity.h5ad      # AnnData with velocity results
-├── report.md                      # Analysis report
-├── result.json                    # Machine-readable results
-├── figures/
-│   ├── velocity_stream.png       # Velocity stream plot on UMAP
-│   ├── velocity_magnitude_umap.png
-│   └── latent_time_umap.png      # (dynamical mode only)
-└── reproducibility/
-    ├── commands.sh
-    └── requirements.txt
-```
-
-## Methods
-
-### RNA Velocity
-
-RNA velocity estimates transcriptional dynamics by comparing spliced (mature) and unspliced
-(nascent) mRNA abundances.
-
-- **High velocity** → active transcription of gene
-- **Negative velocity** → gene being downregulated
-- **Stream arrows** → direction of future state
-
-### Latent Time (Dynamical Mode Only)
-
-Latent time is a global, transcriptome-wide pseudotime learned from the dynamical model.
-Unlike DPT pseudotime, it accounts for splicing kinetics.
-
-## Interpretation
-
-1. **Stream arrows**: Point toward future cell states
-2. **Velocity magnitude**: High values indicate active transcriptional changes
-3. **Latent time**: Trajectory from early (0) to late (1) states
-4. **Branches**: Arrows pointing in different directions indicate bifurcations
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| No spliced/unspliced layers | Run velocyto or kb-python with `--lamanno` |
-| scVelo not installed | `pip install scvelo` |
-| Too few genes pass filtering | Check data quality, reduce `min_shared_counts` |
-| Slow dynamical mode | Use `stochastic` mode for exploration |
-
-## Tips
-
-- Preprocess data with `sc-preprocessing` first
-- Velocity works best on raw counts (not normalized)
-- Combine with `sc-pseudotime` for static trajectory comparison
-- Use `dynamical` mode for final analysis, `stochastic` for exploration
-
-## References
-
-- Bergen et al. (2020) Generalizing RNA velocity to transient cell states through dynamical modeling
-- La Manno et al. (2018) RNA velocity of single cells
+- This wrapper depends on spliced/unspliced layers already being present.
+- This skill writes `README.md` and notebook-style reproducibility artifacts when notebook export dependencies are available.

--- a/skills/singlecell/scrna/sc-velocity/sc_velocity.py
+++ b/skills/singlecell/scrna/sc-velocity/sc_velocity.py
@@ -36,7 +36,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from omicsclaw.common.report import generate_report_header, generate_report_footer, write_result_json
+from omicsclaw.common.report import (
+    generate_report_header,
+    generate_report_footer,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
 from omicsclaw.common.checksums import sha256_file
 from skills.singlecell._lib.method_config import (
     MethodConfig,
@@ -49,8 +55,56 @@ from skills.singlecell._lib import trajectory as sc_traj
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-SKILL_NAME = "singlecell-velocity"
+SKILL_NAME = "sc-velocity"
 SKILL_VERSION = "0.2.0"
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="RNA velocity analysis for single-cell RNA-seq with scVelo.",
+            result_payload=result_payload,
+            preferred_method=summary.get("mode", "stochastic"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="RNA velocity analysis for single-cell RNA-seq with scVelo.",
+            result_payload=result_payload,
+            preferred_method=summary.get("mode", "stochastic"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:
+        logger.warning("Failed to write README.md: %s", exc)
 
 # ---------------------------------------------------------------------------
 # Method registry
@@ -84,6 +138,11 @@ _CLI_TO_MODE = {
     "scvelo_stochastic": "stochastic",
     "scvelo_dynamical": "dynamical",
     "scvelo_steady_state": "steady_state",
+}
+_MODE_ALIAS_MAP = {
+    "stochastic": "scvelo_stochastic",
+    "dynamical": "scvelo_dynamical",
+    "steady_state": "scvelo_steady_state",
 }
 
 # ---------------------------------------------------------------------------
@@ -266,21 +325,34 @@ def generate_demo_data():
     """
     import scanpy as sc
 
-    logger.info("Generating synthetic demo data with spliced/unspliced layers...")
-
-    np.random.seed(42)
-    n_cells = 500
-    n_genes = 500
-
-    # Generate synthetic counts
-    spliced = np.random.negative_binomial(5, 0.1, size=(n_cells, n_genes)).astype(np.float32)
-    unspliced = np.random.negative_binomial(2, 0.15, size=(n_cells, n_genes)).astype(np.float32)
-
-    adata = sc.AnnData(
-        X=spliced,
-        obs=pd.DataFrame(index=[f"cell_{i}" for i in range(n_cells)]),
-        var=pd.DataFrame(index=[f"gene_{i}" for i in range(n_genes)]),
-    )
+    logger.info("Generating demo data with spliced/unspliced layers...")
+    try:
+        adata, demo_path = sc_io.load_repo_demo_data("pbmc3k_raw")
+        logger.info("Loaded demo dataset: %s", demo_path or "scanpy-pbmc3k")
+        adata = adata.copy()
+        if adata.n_obs > 500:
+            adata = adata[:500, :500].copy()
+        elif adata.n_vars > 500:
+            adata = adata[:, :500].copy()
+        if hasattr(adata.X, "toarray"):
+            base_counts = adata.X.toarray().astype(np.float32)
+        else:
+            base_counts = np.asarray(adata.X).astype(np.float32)
+        np.random.seed(42)
+        spliced = np.maximum(base_counts, 0).astype(np.float32)
+        unspliced = np.random.negative_binomial(2, 0.15, size=spliced.shape).astype(np.float32)
+        adata.X = spliced
+    except Exception:
+        np.random.seed(42)
+        n_cells = 500
+        n_genes = 500
+        spliced = np.random.negative_binomial(5, 0.1, size=(n_cells, n_genes)).astype(np.float32)
+        unspliced = np.random.negative_binomial(2, 0.15, size=(n_cells, n_genes)).astype(np.float32)
+        adata = sc.AnnData(
+            X=spliced,
+            obs=pd.DataFrame(index=[f"cell_{i}" for i in range(n_cells)]),
+            var=pd.DataFrame(index=[f"gene_{i}" for i in range(n_genes)]),
+        )
 
     # Add layers
     adata.layers["spliced"] = spliced
@@ -318,9 +390,14 @@ def main():
     parser.add_argument("--input", dest="input_path", help="Input AnnData file (.h5ad)")
     parser.add_argument("--output", dest="output_dir", required=True, help="Output directory")
     parser.add_argument("--demo", action="store_true", help="Run with demo data")
-    parser.add_argument("--method", default="scvelo_stochastic",
-                        choices=list(METHOD_REGISTRY.keys()),
-                        help="Velocity method (default: scvelo_stochastic)")
+    parser.add_argument(
+        "--method",
+        "--mode",
+        dest="method",
+        default="scvelo_stochastic",
+        choices=list(METHOD_REGISTRY.keys()) + list(_MODE_ALIAS_MAP.keys()),
+        help="Velocity method; accepts full backend ids or shorthand modes such as 'dynamical'",
+    )
     parser.add_argument("--n-jobs", type=int, default=4, help="Number of parallel jobs")
     args = parser.parse_args()
 
@@ -370,7 +447,8 @@ def main():
         sys.exit(1)
 
     # Validate method & check dependencies
-    method = validate_method_choice(args.method, METHOD_REGISTRY)
+    requested_method = _MODE_ALIAS_MAP.get(args.method, args.method)
+    method = validate_method_choice(requested_method, METHOD_REGISTRY)
     mode = _CLI_TO_MODE[method]
 
     # Parameters
@@ -423,6 +501,8 @@ def main():
 
     # Save data
     output_h5ad = output_dir / "adata_with_velocity.h5ad"
+    from skills.singlecell._lib.adata_utils import store_analysis_metadata
+    store_analysis_metadata(adata, SKILL_NAME, method, params)
     adata.write_h5ad(output_h5ad)
     logger.info(f"Saved: {output_h5ad}")
 
@@ -434,10 +514,21 @@ def main():
     if input_file:
         cmd += f" --input {input_file}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    _write_repro_requirements(
+        repro_dir,
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib", "scvelo"],
+    )
 
     # Result.json
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
-    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, {"params": params}, checksum)
+    result_data = {"params": params}
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {
+        "skill": SKILL_NAME,
+        "summary": summary,
+        "data": result_data,
+    }
+    write_standard_run_artifacts(output_dir, result_payload, summary)
 
     # Summary
     print(f"\n{'='*60}")


### PR DESCRIPTION
## Summary
- port the validated `scrna` hardening work onto the latest `main` without carrying unrelated interactive/runtime branch changes
- standardize scrna skill contracts, method guides, and knowhow guardrails
- harden matrix/layer usage across scrna methods (`X`, `adata.raw`, `layers["counts"]`, spliced/unspliced)
- fix and validate remaining scrna backends including scVI/scANVI, scanorama, fastmnn, DoubletFinder, scDblFinder, DESeq2 pseudobulk, SingleR, scmap, CellChat wrapper behavior, and sctransform
- wire CellBender CLI into the `omicsclaw` environment and enforce raw 10x `.h5` input validation in the wrapper

## Notes
- this PR intentionally excludes the older interactive/onboard changes from `feat/singlecell-skill-dev` to minimize merge conflict risk against the recently refactored `main`
- a real official 10x raw `.h5` was used locally to verify CellBender launch behavior, but that large test file was not added to the repo
- CellBender currently launches and reaches inference correctly, but full output generation is still blocked by an upstream `CellBender 0.3.0` checkpoint/posterior bug after inference

## Validation
- verified torch-backed GPU usage after switching the `omicsclaw` environment to a driver-compatible CUDA build
- re-ran representative scrna methods on fixture-based smoke tests and targeted method checks
- verified `cellbender remove-background` launches correctly on real 10x raw input through the OmicsClaw skill path