### PR TITLE
Polish scRNA doublet detection methods and gallery

### DIFF
--- a/knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md
@@ -2,26 +2,32 @@
 doc_id: sc-doublet-detection-guardrails
 title: Single-Cell Doublet Detection Guardrails
 doc_type: knowhow
-critical_rule: MUST explain the expected doublet-rate assumption before running sc-doublet-detection and must not invent unsupported backend-specific tuning knobs
+critical_rule: MUST explain the chosen backend's real control knobs before running sc-doublet-detection and MUST not overclaim automatic removal
 domains: [singlecell]
 related_skills: [sc-doublet-detection, sc-doublet]
 phases: [before_run, on_warning, after_run]
-search_terms: [doublet detection, Scrublet, DoubletFinder, scDblFinder, expected doublet rate, 单细胞双细胞, 双细胞检测, 调参]
+search_terms: [doublet detection, Scrublet, DoubletDetection, DoubletFinder, scDblFinder, scds, expected doublet rate, 单细胞双细胞]
 priority: 1.0
 source_urls:
   - https://github.com/swolock/scrublet
+  - https://github.com/JonathanShor/DoubletDetection
   - https://github.com/chris-mcginnis-ucsf/DoubletFinder
   - https://bioconductor.org/packages/release/bioc/vignettes/scDblFinder/inst/doc/scDblFinder.html
+  - https://bioconductor.org/packages/release/bioc/html/scds.html
 ---
 
 # Single-Cell Doublet Detection Guardrails
 
-- **Inspect first**: confirm whether the input is a single capture or mixed samples, because doublet expectations depend on capture structure.
-- **Standardize external inputs first when provenance is unclear**: recommend `sc-standardize-input` for object hygiene, but still verify that the matrix used for doublet detection is truly raw count-like.
-- **Key wrapper controls**: explain `method`, `expected_doublet_rate`, and `threshold` before running.
-- **Use method-correct language**: `threshold` only applies to the Scrublet path in the current wrapper.
-- **Disclose fallback honestly**: if `doubletfinder` fails and the wrapper executes `scdblfinder`, state both the requested and executed methods explicitly.
-- **Stop when raw counts are not available**: do not run any doublet path if neither `layers["counts"]` nor count-like `adata.X` is available.
-- **Do not invent unsupported knobs**: official DoubletFinder and scDblFinder document extra controls such as `pK`, `nExp`, `dbr`, `samples`, or `clusters`, but the current OmicsClaw wrapper does not expose them.
-- **Do not overclaim removal**: this skill annotates doublets in `obs`; it does not silently drop them from the dataset.
-- **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.
+- **Inspect first**: confirm whether the data came from one capture or multiple captures/samples, because expected doublet burden and Scrublet batching strategy depend on capture structure.
+- **Use method-correct language**:
+  - `threshold` only applies to `scrublet`
+  - `batch_key` only affects the current `scrublet` wrapper
+  - `doubletdetection_n_iters` is the main public tuning knob for `doubletdetection`
+  - `scds_mode` only applies to `scds`
+- **Do not pretend `expected_doublet_rate` means the same thing for every backend**: it drives Scrublet / DoubletFinder / scDblFinder / scds in the current wrapper, but for `doubletdetection` it is only recorded as context.
+- **Preserve matrix semantics honestly**: doublet detection should use raw count-like input when possible, but it should not silently rewrite a normalized `adata.X`.
+- **Stop when raw counts are unavailable**: do not run if neither `layers["counts"]`, aligned `adata.raw`, nor count-like `adata.X` exists.
+- **Disclose fallbacks explicitly**: if `doubletfinder` falls back to `scdblfinder`, state both the requested and executed methods.
+- **Do not overclaim removal**: this skill labels doublets in `obs`; it does not drop cells automatically.
+- **After the run**: guide the user to review the calls first, then keep singlets and rerun preprocessing / clustering if the final analysis should exclude doublets.
+- **For detailed parameter strategy and interpretation**: see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.

--- a/knowledge_base/skill-guides/singlecell/sc-doublet-detection.md
+++ b/knowledge_base/skill-guides/singlecell/sc-doublet-detection.md
@@ -4,91 +4,72 @@ title: OmicsClaw Skill Guide — SC Doublet Detection
 doc_type: method-reference
 domains: [singlecell]
 related_skills: [sc-doublet-detection, sc-doublet]
-search_terms: [doublet detection, Scrublet, DoubletFinder, scDblFinder, expected doublet rate, tuning]
+search_terms: [doublet detection, Scrublet, DoubletDetection, DoubletFinder, scDblFinder, scds, expected doublet rate]
 priority: 0.8
 ---
 
 # OmicsClaw Skill Guide — SC Doublet Detection
 
-**Status**: implementation-aligned guide derived from the current OmicsClaw
-`sc-doublet-detection` skill. This guide explains the current wrapper surface,
-not every backend-specific parameter described upstream.
+## When To Use It
 
-## Purpose
+Use this skill when you have already reviewed basic QC and want to label likely multiplets before trusting final clusters, annotation, or DE results.
 
-Use this guide when you need to decide:
-- whether doublet detection should be run before clustering / annotation / DE
-- which backend is the most appropriate first pass
-- how to explain expected doublet rate and thresholding honestly
+Common OmicsClaw path:
 
-## Step 1: Inspect The Data First
+1. `sc-qc`
+2. `sc-doublet-detection`
+3. keep singlets if the calls look credible
+4. `sc-preprocessing`
+5. `sc-clustering`
 
-Key properties to check:
-- **Capture type**:
-  - droplet-based datasets are the primary use case
-- **Load / multiplexing context**:
-  - expected doublet burden depends on loading and sample design
-- **Current analysis stage**:
-  - doublet labeling is usually more useful before final annotation
-- **Input provenance**:
-  - if the object came from outside OmicsClaw, recommend `sc-standardize-input` first, then confirm the matrix used here is still raw count-like
+If the object is already preprocessed, the skill still works as long as raw counts are available in `layers["counts"]`, aligned `adata.raw`, or count-like `adata.X`.
 
-Important implementation notes in current OmicsClaw:
-- the wrapper exposes `scrublet`, `doubletfinder`, and `scdblfinder`
-- `threshold` only affects the Scrublet path
-- `doubletfinder` may fall back to `scdblfinder` if the R runtime fails
-- the wrapper annotates doublets; it does not automatically drop them
+## Method Selection
 
-## Step 2: Pick The Method Deliberately
+| Method | Best first use | Main public controls | Main caveat |
+|--------|----------------|----------------------|-------------|
+| `scrublet` | Default Python first pass | `expected_doublet_rate`, optional `batch_key`, optional `threshold` | `threshold` is Scrublet-only |
+| `doubletdetection` | Python consensus classifier from the SCOP method family | `doubletdetection_n_iters`, optional `doubletdetection_standard_scaling` | wrapper records `expected_doublet_rate` for context only |
+| `doubletfinder` | Seurat-style R path | `expected_doublet_rate` | may fall back to `scdblfinder` |
+| `scdblfinder` | clean Bioconductor default | `expected_doublet_rate` | advanced scDblFinder knobs stay hidden |
+| `scds` | score-family alternative from Bioconductor | `expected_doublet_rate`, `scds_mode` | wrapper converts the chosen score family into top-rate calls; `cxds` is the safest first pass in the current environment |
 
-| Method | Best first use | Strong starting parameters | Main caveat |
-|--------|----------------|----------------------------|-------------|
-| **scrublet** | Fast Python-native first pass | `expected_doublet_rate`, optional `threshold` | Threshold override only applies here |
-| **doubletfinder** | When an R-based Seurat-style path is explicitly desired | `expected_doublet_rate` | Current wrapper does not expose the full DoubletFinder tuning stack and may fall back to `scdblfinder` on runtime failure |
-| **scdblfinder** | Strong R/Bioconductor baseline with a simpler public surface | `expected_doublet_rate` | Wrapper hides many advanced scDblFinder options |
+## How To Explain Parameters To Users
 
-## Step 3: Always Show A Parameter Summary Before Running
+- Start with the **method**
+- Then explain the **one or two knobs that actually matter for that method**
+- Do not dump every backend parameter at once
 
-```text
-About to run doublet detection
-  Method: scrublet
-  Parameters: expected_doublet_rate=0.06, threshold=auto
-  Note: threshold override is only implemented for the Scrublet path.
-```
+Examples:
 
-## Step 4: Method-Specific Tuning Rules
+- `scrublet`
+  - `expected_doublet_rate`
+  - `batch_key` if captures/samples are mixed
+  - `threshold` only when automatic calls look clearly wrong
+- `doubletdetection`
+  - `doubletdetection_n_iters`
+  - optional `doubletdetection_standard_scaling`
+- `scds`
+  - `scds_mode`
+  - `expected_doublet_rate`
 
-### Shared first-pass rule
+## Output Interpretation
 
-Tune in this order:
-1. `expected_doublet_rate`
-2. `threshold` (Scrublet only)
+Standard output columns:
 
-Guidance:
-- `expected_doublet_rate` is the main shared scientific prior in the current wrapper
-- only use manual `threshold` when Scrublet’s automatic separation is clearly unsatisfactory
-- if the user selected an R method but also supplied a Scrublet-only `threshold`, stop and ask which behavior they actually want
+- `doublet_score`
+- `predicted_doublet`
+- `doublet_classification`
 
-Important warnings:
-- do not promise DoubletFinder `pK`, `pN`, or `nExp`; the wrapper does not expose them
-- do not promise scDblFinder sample-level / cluster-level fine controls; the wrapper does not expose them
+Interpret them this way:
 
-## Step 5: What To Say After The Run
+- `doublet_score`: backend-specific evidence score, not a universal probability
+- `predicted_doublet`: wrapper boolean call
+- `doublet_classification`: human-readable label
 
-- If many doublets are called: mention loading burden or sample complexity, not just “bad quality”.
-- If very few are called: mention the assumed expected rate and whether the threshold was conservative.
-- If `doubletfinder` fell back: explain both the requested and executed methods rather than presenting the result as native DoubletFinder output.
-- If users ask whether cells were removed: state clearly that the wrapper labels but does not auto-delete.
+## What To Say After The Run
 
-## Step 6: Explain Outputs Using Method-Correct Language
-
-- describe `doublet_score` as backend-specific evidence, not a universal probability
-- describe `predicted_doublet` as the wrapper’s boolean call
-- describe `doublet_classification` as the human-readable summary column
-
-## Official References
-
-- https://github.com/swolock/scrublet
-- https://github.com/chris-mcginnis-ucsf/DoubletFinder/blob/master/README.md
-- https://bioconductor.org/packages/release/bioc/vignettes/scDblFinder/inst/doc/scDblFinder.html
-- https://github.com/plger/scDblFinder/blob/devel/README.md
+- Review the histogram and embedding plots first
+- If many doublets localize to specific clusters or bridges, treat them as a real branch to inspect
+- If you accept the calls, keep singlets and rerun preprocessing / clustering for the final downstream object
+- If users ask whether OmicsClaw already removed the cells, answer clearly: **no, it only annotated them**

--- a/omicsclaw/core/r_dependency_manager.py
+++ b/omicsclaw/core/r_dependency_manager.py
@@ -41,6 +41,7 @@ R_TIER_PACKAGES: dict[str, list[str]] = {
         "Seurat",
         "DoubletFinder",
         "scDblFinder",
+        "scds",
         "SingleCellExperiment",
     ],
     "singlecell-annotation": [
@@ -114,7 +115,7 @@ _BIOCONDUCTOR_PACKAGES: set[str] = {
     "DESeq2", "SingleCellExperiment", "SingleR", "celldex",
     "S4Vectors", "IRanges", "GenomicRanges",
     "clusterProfiler", "org.Hs.eg.db", "org.Mm.eg.db",
-    "scDblFinder", "batchelor", "sva", "SPARK",
+    "scDblFinder", "scds", "batchelor", "sva", "SPARK",
     "spacexr", "SPOTlight", "CARD", "numbat",
     "SoupX",
 }

--- a/omicsclaw/core/registry.py
+++ b/omicsclaw/core/registry.py
@@ -931,8 +931,12 @@ _HARDCODED_SKILLS: dict[str, dict[str, Any]] = {
         "legacy_aliases": ["sc-doublet"],
         "script": SKILLS_DIR / "singlecell" / "scrna" / "sc-doublet-detection" / "sc_doublet.py",
         "demo_args": ["--demo"],
-        "description": "Doublet detection and removal (Scrublet, scDblFinder, DoubletFinder)",
-        "allowed_extra_flags": {"--method", "--expected-doublet-rate", "--threshold"},
+        "description": "Doublet detection annotation (Scrublet, DoubletDetection, scDblFinder, DoubletFinder, scds)",
+        "allowed_extra_flags": {
+            "--method", "--expected-doublet-rate", "--threshold", "--batch-key",
+            "--doubletdetection-n-iters", "--doubletdetection-standard-scaling", "--no-doubletdetection-standard-scaling",
+            "--scds-mode",
+        },
         "saves_h5ad": True,
     },
     "sc-cell-annotation": {

--- a/omicsclaw/r_scripts/sc_scds.R
+++ b/omicsclaw/r_scripts/sc_scds.R
@@ -1,0 +1,69 @@
+#!/usr/bin/env Rscript
+# OmicsClaw: scds doublet detection
+#
+# Usage:
+#   Rscript sc_scds.R <h5ad_file> <output_dir> [expected_doublet_rate] [mode]
+
+args <- commandArgs(trailingOnly = TRUE)
+
+if (length(args) < 2) {
+    cat("Usage: Rscript sc_scds.R <h5ad_file> <output_dir> [expected_doublet_rate] [mode]\n")
+    quit(status = 1)
+}
+
+h5ad_file <- args[1]
+output_dir <- args[2]
+expected_rate <- if (length(args) >= 3) as.numeric(args[3]) else 0.06
+mode <- if (length(args) >= 4) as.character(args[4]) else "hybrid"
+mode <- match.arg(mode, choices = c("hybrid", "cxds", "bcds"))
+
+suppressPackageStartupMessages({
+    library(scds)
+    library(SingleCellExperiment)
+    library(zellkonverter)
+})
+
+if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+
+tryCatch({
+    cat(sprintf("Loading data from %s...\n", h5ad_file))
+    sce <- readH5AD(h5ad_file)
+    SummarizedExperiment::assay(sce, "counts") <- round(SummarizedExperiment::assay(sce, "X"))
+
+    cat(sprintf("Running scds (%s)...\n", mode))
+    if (mode == "cxds") {
+        sce <- scds::cxds(sce, verb = FALSE)
+        score_col <- "cxds_score"
+    } else if (mode == "bcds") {
+        sce <- scds::bcds(sce, verb = FALSE)
+        score_col <- "bcds_score"
+    } else {
+        sce <- scds::cxds_bcds_hybrid(sce, verb = FALSE)
+        score_col <- "hybrid_score"
+    }
+
+    scores <- as.numeric(SummarizedExperiment::colData(sce)[[score_col]])
+    n_cells <- length(scores)
+    n_exp <- max(1, round(expected_rate * n_cells))
+    rank_idx <- order(scores, decreasing = TRUE)
+    predicted <- rep(FALSE, n_cells)
+    predicted[rank_idx[seq_len(min(n_exp, n_cells))]] <- TRUE
+    classification <- ifelse(predicted, "Doublet", "Singlet")
+
+    out <- data.frame(
+        cell = colnames(sce),
+        classification = classification,
+        doublet_score = scores,
+        predicted_doublet = predicted,
+        stringsAsFactors = FALSE,
+        row.names = colnames(sce)
+    )
+
+    write.csv(out, file.path(output_dir, "scds_results.csv"), quote = FALSE)
+    n_doublets <- sum(out$predicted_doublet)
+    cat(sprintf("Done. %d doublets detected out of %d cells (%.1f%%)\n",
+        n_doublets, nrow(out), 100 * n_doublets / nrow(out)))
+}, error = function(e) {
+    cat(sprintf("ERROR: %s\n", e$message), file = stderr())
+    quit(status = 1)
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ spatial = [
 
 singlecell = [
     "scrublet>=0.2.3",                # sc-doublet-detection: Scrublet
+    "doubletdetection>=4.3.0",        # sc-doublet-detection: DoubletDetection
     "liana>=1.4.0",                   # sc-cell-communication: LIANA+
     "harmonypy>=0.0.9",               # sc-batch-integration: Harmony
     "bbknn>=1.5.0",                   # sc-batch-integration: BBKNN

--- a/skills/singlecell/_lib/dependency_manager.py
+++ b/skills/singlecell/_lib/dependency_manager.py
@@ -37,6 +37,7 @@ DEPENDENCY_REGISTRY: dict[str, DependencyInfo] = {
 
     # Doublet detection
     "scrublet": DependencyInfo("scrublet", "pip install scrublet", "Scrublet doublet detection"),
+    "doubletdetection": DependencyInfo("doubletdetection", "pip install doubletdetection", "DoubletDetection consensus doublet calling"),
 
     # Communication
     "liana": DependencyInfo("liana", "pip install liana", "LIANA+ L-R analysis"),

--- a/skills/singlecell/_lib/preflight.py
+++ b/skills/singlecell/_lib/preflight.py
@@ -593,6 +593,9 @@ def preflight_sc_doublet_detection(
     method: str,
     expected_doublet_rate: float,
     threshold: float | None = None,
+    batch_key: str | None = None,
+    doubletdetection_n_iters: int | None = None,
+    scds_mode: str | None = None,
     source_path: str | None = None,
 ) -> PreflightDecision:
     decision = PreflightDecision("sc-doublet-detection")
@@ -611,16 +614,79 @@ def preflight_sc_doublet_detection(
             aliases=["method"],
         )
 
+    if batch_key and batch_key not in adata.obs.columns:
+        batch_candidates = _obs_candidates(adata, "batch")
+        decision.require_field(
+            "batch_key",
+            f"`--batch-key {batch_key}` was not found. Available batch/sample-style columns include: {_format_candidates(batch_candidates)}.",
+            aliases=["batch_key", "batch", "sample_key"],
+            flag="--batch-key",
+            choices=batch_candidates,
+        )
+
+    if method == "doubletdetection":
+        if find_spec("doubletdetection") is None:
+            decision.block(
+                "`doubletdetection` requires the optional Python package `doubletdetection`, which is not installed in the current environment."
+            )
+        if doubletdetection_n_iters is not None and int(doubletdetection_n_iters) < 2:
+            decision.block("`--doubletdetection-n-iters` must be at least 2.")
+
     if "counts" not in adata.layers:
-        if _declared_x_is_count_like(adata):
+        if _aligned_raw_is_count_like(adata) or (raw_matrix_kind(adata) and matrix_kind_is_count_like(raw_matrix_kind(adata))):
+            decision.add_guidance(
+                "No explicit `layers['counts']` was found; doublet detection will use aligned `adata.raw` while preserving the current `adata.X` semantics."
+            )
+        elif _declared_x_is_count_like(adata):
             decision.add_guidance(
                 "No explicit `layers['counts']` was found; doublet detection will use count-like `adata.X`."
             )
         else:
             decision.block(
-                "Doublet detection requires raw count-like input in `layers['counts']` or count-like `adata.X`."
+                "Doublet detection requires raw count-like input in `layers['counts']`, aligned `adata.raw`, or count-like `adata.X`."
             )
 
+    batch_candidates = _obs_candidates(adata, "batch")
+    if method == "scrublet" and not batch_key and batch_candidates:
+        decision.add_guidance(
+            f"Potential capture/sample columns were detected: {_format_candidates(batch_candidates)}. For multi-capture droplet data, `scrublet` is often safer run per capture via `--batch-key`."
+        )
+
+    if any(col in adata.obs.columns for col in ("predicted_doublet", "doublet_score", "doublet_classification")):
+        decision.add_guidance(
+            "Existing doublet annotations were detected and will be overwritten by the selected method."
+        )
+
+    decision.add_guidance(
+        "Doublet detection is usually most helpful after QC review and before final clustering, annotation, or DE interpretation."
+    )
+
+    if method == "scrublet":
+        decision.add_guidance(
+            f"Current first-pass settings: `method=scrublet`, `expected_doublet_rate={expected_doublet_rate}`, `threshold={threshold if threshold is not None else 'auto'}`."
+        )
+        if batch_key:
+            decision.add_guidance(f"`scrublet` will run per batch using `batch_key={batch_key}`.")
+    elif method == "doubletdetection":
+        decision.add_guidance(
+            f"Current first-pass settings: `method=doubletdetection`, `doubletdetection_n_iters={doubletdetection_n_iters}`, `expected_doublet_rate` is recorded for context but does not control this backend's native classifier."
+        )
+    elif method == "scds":
+        decision.add_guidance(
+            f"Current first-pass settings: `method=scds`, `expected_doublet_rate={expected_doublet_rate}`, `scds_mode={scds_mode}`."
+        )
+    else:
+        decision.add_guidance(
+            f"Current first-pass settings: `method={method}`, `expected_doublet_rate={expected_doublet_rate}`."
+        )
+        if batch_key:
+            decision.add_guidance(
+                f"`batch_key={batch_key}` was provided, but the current `{method}` wrapper does not use it directly."
+            )
+
+    decision.add_guidance(
+        "This skill annotates doublets in `obs` but does not remove cells automatically. After review, keep singlets for downstream preprocessing/clustering if needed."
+    )
     return decision
 
 

--- a/skills/singlecell/_lib/viz/__init__.py
+++ b/skills/singlecell/_lib/viz/__init__.py
@@ -8,6 +8,12 @@ from .embedding import (
     plot_cluster_size_summary,
     plot_embedding_categorical,
     plot_embedding_comparison,
+    plot_embedding_continuous,
+)
+from .doublet import (
+    plot_doublet_call_summary,
+    plot_doublet_score_by_group,
+    plot_doublet_score_distribution,
 )
 from .qc import (
     plot_barcode_rank,
@@ -48,8 +54,12 @@ __all__ = [
     "make_categorical_palette",
     "plot_embedding_categorical",
     "plot_embedding_comparison",
+    "plot_embedding_continuous",
     "plot_cluster_size_summary",
     "plot_cluster_qc_heatmap",
+    "plot_doublet_score_distribution",
+    "plot_doublet_call_summary",
+    "plot_doublet_score_by_group",
     "plot_qc_violin",
     "plot_qc_scatter",
     "plot_qc_histograms",

--- a/skills/singlecell/_lib/viz/doublet.py
+++ b/skills/singlecell/_lib/viz/doublet.py
@@ -1,0 +1,150 @@
+"""Visualization helpers for single-cell doublet detection."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+from .core import QC_PALETTE, apply_singlecell_theme, save_figure
+
+logger = logging.getLogger(__name__)
+
+
+def plot_doublet_score_distribution(
+    score_series,
+    output_dir: Union[str, Path],
+    *,
+    filename: str = "doublet_score_distribution.png",
+    title: str = "Doublet score distribution",
+    threshold: float | None = None,
+    expected_rate: float | None = None,
+) -> Path | None:
+    """Plot the score distribution and optional decision threshold."""
+    import matplotlib.pyplot as plt
+
+    output_dir = Path(output_dir)
+    values = pd.to_numeric(pd.Series(score_series), errors="coerce").dropna()
+    if values.empty:
+        logger.warning("Doublet scores are empty; skipping %s", filename)
+        return None
+
+    apply_singlecell_theme()
+    fig, ax = plt.subplots(figsize=(8.2, 5.2))
+    ax.hist(values, bins=40, color=QC_PALETTE["counts"], alpha=0.9, edgecolor="white")
+    ax.set_xlabel("Doublet score")
+    ax.set_ylabel("Cells")
+    ax.set_title(title, fontsize=17, pad=14)
+
+    if threshold is not None:
+        ax.axvline(threshold, color="#C53030", linestyle="--", linewidth=2, label=f"threshold={threshold:.3f}")
+    if expected_rate is not None:
+        ax.text(
+            0.98,
+            0.96,
+            f"expected rate: {expected_rate * 100:.1f}%",
+            transform=ax.transAxes,
+            ha="right",
+            va="top",
+            fontsize=10,
+            color="#475569",
+            bbox={"boxstyle": "round,pad=0.28", "fc": "white", "ec": "#CBD5E1", "alpha": 0.92},
+        )
+    if threshold is not None:
+        ax.legend(frameon=False, loc="upper left")
+
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_doublet_call_summary(
+    summary_df: pd.DataFrame,
+    output_dir: Union[str, Path],
+    *,
+    filename: str = "doublet_call_summary.png",
+) -> Path | None:
+    """Plot singlet vs doublet counts and fractions."""
+    import matplotlib.pyplot as plt
+
+    output_dir = Path(output_dir)
+    if summary_df.empty:
+        logger.warning("Doublet summary is empty; skipping %s", filename)
+        return None
+
+    frame = summary_df.copy()
+    frame["classification"] = frame["classification"].astype(str)
+    apply_singlecell_theme()
+    fig, ax = plt.subplots(figsize=(7.4, 4.8))
+    colors = [QC_PALETTE["genes"], "#C53030"]
+    bars = ax.bar(frame["classification"], frame["n_cells"], color=colors[: len(frame)], alpha=0.92)
+    ax.set_ylabel("Cells")
+    ax.set_xlabel("")
+    ax.set_title("Doublet call summary", fontsize=17, pad=14)
+    ymax = max(frame["n_cells"].max(), 1)
+    for bar, pct in zip(bars, frame["proportion_pct"]):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + ymax * 0.03,
+            f"{pct:.1f}%",
+            ha="center",
+            va="bottom",
+            fontsize=10,
+            color="#334155",
+        )
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_doublet_score_by_group(
+    score_df: pd.DataFrame,
+    output_dir: Union[str, Path],
+    *,
+    group_key: str,
+    filename: str = "doublet_score_by_group.png",
+) -> Path | None:
+    """Plot score distributions stratified by a grouping column."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    output_dir = Path(output_dir)
+    if score_df.empty or group_key not in score_df.columns or "doublet_score" not in score_df.columns:
+        logger.warning("Missing grouped score inputs; skipping %s", filename)
+        return None
+
+    frame = score_df[[group_key, "doublet_score"]].copy()
+    frame[group_key] = frame[group_key].astype(str)
+    frame["doublet_score"] = pd.to_numeric(frame["doublet_score"], errors="coerce")
+    frame = frame.dropna(subset=["doublet_score"])
+    if frame.empty or frame[group_key].nunique() <= 1:
+        return None
+
+    apply_singlecell_theme()
+    n_groups = frame[group_key].nunique()
+    width = max(7.8, min(12.0, 0.65 * n_groups + 4.5))
+    fig, ax = plt.subplots(figsize=(width, 5.4))
+    sns.violinplot(
+        data=frame,
+        x=group_key,
+        y="doublet_score",
+        inner=None,
+        color="#D6E4F0",
+        linewidth=0.8,
+        ax=ax,
+    )
+    sns.stripplot(
+        data=frame.sample(min(len(frame), 3000), random_state=0),
+        x=group_key,
+        y="doublet_score",
+        color=QC_PALETTE["counts"],
+        alpha=0.35,
+        size=2.5,
+        ax=ax,
+    )
+    ax.set_title(f"Doublet scores by {group_key}", fontsize=17, pad=14)
+    ax.set_xlabel(group_key)
+    ax.set_ylabel("Doublet score")
+    ax.tick_params(axis="x", rotation=35)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)

--- a/skills/singlecell/_lib/viz/embedding.py
+++ b/skills/singlecell/_lib/viz/embedding.py
@@ -38,6 +38,17 @@ def make_categorical_palette(values: Iterable[str]) -> dict[str, str]:
     if not unique_values:
         return {}
 
+    # Keep binary doublet-style labels visually far apart instead of relying on tab20 ordering.
+    normalized = {value.lower() for value in unique_values}
+    if normalized <= {"singlet", "doublet"} and normalized:
+        palette = {
+            "Singlet": "#2B6CB0",
+            "Doublet": "#D1495B",
+            "singlet": "#2B6CB0",
+            "doublet": "#D1495B",
+        }
+        return {value: palette.get(value, palette.get(value.lower(), "#2B6CB0")) for value in unique_values}
+
     base = sns.color_palette("tab20", min(len(unique_values), 20))
     if len(unique_values) > 20:
         extra = sns.color_palette("husl", len(unique_values))

--- a/skills/singlecell/_lib/viz/embedding.py
+++ b/skills/singlecell/_lib/viz/embedding.py
@@ -209,6 +209,69 @@ def plot_embedding_comparison(
     return save_figure(fig, output_dir, filename)
 
 
+def plot_embedding_continuous(
+    adata,
+    output_dir: Union[str, Path],
+    *,
+    obsm_key: str,
+    color_key: str,
+    filename: str,
+    title: str,
+    subtitle: str | None = None,
+    point_size: float = 11,
+    alpha: float = 0.88,
+    cmap: str = "viridis",
+) -> Path | None:
+    """Plot one embedding colored by a continuous obs column."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    output_dir = Path(output_dir)
+    if obsm_key not in adata.obsm or color_key not in adata.obs.columns:
+        logger.warning("Skipping %s because %s or %s is missing.", filename, obsm_key, color_key)
+        return None
+
+    values = pd.to_numeric(adata.obs[color_key], errors="coerce")
+    if values.isna().all():
+        logger.warning("Skipping %s because %s has no numeric values.", filename, color_key)
+        return None
+
+    apply_singlecell_theme()
+    frame = _build_embedding_frame(adata, obsm_key)
+    xcol, ycol = embedding_axis_labels(obsm_key)
+    frame[color_key] = values.to_numpy()
+    frame = frame.dropna(subset=[color_key])
+    if frame.empty:
+        logger.warning("Skipping %s because %s has no finite values.", filename, color_key)
+        return None
+
+    fig, ax = plt.subplots(figsize=(8.2, 6.4))
+    scatter = sns.scatterplot(
+        data=frame,
+        x=xcol,
+        y=ycol,
+        hue=color_key,
+        palette=cmap,
+        s=point_size,
+        linewidth=0,
+        alpha=alpha,
+        ax=ax,
+        legend=False,
+    )
+    ax.set_title(title, fontsize=17, pad=14)
+    if subtitle:
+        fig.text(0.125, 0.965, subtitle, fontsize=10, color="#4A5568", ha="left", va="top")
+    ax.set_xlabel(xcol)
+    ax.set_ylabel(ycol)
+    norm = plt.Normalize(vmin=float(frame[color_key].min()), vmax=float(frame[color_key].max()))
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax, shrink=0.82, pad=0.02)
+    cbar.set_label(color_key)
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    return save_figure(fig, output_dir, filename)
+
+
 def plot_cluster_size_summary(
     cluster_summary_df: pd.DataFrame,
     output_dir: Union[str, Path],

--- a/skills/singlecell/scrna/sc-doublet-detection/SKILL.md
+++ b/skills/singlecell/scrna/sc-doublet-detection/SKILL.md
@@ -1,148 +1,116 @@
 ---
 name: sc-doublet-detection
 description: >-
-  Detect putative doublets in single-cell RNA-seq data using Scrublet,
-  DoubletFinder, or scDblFinder. The wrapper standardizes output columns and
-  keeps the public parameter surface compact.
-version: 0.5.0
+  Annotate putative doublets in single-cell RNA-seq data using Scrublet,
+  DoubletDetection, DoubletFinder, scDblFinder, or scds. The wrapper preserves
+  the current AnnData matrix semantics, standardizes output columns in `obs`,
+  and exports a reusable figure/table gallery.
+version: 0.6.0
 author: OmicsClaw
 license: MIT
-tags: [singlecell, doublet, scrublet, doubletfinder, scdblfinder, qc]
+tags: [singlecell, doublet, scrublet, doubletdetection, doubletfinder, scdblfinder, scds, qc]
 metadata:
   omicsclaw:
     domain: singlecell
     allowed_extra_flags:
-      - "--expected-doublet-rate"
       - "--method"
+      - "--expected-doublet-rate"
       - "--threshold"
+      - "--batch-key"
+      - "--doubletdetection-n-iters"
+      - "--doubletdetection-standard-scaling"
+      - "--no-doubletdetection-standard-scaling"
+      - "--scds-mode"
     param_hints:
       scrublet:
-        priority: "expected_doublet_rate -> threshold"
-        params: ["expected_doublet_rate", "threshold"]
-        defaults: {expected_doublet_rate: 0.06}
-        requires: ["scrublet", "count_like_matrix_in_X"]
+        priority: "expected_doublet_rate -> batch_key -> threshold"
+        params: ["expected_doublet_rate", "batch_key", "threshold"]
+        defaults: {expected_doublet_rate: 0.06, threshold: auto}
+        requires: ["scrublet", "raw_count_like_input"]
         tips:
-          - "--method scrublet: Python-native default path."
-          - "--threshold: Optional manual cutoff overriding Scrublet's automatic decision boundary."
+          - "--method scrublet: default Python-native path."
+          - "--batch-key: useful when captures/samples are mixed and Scrublet should run per batch."
+          - "--threshold: manual cutoff overriding Scrublet's automatic call."
+      doubletdetection:
+        priority: "doubletdetection_n_iters"
+        params: ["doubletdetection_n_iters", "doubletdetection_standard_scaling"]
+        defaults: {doubletdetection_n_iters: 10, doubletdetection_standard_scaling: false}
+        requires: ["doubletdetection", "raw_count_like_input"]
+        tips:
+          - "--method doubletdetection: consensus Python path borrowed from SCOP's method surface."
+          - "The current wrapper records expected_doublet_rate for context, but the native DoubletDetection classifier does not use it directly."
       doubletfinder:
         priority: "expected_doublet_rate"
         params: ["expected_doublet_rate"]
         defaults: {expected_doublet_rate: 0.06}
         requires: ["R_doubletfinder_stack"]
         tips:
-          - "--method doubletfinder: R-backed path."
-          - "If the R runtime fails, the current wrapper falls back to `scdblfinder`."
+          - "--method doubletfinder: R-backed Seurat path."
+          - "If the R runtime fails, the wrapper falls back to scDblFinder and reports both methods."
       scdblfinder:
         priority: "expected_doublet_rate"
         params: ["expected_doublet_rate"]
         defaults: {expected_doublet_rate: 0.06}
         requires: ["R_scdblfinder_stack"]
         tips:
-          - "--method scdblfinder: Fast R/Bioconductor path with the cleanest current wrapper contract."
+          - "--method scdblfinder: fast Bioconductor path with a compact wrapper surface."
+      scds:
+        priority: "expected_doublet_rate -> scds_mode"
+        params: ["expected_doublet_rate", "scds_mode"]
+        defaults: {expected_doublet_rate: 0.06, scds_mode: cxds}
+        requires: ["R_scds_stack"]
+        tips:
+          - "--method scds: Bioconductor score family from SCOP."
+          - "--scds-mode chooses which score (`hybrid`, `cxds`, or `bcds`) becomes the public call surface."
+          - "In the current environment, `cxds` is the safest first-pass default."
     legacy_aliases: [sc-doublet]
     saves_h5ad: true
     requires_preprocessed: false
-    requires:
-      bins: [python3]
-      env: []
-      config: []
-    emoji: "S"
-    homepage: https://github.com/OmicsClaw/OmicsClaw
-    os: [macos, linux]
-    install:
-      - kind: pip
-        package: scrublet
-        bins: []
-    trigger_keywords:
-      - doublet detection
-      - doublet removal
-      - scrublet
-      - doubletfinder
-      - scdblfinder
 ---
 
 # Single-Cell Doublet Detection
 
 ## Why This Exists
 
-- Without it: artificial multiplets can form misleading intermediate clusters.
-- With it: cells are annotated with standardized doublet scores and labels before downstream analysis.
-- Why OmicsClaw: one wrapper normalizes three common entry paths into the same output columns.
-
-## Core Capabilities
-
-1. **Three detector backends**: Scrublet, DoubletFinder, and scDblFinder.
-2. **Shared doublet contract**: standardized score, label, and classification columns in `obs`.
-3. **Direct QC figures**: doublet histogram plus optional UMAP projection.
-4. **Compact summary export**: summary table, processed AnnData, report, and structured result JSON.
-5. **No silent removal**: the skill annotates doublets but does not automatically drop them.
+- Without it: artificial multiplets can masquerade as transitional or mixed cell states.
+- With it: cells receive standardized doublet scores and labels before final clustering, annotation, or DE interpretation.
+- Why OmicsClaw: one wrapper harmonizes multiple common backends into the same output columns and gallery layout.
 
 ## Scope Boundary
 
-Implemented methods:
+Implemented method families:
 
-1. `scrublet` - Python-native default
-2. `doubletfinder` - R-backed path
-3. `scdblfinder` - R-backed path
+1. `scrublet`
+2. `doubletdetection`
+3. `doubletfinder`
+4. `scdblfinder`
+5. `scds` (`hybrid`, `cxds`, `bcds`)
 
-The wrapper writes classification columns but does not automatically drop doublets from the AnnData object.
+This skill annotates doublets in `obs`. It does **not** silently remove cells.
 
-## Input Formats
+## Input Expectations
 
-| Format | Extension / form | Current wrapper support | Notes |
-|--------|------------------|-------------------------|-------|
-| AnnData | `.h5ad` | yes | current direct input path |
-| Demo | `--demo` | yes | bundled fallback |
-
-### Input Expectations
-
-- Expected data state: count-like matrix in `X`.
-- Useful upstream step: run this before final clustering and annotation.
-- UMAP is optional; when available or computable, the wrapper can render doublet projections on UMAP.
-
-## Workflow
-
-1. Load AnnData or demo data.
-2. Run the selected detector.
-3. Write `doublet_score`, `predicted_doublet`, and `doublet_classification` into `obs`.
-4. Export figures, summary tables, and `processed.h5ad`.
-5. Record the chosen method and thresholds in `result.json`.
-
-## CLI Reference
-
-```bash
-python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
-  --input <data.h5ad> --output <dir>
-
-python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
-  --input <data.h5ad> --method scdblfinder --output <dir>
-
-python skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py \
-  --input <data.h5ad> --method scrublet \
-  --expected-doublet-rate 0.08 --threshold 0.25 --output <dir>
-```
+- Preferred state: raw count-like input in `layers["counts"]`, aligned `adata.raw`, or count-like `adata.X`
+- Typical stage: after QC review and before final clustering / annotation / DE interpretation
+- Important nuance: if the object is already normalized, the wrapper still uses raw counts for calling and preserves the current `adata.X` semantics
 
 ## Public Parameters
 
-| Parameter | Role | Notes |
-|-----------|------|-------|
-| `--method` | detector backend | `scrublet`, `doubletfinder`, or `scdblfinder` |
-| `--expected-doublet-rate` | expected doublet prior | shared high-level control |
-| `--threshold` | manual score cutoff | used only by the Scrublet path |
+Shared controls:
 
-## Algorithm / Methodology
+- `--method`
+- `--expected-doublet-rate`
 
-Current OmicsClaw `sc-doublet-detection` always:
+Method-specific controls:
 
-1. validates the requested backend
-2. runs doublet scoring with the selected detector
-3. standardizes `doublet_score`, `predicted_doublet`, and `doublet_classification`
-4. exports figures and summary tables
-
-Important implementation notes:
-
-- `threshold` only applies to `scrublet`.
-- `doubletfinder` can fall back to `scdblfinder` if the R path fails.
+- `scrublet`
+  - `--batch-key`
+  - `--threshold`
+- `doubletdetection`
+  - `--doubletdetection-n-iters`
+  - `--doubletdetection-standard-scaling`
+- `scds`
+  - `--scds-mode`
 
 ## Output Contract
 
@@ -151,34 +119,30 @@ Successful runs write:
 - `processed.h5ad`
 - `report.md`
 - `result.json`
-- `figures/doublet_histogram.png`
-- `figures/umap_doublets.png` when a UMAP is available or can be computed
+- `figures/doublet_score_distribution.png`
+- `figures/doublet_call_summary.png`
+- `figures/embedding_doublet_calls.png` when an embedding exists or a preview embedding can be computed
+- `figures/embedding_doublet_scores.png` when an embedding exists or a preview embedding can be computed
+- `figures/embedding_doublet_vs_group.png` when a useful batch/sample grouping is available
+- `figures/doublet_score_by_group.png` when a useful grouping is available
 - `tables/summary.csv`
+- `tables/doublet_calls.csv`
+- `figure_data/`
 
-### Visualization Contract
-
-The current wrapper writes direct figure outputs rather than a recipe-driven gallery:
-
-- `figures/doublet_histogram.png`
-- `figures/umap_doublets.png` when available
-
-### What Users Should Inspect First
+## What Users Should Inspect First
 
 1. `report.md`
-2. `figures/doublet_histogram.png`
-3. `tables/summary.csv`
-4. `figures/umap_doublets.png` when available
+2. `figures/doublet_score_distribution.png`
+3. `figures/embedding_doublet_calls.png`
+4. `tables/doublet_calls.csv`
 5. `processed.h5ad`
 
-## Current Limitations
+## Guardrails
 
-- The wrapper now writes README and notebook-style reproducibility artifacts when notebook export dependencies are available.
-- `doubletfinder` can fall back to `scdblfinder` at runtime if the R path fails.
+- Explain whether `expected_doublet_rate` truly drives the selected backend.
+- `threshold` only applies to `scrublet`.
+- `batch_key` currently only affects `scrublet`.
+- If `doubletfinder` falls back to `scdblfinder`, report both the requested and executed methods.
+- After inspection, keep singlets and rerun preprocessing / clustering if the final downstream object should exclude doublets.
 
-## Safety And Guardrails
-
-- Explain both the requested method and the actually executed method when `doubletfinder` falls back to `scdblfinder`.
-- `threshold` is only a Scrublet control; do not present it as a universal cutoff knob across backends.
-- This skill annotates doublets in `obs` and does not automatically remove them.
-- For short execution guardrails, see `knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md`.
-- For longer method and interpretation guidance, see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.
+For concise execution guardrails, see `knowledge_base/knowhows/KH-sc-doublet-detection-guardrails.md`. For longer interpretation guidance, see `knowledge_base/skill-guides/singlecell/sc-doublet-detection.md`.

--- a/skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py
+++ b/skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Single-Cell Doublet Detection - Scrublet, DoubletFinder, scDblFinder."""
+"""Single-Cell Doublet Detection with shared OmicsClaw scRNA contracts."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
-import tempfile
+import shlex
 import sys
+import tempfile
 from pathlib import Path
+
 import h5py
 
 import matplotlib
+
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scanpy as sc
@@ -23,26 +26,76 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from omicsclaw.common.checksums import sha256_file
 from omicsclaw.common.report import (
-    generate_report_header,
     generate_report_footer,
+    generate_report_header,
     load_result_json,
     write_output_readme,
     write_result_json,
 )
-from skills.singlecell._lib import io as sc_io
-from skills.singlecell._lib.adata_utils import store_analysis_metadata
-from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
-from skills.singlecell._lib.preflight import apply_preflight, preflight_sc_doublet_detection
 from omicsclaw.core.dependency_manager import validate_r_environment
 from omicsclaw.core.r_script_runner import RScriptRunner
-
-from skills.singlecell._lib.viz_utils import save_figure
+from skills.singlecell._lib import dependency_manager as sc_dep_manager
+from skills.singlecell._lib import io as sc_io
+from skills.singlecell._lib import qc as sc_qc_utils
+from skills.singlecell._lib.adata_utils import (
+    ensure_input_contract,
+    get_matrix_contract,
+    infer_x_matrix_kind,
+    record_matrix_contract,
+    select_count_like_expression_source,
+    store_analysis_metadata,
+)
+from skills.singlecell._lib.export import save_h5ad
+from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from skills.singlecell._lib.preflight import (
+    _format_candidates,
+    _obs_candidates,
+    apply_preflight,
+    preflight_sc_doublet_detection,
+)
+from skills.singlecell._lib.viz import (
+    plot_doublet_call_summary,
+    plot_doublet_score_by_group,
+    plot_doublet_score_distribution,
+    plot_embedding_categorical,
+    plot_embedding_comparison,
+    plot_embedding_continuous,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 SKILL_NAME = "sc-doublet-detection"
-SKILL_VERSION = "0.4.0"
+SKILL_VERSION = "0.6.0"
+SCRIPT_REL_PATH = "skills/singlecell/scrna/sc-doublet-detection/sc_doublet.py"
+
+METHOD_REGISTRY: dict[str, MethodConfig] = {
+    "scrublet": MethodConfig(
+        name="scrublet",
+        description="Scrublet — Python-native first-pass doublet detection",
+        dependencies=("scrublet",),
+    ),
+    "doubletdetection": MethodConfig(
+        name="doubletdetection",
+        description="DoubletDetection — consensus classifier borrowed from the SCOP method surface",
+        dependencies=("doubletdetection",),
+    ),
+    "doubletfinder": MethodConfig(
+        name="doubletfinder",
+        description="DoubletFinder — R/Seurat-backed path",
+        dependencies=(),
+    ),
+    "scdblfinder": MethodConfig(
+        name="scdblfinder",
+        description="scDblFinder — fast Bioconductor path",
+        dependencies=(),
+    ),
+    "scds": MethodConfig(
+        name="scds",
+        description="scds — cxds/bcds/hybrid scores from Bioconductor",
+        dependencies=(),
+    ),
+}
 
 
 def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
@@ -71,81 +124,50 @@ def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary
         notebook_path = write_analysis_notebook(
             output_dir,
             skill_alias=SKILL_NAME,
-            description="Doublet detection and scoring for single-cell RNA-seq data.",
+            description="Single-cell doublet calling with standardized score and label outputs.",
             result_payload=result_payload,
-            preferred_method=summary.get("method", "scrublet"),
+            preferred_method=summary.get("executed_method", summary.get("method", "scrublet")),
             script_path=Path(__file__).resolve(),
             actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
         )
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         logger.warning("Failed to write analysis notebook: %s", exc)
 
     try:
         write_output_readme(
             output_dir,
             skill_alias=SKILL_NAME,
-            description="Doublet detection and scoring for single-cell RNA-seq data.",
+            description="Single-cell doublet detection with standardized score and label outputs.",
             result_payload=result_payload,
-            preferred_method=summary.get("method", "scrublet"),
+            preferred_method=summary.get("executed_method", summary.get("method", "scrublet")),
             notebook_path=notebook_path,
         )
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover
         logger.warning("Failed to write README.md: %s", exc)
-
-METHOD_REGISTRY: dict[str, MethodConfig] = {
-    "scrublet": MethodConfig(
-        name="scrublet",
-        description="Scrublet — computational doublet detection",
-        dependencies=("scrublet",),
-    ),
-    "doubletfinder": MethodConfig(
-        name="doubletfinder",
-        description="DoubletFinder — k-NN based doublet detection (R)",
-        dependencies=(),
-    ),
-    "scdblfinder": MethodConfig(
-        name="scdblfinder",
-        description="scDblFinder — fast doublet detection (R/Bioconductor)",
-        dependencies=(),
-    ),
-}
-
-
-def _matrix_looks_count_like(matrix) -> bool:
-    sample = matrix
-    if hasattr(sample, "toarray"):
-        sample = sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])].toarray()
-    else:
-        sample = np.asarray(sample[: min(200, sample.shape[0]), : min(200, sample.shape[1])])
-    if sample.size == 0:
-        return True
-    if np.nanmin(sample) < 0:
-        return False
-    frac_integer = float(np.mean(np.isclose(sample, np.round(sample), atol=1e-6)))
-    return frac_integer > 0.98
-
-
-def _get_count_like_matrix(adata):
-    if "counts" in adata.layers:
-        return adata.layers["counts"], "layers.counts"
-    if _matrix_looks_count_like(adata.X):
-        return adata.X, "adata.X"
-    raise ValueError("Doublet detection requires raw count-like input; provide adata.layers['counts'] or count-like adata.X")
 
 
 def _build_count_like_export_adata(adata):
-    matrix, source = _get_count_like_matrix(adata)
+    matrix, source, warnings = select_count_like_expression_source(adata, preferred_layer="counts")
     export = sc.AnnData(X=matrix.copy(), obs=adata.obs.copy(), var=adata.var.copy())
     export.obs_names = adata.obs_names.copy()
     export.var_names = adata.var_names.copy()
-    return export, source
+    return export, source, warnings
 
 
-def _run_r_doublet_script(adata, *, script_name: str, output_csv: str, expected_doublet_rate: float, required_packages: list[str]):
+def _run_r_doublet_script(
+    adata,
+    *,
+    script_name: str,
+    output_csv: str,
+    required_packages: list[str],
+    expected_doublet_rate: float,
+    extra_args: list[str] | None = None,
+):
     validate_r_environment(required_r_packages=required_packages)
     scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
     runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
-    export, source = _build_count_like_export_adata(adata)
+    export, source, _ = _build_count_like_export_adata(adata)
+
     with tempfile.TemporaryDirectory(prefix="omicsclaw_doublet_r_") as tmpdir:
         tmpdir = Path(tmpdir)
         input_h5ad = tmpdir / "input.h5ad"
@@ -157,77 +179,158 @@ def _run_r_doublet_script(adata, *, script_name: str, output_csv: str, expected_
                 del handle["layers"]
         runner.run_script(
             script_name,
-            args=[str(input_h5ad), str(output_dir), str(expected_doublet_rate)],
+            args=[str(input_h5ad), str(output_dir), str(expected_doublet_rate), *(extra_args or [])],
             expected_outputs=[output_csv],
             output_dir=output_dir,
         )
         df = pd.read_csv(output_dir / output_csv, index_col=0)
+
     return df, source
 
 
-def run_doubletfinder(adata, expected_doublet_rate=0.06):
-    df, _ = _run_r_doublet_script(
+def run_doubletfinder(adata, *, expected_doublet_rate: float):
+    return _run_r_doublet_script(
         adata,
         script_name="sc_doubletfinder.R",
         output_csv="doubletfinder_results.csv",
         expected_doublet_rate=expected_doublet_rate,
         required_packages=["Seurat", "DoubletFinder", "SingleCellExperiment", "zellkonverter"],
     )
-    return df
 
 
-def run_scdblfinder(adata, expected_doublet_rate=0.06):
-    df, _ = _run_r_doublet_script(
+def run_scdblfinder(adata, *, expected_doublet_rate: float):
+    return _run_r_doublet_script(
         adata,
         script_name="sc_scdblfinder.R",
         output_csv="scdblfinder_results.csv",
         expected_doublet_rate=expected_doublet_rate,
         required_packages=["scDblFinder", "SingleCellExperiment", "zellkonverter"],
     )
-    return df
 
 
-def detect_doublets_scrublet(adata, expected_doublet_rate=0.06, threshold=None):
-    import scrublet as scr
+def _normalize_r_result(result, *, fallback_source: str = "unknown") -> tuple[pd.DataFrame, str]:
+    """Accept either ``df`` or ``(df, source)`` from R-wrapper helpers."""
+    if isinstance(result, tuple) and len(result) == 2:
+        df, source = result
+        return df, str(source)
+    return result, fallback_source
 
-    counts_matrix, source = _get_count_like_matrix(adata)
-    logger.info("Running Scrublet (expected_rate=%s, source=%s)", expected_doublet_rate, source)
-    scrub = scr.Scrublet(counts_matrix, expected_doublet_rate=expected_doublet_rate)
-    doublet_scores, predicted_doublets = scrub.scrub_doublets(
-        min_counts=2, min_cells=3, min_gene_variability_pctl=85, n_prin_comps=30
+
+def run_scds(adata, *, expected_doublet_rate: float, mode: str):
+    return _run_r_doublet_script(
+        adata,
+        script_name="sc_scds.R",
+        output_csv="scds_results.csv",
+        expected_doublet_rate=expected_doublet_rate,
+        required_packages=["scds", "SingleCellExperiment", "zellkonverter"],
+        extra_args=[mode],
     )
-    adata.obs["doublet_score"] = doublet_scores
-    adata.obs["predicted_doublet"] = predicted_doublets
-    adata.obs["doublet_classification"] = np.where(predicted_doublets, "Doublet", "Singlet")
 
+
+def _copy_doublet_columns(source_adata, target_adata) -> None:
+    for key in ("doublet_score", "predicted_doublet", "doublet_classification"):
+        if key in source_adata.obs.columns:
+            target_adata.obs[key] = source_adata.obs[key].values
+
+
+def detect_doublets_scrublet(
+    adata,
+    *,
+    expected_doublet_rate: float,
+    threshold: float | None,
+    batch_key: str | None,
+) -> dict:
+    export, expression_source, _ = _build_count_like_export_adata(adata)
+    export = sc_qc_utils.run_scrublet_detection(
+        export,
+        batch_key=batch_key,
+        expected_doublet_rate=expected_doublet_rate,
+        auto_rate=False,
+    )
+    export.obs["doublet_classification"] = np.where(export.obs["predicted_doublet"], "Doublet", "Singlet")
     if threshold is not None:
-        adata.obs["predicted_doublet"] = adata.obs["doublet_score"] > threshold
-        adata.obs["doublet_classification"] = np.where(adata.obs["predicted_doublet"], "Doublet", "Singlet")
+        export.obs["predicted_doublet"] = export.obs["doublet_score"] > threshold
+        export.obs["doublet_classification"] = np.where(export.obs["predicted_doublet"], "Doublet", "Singlet")
 
+    _copy_doublet_columns(export, adata)
     n_doublets = int(adata.obs["predicted_doublet"].sum())
     return {
         "method": "scrublet",
+        "requested_method": "scrublet",
+        "executed_method": "scrublet",
+        "fallback_used": False,
+        "fallback_reason": None,
         "n_doublets": n_doublets,
-        "doublet_rate": float(n_doublets / adata.n_obs),
+        "doublet_rate": float(n_doublets / max(adata.n_obs, 1)),
         "expected_rate": expected_doublet_rate,
-        "expression_source": source,
+        "expression_source": expression_source,
+        "batch_key": batch_key,
     }
 
 
-def detect_doublets_doubletfinder(adata, expected_doublet_rate=0.06):
+def detect_doublets_doubletdetection(
+    adata,
+    *,
+    n_iters: int,
+    standard_scaling: bool,
+) -> dict:
+    doubletdetection = sc_dep_manager.require("doubletdetection", feature="doublet detection")
+    export, expression_source, _ = _build_count_like_export_adata(adata)
+    clf = doubletdetection.BoostClassifier(
+        n_iters=n_iters,
+        clustering_algorithm="leiden",
+        standard_scaling=standard_scaling,
+        random_state=0,
+        verbose=False,
+        n_jobs=1,
+    )
+    clf_fit = clf.fit(export.X)
+    scores = np.asarray(clf_fit.doublet_score()).ravel()
+    labels = np.asarray(clf_fit.predict()).ravel()
+    predicted = labels.astype(int) != 0
+
+    adata.obs["doublet_score"] = scores
+    adata.obs["predicted_doublet"] = predicted
+    adata.obs["doublet_classification"] = np.where(predicted, "Doublet", "Singlet")
+    n_doublets = int(predicted.sum())
+    return {
+        "method": "doubletdetection",
+        "requested_method": "doubletdetection",
+        "executed_method": "doubletdetection",
+        "fallback_used": False,
+        "fallback_reason": None,
+        "n_doublets": n_doublets,
+        "doublet_rate": float(n_doublets / max(adata.n_obs, 1)),
+        "expression_source": expression_source,
+    }
+
+
+def _apply_r_results(adata, df: pd.DataFrame) -> None:
+    df = df.reindex(adata.obs_names)
+    adata.obs["doublet_score"] = pd.to_numeric(df["doublet_score"], errors="coerce").values
+    classification = df["classification"].fillna("Singlet").astype(str).str.strip()
+    adata.obs["doublet_classification"] = classification.str.capitalize().values
+    adata.obs["predicted_doublet"] = df["predicted_doublet"].fillna(False).astype(bool).values
+
+
+def detect_doublets_doubletfinder(adata, *, expected_doublet_rate: float) -> dict:
     try:
-        df = run_doubletfinder(adata, expected_doublet_rate=expected_doublet_rate)
+        df, expression_source = _normalize_r_result(
+            run_doubletfinder(adata, expected_doublet_rate=expected_doublet_rate),
+            fallback_source="unknown",
+        )
         executed_method = "doubletfinder"
         fallback_reason = None
     except Exception as exc:
         logger.warning("DoubletFinder runtime failed (%s). Falling back to scDblFinder.", exc)
-        df = run_scdblfinder(adata, expected_doublet_rate=expected_doublet_rate)
+        df, expression_source = _normalize_r_result(
+            run_scdblfinder(adata, expected_doublet_rate=expected_doublet_rate),
+            fallback_source="unknown",
+        )
         executed_method = "scdblfinder"
         fallback_reason = f"DoubletFinder runtime failed and wrapper fell back to scDblFinder: {exc}"
-    df = df.reindex(adata.obs_names)
-    adata.obs["doublet_score"] = pd.to_numeric(df["doublet_score"], errors="coerce").values
-    adata.obs["doublet_classification"] = df["classification"].fillna("Singlet").astype(str).values
-    adata.obs["predicted_doublet"] = df["predicted_doublet"].fillna(False).astype(bool).values
+
+    _apply_r_results(adata, df)
     n_doublets = int(adata.obs["predicted_doublet"].sum())
     return {
         "method": executed_method,
@@ -236,115 +339,491 @@ def detect_doublets_doubletfinder(adata, expected_doublet_rate=0.06):
         "fallback_used": fallback_reason is not None,
         "fallback_reason": fallback_reason,
         "n_doublets": n_doublets,
-        "doublet_rate": float(n_doublets / adata.n_obs),
+        "doublet_rate": float(n_doublets / max(adata.n_obs, 1)),
         "expected_rate": expected_doublet_rate,
+        "expression_source": expression_source,
     }
 
 
-def detect_doublets_scdblfinder(adata, expected_doublet_rate=0.06):
-    df = run_scdblfinder(adata, expected_doublet_rate=expected_doublet_rate)
-    df = df.reindex(adata.obs_names)
-    adata.obs["doublet_score"] = pd.to_numeric(df["doublet_score"], errors="coerce").values
-    adata.obs["doublet_classification"] = df["classification"].fillna("singlet").astype(str).values
-    adata.obs["predicted_doublet"] = df["predicted_doublet"].fillna(False).astype(bool).values
+def detect_doublets_scdblfinder(adata, *, expected_doublet_rate: float) -> dict:
+    df, expression_source = _normalize_r_result(
+        run_scdblfinder(adata, expected_doublet_rate=expected_doublet_rate),
+        fallback_source="unknown",
+    )
+    _apply_r_results(adata, df)
     n_doublets = int(adata.obs["predicted_doublet"].sum())
     return {
         "method": "scdblfinder",
+        "requested_method": "scdblfinder",
+        "executed_method": "scdblfinder",
+        "fallback_used": False,
+        "fallback_reason": None,
         "n_doublets": n_doublets,
-        "doublet_rate": float(n_doublets / adata.n_obs),
+        "doublet_rate": float(n_doublets / max(adata.n_obs, 1)),
         "expected_rate": expected_doublet_rate,
+        "expression_source": expression_source,
     }
 
 
-_METHOD_DISPATCH = {
-    "scrublet": lambda adata, args: detect_doublets_scrublet(adata, args.expected_doublet_rate, args.threshold),
-    "doubletfinder": lambda adata, args: detect_doublets_doubletfinder(adata, args.expected_doublet_rate),
-    "scdblfinder": lambda adata, args: detect_doublets_scdblfinder(adata, args.expected_doublet_rate),
-}
-
-
-def generate_figures(adata, output_dir: Path) -> list[str]:
-    figures = []
+def detect_doublets_scds(adata, *, expected_doublet_rate: float, mode: str) -> dict:
+    requested_mode = str(mode)
+    executed_mode = requested_mode
+    fallback_reason = None
     try:
-        fig, ax = plt.subplots(figsize=(8, 5))
-        ax.hist(adata.obs["doublet_score"].dropna(), bins=50, edgecolor="black")
-        ax.set_xlabel("Doublet Score")
-        ax.set_ylabel("Count")
-        ax.set_title("Doublet Score Distribution")
-        p = save_figure(fig, output_dir, "doublet_histogram.png")
-        figures.append(str(p))
-        plt.close()
+        df, expression_source = _normalize_r_result(
+            run_scds(adata, expected_doublet_rate=expected_doublet_rate, mode=requested_mode),
+            fallback_source="unknown",
+        )
     except Exception as exc:
-        logger.warning("Doublet histogram failed: %s", exc)
+        if requested_mode == "cxds":
+            raise
+        logger.warning("scds runtime failed for mode=%s (%s). Falling back to cxds.", requested_mode, exc)
+        df, expression_source = _normalize_r_result(
+            run_scds(adata, expected_doublet_rate=expected_doublet_rate, mode="cxds"),
+            fallback_source="unknown",
+        )
+        executed_mode = "cxds"
+        fallback_reason = f"scds mode `{requested_mode}` failed and wrapper fell back to `cxds`: {exc}"
+    _apply_r_results(adata, df)
+    n_doublets = int(adata.obs["predicted_doublet"].sum())
+    return {
+        "method": "scds",
+        "requested_method": "scds",
+        "executed_method": "scds",
+        "fallback_used": fallback_reason is not None,
+        "fallback_reason": fallback_reason,
+        "n_doublets": n_doublets,
+        "doublet_rate": float(n_doublets / max(adata.n_obs, 1)),
+        "expected_rate": expected_doublet_rate,
+        "expression_source": expression_source,
+        "requested_scds_mode": requested_mode,
+        "executed_scds_mode": executed_mode,
+    }
 
-    if "X_umap" not in adata.obsm:
-        try:
-            sc.pp.neighbors(adata)
-            sc.tl.umap(adata)
-        except Exception as exc:
-            logger.warning("UMAP computation failed: %s", exc)
 
-    if "X_umap" in adata.obsm:
-        try:
-            sc.pl.umap(adata, color="predicted_doublet", show=False)
-            p = save_figure(plt.gcf(), output_dir, "umap_doublets.png")
-            figures.append(str(p))
-            plt.close()
-        except Exception as exc:
-            logger.warning("UMAP doublet plot failed: %s", exc)
-    return figures
+def _candidate_embeddings(adata) -> list[str]:
+    preferred = [key for key in ("X_umap", "X_tsne", "X_phate", "X_diffmap", "X_pca") if key in adata.obsm]
+    if preferred:
+        return preferred
+    return [str(key) for key in adata.obsm.keys() if str(key).startswith("X_")]
 
 
-def write_report(output_dir: Path, summary: dict, input_file: str | None, params: dict) -> None:
-    requested_method = str(summary.get("requested_method", params.get("method", summary["method"])))
-    executed_method = str(summary.get("executed_method", summary["method"]))
+def _resolve_compare_key(adata, batch_key: str | None) -> str | None:
+    if batch_key and batch_key in adata.obs.columns:
+        if adata.obs[batch_key].astype(str).nunique(dropna=False) > 1:
+            return batch_key
+        return None
+    candidates = _obs_candidates(adata, "batch") or _obs_candidates(adata, "condition")
+    for candidate in candidates:
+        if candidate in adata.obs.columns and adata.obs[candidate].astype(str).nunique(dropna=False) > 1:
+            return candidate
+    return None
+
+
+def _build_preview_embedding(adata):
+    preview, _, _ = _build_count_like_export_adata(adata)
+    for column in ("doublet_score", "predicted_doublet", "doublet_classification"):
+        if column in adata.obs.columns:
+            preview.obs[column] = adata.obs[column].values
+
+    sc.pp.normalize_total(preview, target_sum=1e4)
+    sc.pp.log1p(preview)
+    if preview.n_vars > 2000:
+        sc.pp.highly_variable_genes(preview, n_top_genes=min(2000, preview.n_vars), flavor="seurat")
+        if "highly_variable" in preview.var.columns and int(preview.var["highly_variable"].sum()) >= 50:
+            preview = preview[:, preview.var["highly_variable"]].copy()
+
+    n_comps = min(30, max(2, preview.n_obs - 1), max(2, preview.n_vars - 1))
+    sc.tl.pca(preview, n_comps=n_comps)
+    sc.pp.neighbors(preview, n_neighbors=min(15, max(2, preview.n_obs - 1)), n_pcs=min(n_comps, preview.obsm["X_pca"].shape[1]))
+    sc.tl.umap(preview)
+    return preview, "X_umap", "Preview UMAP computed from raw counts for visualization only."
+
+
+def _prepare_visualization_adata(adata):
+    candidates = _candidate_embeddings(adata)
+    if candidates:
+        return adata, candidates[0], None
+    try:
+        return _build_preview_embedding(adata)
+    except Exception as exc:
+        logger.warning("Preview embedding computation failed: %s", exc)
+        return adata, None, None
+
+
+def _build_doublet_summary_table(summary: dict) -> pd.DataFrame:
+    n_cells = max(int(summary["n_cells"]), 1)
+    n_doublets = int(summary["n_doublets"])
+    n_singlets = int(n_cells - n_doublets)
+    frame = pd.DataFrame(
+        [
+            {"classification": "Singlet", "n_cells": n_singlets, "proportion_pct": 100.0 * n_singlets / n_cells},
+            {"classification": "Doublet", "n_cells": n_doublets, "proportion_pct": 100.0 * n_doublets / n_cells},
+        ]
+    )
+    return frame
+
+
+def _build_doublet_calls_table(adata, compare_key: str | None = None) -> pd.DataFrame:
+    frame = pd.DataFrame(
+        {
+            "cell_id": adata.obs_names.astype(str),
+            "doublet_score": pd.to_numeric(adata.obs["doublet_score"], errors="coerce").to_numpy(),
+            "predicted_doublet": adata.obs["predicted_doublet"].astype(bool).to_numpy(),
+            "doublet_classification": adata.obs["doublet_classification"].astype(str).to_numpy(),
+        }
+    )
+    if compare_key and compare_key in adata.obs.columns:
+        frame[compare_key] = adata.obs[compare_key].astype(str).to_numpy()
+    return frame
+
+
+def _build_group_summary_table(calls_df: pd.DataFrame, compare_key: str | None) -> pd.DataFrame:
+    if not compare_key or compare_key not in calls_df.columns:
+        return pd.DataFrame()
+    grouped = (
+        calls_df.groupby(compare_key, dropna=False)
+        .agg(
+            n_cells=("cell_id", "count"),
+            n_doublets=("predicted_doublet", "sum"),
+            median_score=("doublet_score", "median"),
+            mean_score=("doublet_score", "mean"),
+        )
+        .reset_index()
+    )
+    grouped["doublet_rate_pct"] = 100.0 * grouped["n_doublets"] / grouped["n_cells"].clip(lower=1)
+    return grouped
+
+
+def _build_embedding_points_table(adata, embedding_key: str, extra_obs: list[str] | None = None) -> pd.DataFrame:
+    coords = np.asarray(adata.obsm[embedding_key])
+    if coords.shape[1] < 2:
+        raise ValueError(f"{embedding_key} has fewer than 2 columns.")
+    frame = pd.DataFrame(
+        {
+            "cell_id": adata.obs_names.astype(str),
+            "dim1": coords[:, 0],
+            "dim2": coords[:, 1],
+        }
+    )
+    for key in extra_obs or []:
+        if key in adata.obs.columns:
+            frame[key] = adata.obs[key].to_numpy()
+    return frame
+
+
+def _write_figure_data(output_dir: Path, *, calls_df: pd.DataFrame, summary_df: pd.DataFrame, group_df: pd.DataFrame, embedding_df: pd.DataFrame | None) -> dict[str, str]:
+    figure_data_dir = output_dir / "figure_data"
+    figure_data_dir.mkdir(parents=True, exist_ok=True)
+    files = {
+        "doublet_calls": "doublet_calls.csv",
+        "doublet_summary": "doublet_summary.csv",
+    }
+    calls_df.to_csv(figure_data_dir / files["doublet_calls"], index=False)
+    summary_df.to_csv(figure_data_dir / files["doublet_summary"], index=False)
+    if not group_df.empty:
+        files["group_summary"] = "group_summary.csv"
+        group_df.to_csv(figure_data_dir / files["group_summary"], index=False)
+    if embedding_df is not None and not embedding_df.empty:
+        files["embedding_points"] = "embedding_points.csv"
+        embedding_df.to_csv(figure_data_dir / files["embedding_points"], index=False)
+    (figure_data_dir / "manifest.json").write_text(
+        json.dumps({"skill": SKILL_NAME, "available_files": files}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return files
+
+
+def generate_figures(
+    adata,
+    output_dir: Path,
+    *,
+    summary: dict,
+    params: dict,
+    compare_key: str | None,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    figures_dir = output_dir / "figures"
+    figures_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_df = _build_doublet_summary_table(summary)
+    calls_df = _build_doublet_calls_table(adata, compare_key=compare_key)
+    group_df = _build_group_summary_table(calls_df, compare_key)
+
+    plot_doublet_score_distribution(
+        adata.obs["doublet_score"],
+        output_dir,
+        threshold=params.get("threshold"),
+        expected_rate=summary.get("expected_rate"),
+    )
+    plot_doublet_call_summary(summary_df, output_dir)
+
+    viz_adata, embedding_key, preview_note = _prepare_visualization_adata(adata)
+    embedding_df = None
+    if embedding_key:
+        plot_embedding_categorical(
+            viz_adata,
+            output_dir,
+            obsm_key=embedding_key,
+            color_key="doublet_classification",
+            filename="embedding_doublet_calls.png",
+            title="Doublet classification on embedding",
+            subtitle=f"Embedding: {embedding_key}",
+            legend=True,
+            label_on_data=False,
+        )
+        plot_embedding_continuous(
+            viz_adata,
+            output_dir,
+            obsm_key=embedding_key,
+            color_key="doublet_score",
+            filename="embedding_doublet_scores.png",
+            title="Doublet score on embedding",
+            subtitle=f"Embedding: {embedding_key}",
+            cmap="mako",
+        )
+        if compare_key and compare_key in viz_adata.obs.columns and compare_key != "doublet_classification":
+            plot_embedding_comparison(
+                viz_adata,
+                output_dir,
+                obsm_key=embedding_key,
+                color_keys=["doublet_classification", compare_key],
+                filename="embedding_doublet_vs_group.png",
+                title="Doublet calls versus grouping context",
+            )
+        embedding_df = _build_embedding_points_table(
+            viz_adata,
+            embedding_key,
+            extra_obs=["doublet_classification", "doublet_score", compare_key] if compare_key else ["doublet_classification", "doublet_score"],
+        )
+    if compare_key:
+        plot_doublet_score_by_group(calls_df, output_dir, group_key=compare_key)
+
+    figure_data_files = _write_figure_data(
+        output_dir,
+        calls_df=calls_df,
+        summary_df=summary_df,
+        group_df=group_df,
+        embedding_df=embedding_df,
+    )
+    return {
+        "summary_df": summary_df,
+        "calls_df": calls_df,
+        "group_df": group_df,
+        "embedding_df": embedding_df,
+        "embedding_key": embedding_key,
+        "preview_note": preview_note,
+        "figure_data_files": figure_data_files,
+    }
+
+
+def _write_tables(output_dir: Path, gallery_context: dict[str, object]) -> None:
+    tables_dir = output_dir / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    gallery_context["summary_df"].to_csv(tables_dir / "summary.csv", index=False)
+    gallery_context["calls_df"].to_csv(tables_dir / "doublet_calls.csv", index=False)
+    group_df = gallery_context["group_df"]
+    if isinstance(group_df, pd.DataFrame) and not group_df.empty:
+        group_df.to_csv(tables_dir / "group_summary.csv", index=False)
+
+
+def write_report(output_dir: Path, summary: dict, params: dict, input_file: str | None, *, gallery_context: dict[str, object]) -> None:
     header = generate_report_header(
-        title="Doublet Detection Report",
+        title="Single-Cell Doublet Detection Report",
         skill_name=SKILL_NAME,
         input_files=[Path(input_file)] if input_file else None,
         extra_metadata={
-            "Method": executed_method,
+            "Requested method": str(summary["requested_method"]),
+            "Executed method": str(summary["executed_method"]),
             "Doublets detected": str(summary["n_doublets"]),
-            "Doublet rate": f"{summary['doublet_rate']*100:.2f}%",
+            "Doublet rate": f"{summary['doublet_rate'] * 100:.2f}%",
         },
     )
-    body_lines = [
+    lines = [
         "## Summary\n",
-        f"- **Requested method**: {requested_method}",
-        f"- **Executed method**: {executed_method}",
-        f"- **Total cells**: {summary.get('n_cells', 'N/A')}",
+        f"- **Requested method**: `{summary['requested_method']}`",
+        f"- **Executed method**: `{summary['executed_method']}`",
+        f"- **Cells**: {summary['n_cells']}",
         f"- **Doublets detected**: {summary['n_doublets']}",
-        f"- **Doublet rate**: {summary['doublet_rate']*100:.2f}%",
-        f"- **Expected rate**: {summary.get('expected_rate', 0)*100:.2f}%",
-        "",
-        "## Parameters\n",
+        f"- **Doublet rate**: {summary['doublet_rate'] * 100:.2f}%",
     ]
+    if summary.get("expected_rate") is not None:
+        lines.append(f"- **Expected doublet rate**: {summary['expected_rate'] * 100:.2f}%")
     if summary.get("fallback_reason"):
-        body_lines.insert(7, f"- **Fallback note**: {summary['fallback_reason']}")
-    for k, v in params.items():
-        body_lines.append(f"- `{k}`: {v}")
-    footer = generate_report_footer()
-    (output_dir / "report.md").write_text(header + "\n".join(body_lines) + "\n" + footer)
+        lines.append(f"- **Fallback note**: {summary['fallback_reason']}")
+    if summary.get("expression_source"):
+        lines.append(f"- **Raw-count source used for calling**: `{summary['expression_source']}`")
 
-    tables_dir = output_dir / "tables"
-    tables_dir.mkdir(exist_ok=True)
-    pd.DataFrame([
-        {"metric": "doublets_detected", "value": summary["n_doublets"]},
-        {"metric": "doublet_rate", "value": summary["doublet_rate"]},
-    ]).to_csv(tables_dir / "summary.csv", index=False)
+    lines.extend(
+        [
+            "",
+            "## First-pass Settings\n",
+            f"- `method`: {params['method']}",
+        ]
+    )
+    if "expected_doublet_rate" in params:
+        lines.append(f"- `expected_doublet_rate`: {params.get('expected_doublet_rate')}")
+    if params["method"] == "scrublet":
+        lines.append(f"- `threshold`: {params.get('threshold') if params.get('threshold') is not None else 'auto'}")
+        if params.get("batch_key"):
+            lines.append(f"- `batch_key`: {params['batch_key']}")
+    elif params["method"] == "doubletdetection":
+        lines.append(f"- `doubletdetection_n_iters`: {params['doubletdetection_n_iters']}")
+        lines.append(f"- `doubletdetection_standard_scaling`: {params['doubletdetection_standard_scaling']}")
+    elif params["method"] == "scds":
+        lines.append(f"- `scds_mode`: {params['scds_mode']}")
+        if params.get("executed_scds_mode") and params["executed_scds_mode"] != params["scds_mode"]:
+            lines.append(f"- `executed_scds_mode`: {params['executed_scds_mode']}")
 
+    lines.extend(
+        [
+            "",
+            "## Beginner Notes\n",
+            "- Doublet detection usually belongs after QC review and before final clustering, annotation, or DE interpretation.",
+            "- This skill **annotates** doublets; it does not silently remove cells.",
+            "- If the calls look credible, keep singlets and rerun preprocessing / clustering as needed for the final downstream object.",
+        ]
+    )
+    if gallery_context.get("preview_note"):
+        lines.append(f"- {gallery_context['preview_note']}")
+
+    lines.extend(
+        [
+            "",
+            "## Recommended Next Steps\n",
+            "- Inspect `figures/doublet_score_distribution.png` and `tables/doublet_calls.csv` first.",
+            "- If many high-scoring cells cluster together, keep only singlets before final clustering or annotation.",
+            "- After doublet review, common next steps are `sc-preprocessing`, `sc-clustering`, `sc-cell-annotation`, or `sc-de` depending on your stage.",
+            "",
+            "## Output Files\n",
+            "- `processed.h5ad` — input AnnData plus standardized doublet score / label columns in `obs`.",
+            "- `figures/` — doublet gallery (distribution, embedding calls, score map, optional group comparison).",
+            "- `tables/doublet_calls.csv` — per-cell scores and calls for downstream filtering.",
+            "- `figure_data/` — reusable figure-ready tables and coordinates.",
+        ]
+    )
+    report = header + "\n".join(lines) + "\n" + generate_report_footer()
+    (output_dir / "report.md").write_text(report, encoding="utf-8")
+
+
+def write_reproducibility(output_dir: Path, params: dict, input_file: str | None, *, demo_mode: bool = False) -> None:
     repro_dir = output_dir / "reproducibility"
     repro_dir.mkdir(exist_ok=True)
-    cmd = f"python sc_doublet.py --input <input.h5ad> --output {output_dir}"
-    cmd += f" --method {params['method']}"
-    cmd += f" --expected-doublet-rate {params['expected_doublet_rate']}"
-    if params.get("threshold") is not None:
-        cmd += f" --threshold {params['threshold']}"
-    (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    command_parts = ["python", SCRIPT_REL_PATH]
+    if demo_mode:
+        command_parts.append("--demo")
+    elif input_file:
+        command_parts.extend(["--input", input_file])
+    else:
+        command_parts.extend(["--input", "<input.h5ad>"])
+    command_parts.extend(["--output", str(output_dir)])
+    cli_keys = (
+        "method",
+        "expected_doublet_rate",
+        "threshold",
+        "batch_key",
+        "doubletdetection_n_iters",
+        "doubletdetection_standard_scaling",
+        "scds_mode",
+    )
+    for key in cli_keys:
+        value = params.get(key)
+        flag = f"--{key.replace('_', '-')}"
+        if isinstance(value, bool):
+            if key == "doubletdetection_standard_scaling":
+                command_parts.append(flag if value else "--no-doubletdetection-standard-scaling")
+            continue
+        if value not in (None, ""):
+            command_parts.extend([flag, str(value)])
+    command = " ".join(shlex.quote(part) for part in command_parts)
+    (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{command}\n", encoding="utf-8")
     _write_repro_requirements(
         repro_dir,
-        ["scanpy", "anndata", "numpy", "pandas", "matplotlib"],
+        ["scanpy", "anndata", "numpy", "pandas", "matplotlib", "scrublet", "doubletdetection"],
     )
+
+
+def _ensure_output_contract(adata, *, source_path: str | None) -> tuple[dict, dict]:
+    input_contract = ensure_input_contract(adata, source_path=source_path)
+    existing = get_matrix_contract(adata)
+    x_kind = existing.get("X") or infer_x_matrix_kind(adata)
+    layers = dict(existing.get("layers") or {})
+
+    try:
+        matrix, _, _ = select_count_like_expression_source(adata, preferred_layer="counts")
+        if "counts" not in adata.layers:
+            adata.layers["counts"] = matrix.copy()
+        if adata.raw is None:
+            raw_snapshot = sc.AnnData(X=matrix.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+            raw_snapshot.obs_names = adata.obs_names.copy()
+            raw_snapshot.var_names = adata.var_names.copy()
+            adata.raw = raw_snapshot
+        layers["counts"] = "raw_counts"
+        raw_kind = "raw_counts_snapshot"
+    except Exception:
+        raw_kind = existing.get("raw")
+
+    matrix_contract = record_matrix_contract(
+        adata,
+        x_kind=x_kind,
+        raw_kind=raw_kind,
+        layers=layers,
+        producer_skill=SKILL_NAME,
+        preprocess_method=existing.get("preprocess_method"),
+        primary_cluster_key=existing.get("primary_cluster_key"),
+    )
+    return input_contract, matrix_contract
+
+
+def _build_public_params(args, method: str, summary: dict) -> dict:
+    params = {
+        "method": method,
+        "requested_method": summary["requested_method"],
+        "executed_method": summary["executed_method"],
+    }
+    if method in {"scrublet", "doubletfinder", "scdblfinder", "scds"}:
+        params["expected_doublet_rate"] = args.expected_doublet_rate
+    if method == "scrublet":
+        params["threshold"] = args.threshold
+        if args.batch_key:
+            params["batch_key"] = args.batch_key
+    elif method == "doubletdetection":
+        params["doubletdetection_n_iters"] = args.doubletdetection_n_iters
+        params["doubletdetection_standard_scaling"] = bool(args.doubletdetection_standard_scaling)
+    elif method == "scds":
+        params["scds_mode"] = args.scds_mode
+        params["executed_scds_mode"] = summary.get("executed_scds_mode", args.scds_mode)
+    if summary.get("fallback_reason"):
+        params["fallback_reason"] = summary["fallback_reason"]
+    return params
+
+
+def _dispatch_detection(adata, args, method: str) -> dict:
+    if method == "scrublet":
+        return detect_doublets_scrublet(
+            adata,
+            expected_doublet_rate=args.expected_doublet_rate,
+            threshold=args.threshold,
+            batch_key=args.batch_key,
+        )
+    if method == "doubletdetection":
+        return detect_doublets_doubletdetection(
+            adata,
+            n_iters=args.doubletdetection_n_iters,
+            standard_scaling=bool(args.doubletdetection_standard_scaling),
+        )
+    if method == "doubletfinder":
+        return detect_doublets_doubletfinder(adata, expected_doublet_rate=args.expected_doublet_rate)
+    if method == "scdblfinder":
+        return detect_doublets_scdblfinder(adata, expected_doublet_rate=args.expected_doublet_rate)
+    if method == "scds":
+        return detect_doublets_scds(adata, expected_doublet_rate=args.expected_doublet_rate, mode=args.scds_mode)
+    raise ValueError(f"Unsupported method: {method}")
+
+
+def get_demo_data():
+    adata, _ = sc_io.load_repo_demo_data("pbmc3k_raw")
+    return adata
 
 
 def main():
@@ -355,19 +834,26 @@ def main():
     parser.add_argument("--method", choices=list(METHOD_REGISTRY.keys()), default="scrublet")
     parser.add_argument("--expected-doublet-rate", type=float, default=0.06)
     parser.add_argument("--threshold", type=float, default=None)
+    parser.add_argument("--batch-key", default=None)
+    parser.add_argument("--doubletdetection-n-iters", type=int, default=10)
+    parser.add_argument(
+        "--doubletdetection-standard-scaling",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument("--scds-mode", choices=["hybrid", "cxds", "bcds"], default="cxds")
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.demo:
-        adata = sc_io.load_repo_demo_data("pbmc3k_raw")[0]
+        adata = get_demo_data()
         input_file = None
     else:
         if not args.input_path:
             raise ValueError("--input required when not using --demo")
-        adata = sc.read_h5ad(args.input_path)
-        sc_io.maybe_warn_standardize_first(adata, source_path=args.input_path, skill_name=SKILL_NAME)
+        adata = sc_io.smart_load(args.input_path, preserve_all=True, skill_name=SKILL_NAME)
         input_file = args.input_path
 
     logger.info("Input: %d cells x %d genes", adata.n_obs, adata.n_vars)
@@ -378,33 +864,31 @@ def main():
             method=method,
             expected_doublet_rate=args.expected_doublet_rate,
             threshold=args.threshold,
+            batch_key=args.batch_key,
+            doubletdetection_n_iters=args.doubletdetection_n_iters,
+            scds_mode=args.scds_mode,
             source_path=input_file,
         ),
         logger,
     )
-    summary = _METHOD_DISPATCH[method](adata, args)
+
+    summary = _dispatch_detection(adata, args, method)
     summary.setdefault("requested_method", method)
     summary.setdefault("executed_method", summary.get("method", method))
     summary.setdefault("fallback_used", summary["requested_method"] != summary["executed_method"])
     summary["n_cells"] = int(adata.n_obs)
 
-    params = {
-        "method": method,
-        "requested_method": summary["requested_method"],
-        "executed_method": summary["executed_method"],
-        "expected_doublet_rate": args.expected_doublet_rate,
-    }
-    if args.threshold is not None:
-        params["threshold"] = args.threshold
-    if summary.get("fallback_reason"):
-        params["fallback_reason"] = summary["fallback_reason"]
+    compare_key = _resolve_compare_key(adata, args.batch_key)
+    params = _build_public_params(args, method, summary)
+    gallery_context = generate_figures(adata, output_dir, summary=summary, params=params, compare_key=compare_key)
+    _write_tables(output_dir, gallery_context)
+    write_report(output_dir, summary, params, input_file, gallery_context=gallery_context)
+    write_reproducibility(output_dir, params, input_file, demo_mode=args.demo)
 
-    generate_figures(adata, output_dir)
-    write_report(output_dir, summary, input_file, params)
-
+    input_contract, matrix_contract = _ensure_output_contract(adata, source_path=input_file)
     store_analysis_metadata(adata, SKILL_NAME, summary["executed_method"], params)
     output_h5ad = output_dir / "processed.h5ad"
-    adata.write_h5ad(output_h5ad)
+    save_h5ad(adata, output_h5ad)
     logger.info("Saved to %s", output_h5ad)
 
     checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
@@ -414,6 +898,13 @@ def main():
         "fallback_used": bool(summary.get("fallback_used")),
         "fallback_reason": summary.get("fallback_reason"),
         "params": params,
+        "input_contract": input_contract,
+        "matrix_contract": matrix_contract,
+        "visualization": {
+            "embedding_key": gallery_context.get("embedding_key"),
+            "preview_note": gallery_context.get("preview_note"),
+            "available_figure_data": gallery_context.get("figure_data_files", {}),
+        },
     }
     write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
     result_payload = load_result_json(output_dir) or {
@@ -427,7 +918,7 @@ def main():
     print(f"  Output: {output_dir}")
     print(
         f"Doublet detection complete: {summary['n_doublets']} doublets "
-        f"({summary['doublet_rate']*100:.1f}%), requested={summary['requested_method']}, "
+        f"({summary['doublet_rate'] * 100:.1f}%), requested={summary['requested_method']}, "
         f"executed={summary['executed_method']}"
     )
 

--- a/skills/singlecell/scrna/sc-doublet-detection/tests/test_sc_doublet.py
+++ b/skills/singlecell/scrna/sc-doublet-detection/tests/test_sc_doublet.py
@@ -29,6 +29,9 @@ def test_demo_mode(tmp_output):
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert (tmp_output / "report.md").exists()
     assert (tmp_output / "result.json").exists()
+    assert (tmp_output / "processed.h5ad").exists()
+    assert (tmp_output / "tables" / "doublet_calls.csv").exists()
+    assert (tmp_output / "figure_data" / "manifest.json").exists()
 
 
 def test_demo_report_content(tmp_output):
@@ -57,3 +60,4 @@ def test_demo_result_json(tmp_output):
     data = json.loads((tmp_output / "result.json").read_text())
     assert data["skill"] == "sc-doublet-detection"
     assert "summary" in data
+    assert "visualization" in data["data"]


### PR DESCRIPTION
## Summary
- expand `sc-doublet-detection` with `doubletdetection` and `scds`
- reuse shared raw-count source selection and preserve AnnData matrix semantics
- add richer doublet figures, figure-data exports, and stronger novice guidance
- align `SKILL.md`, knowhow, skill-guide, registry, and dependency metadata

## Validation
- `python -m pytest -q skills/singlecell/scrna/sc-doublet-detection/tests/test_sc_doublet.py tests/test_scrna_method_contracts.py tests/test_sc_preflight.py tests/test_knowhow.py tests/test_registry.py`
- smoke outputs generated under:
  - `output/review_sc_doublet_scrublet`
  - `output/review_sc_doublet_doubletdetection`
  - `output/review_sc_doublet_doubletfinder`
  - `output/review_sc_doublet_scdblfinder`
  - `output/review_sc_doublet_scds`
  - `output/review_sc_doublet_scds_hybrid`

## Notes
- `scds --scds-mode hybrid` currently falls back to `cxds` in the active environment because the bundled `bcds` path is not compatible with the installed xgboost stack; the wrapper reports this honestly in `report.md` and `result.json`.
- runtime behavior still only **prompts** for missing optional dependencies; it does not auto-install them for end users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DoubletDetection and scds methods (configurable modes), batch-key support, and CSV export of doublet calls
  * New visual outputs: score distribution, call summary, embedding and group-comparison plots

* **Documentation**
  * Expanded doublet detection guide and pre-run/run guidance; clarified expected-rate semantics and that annotation does not remove cells
  * Updated “what to inspect” and recommended next steps after running

* **Chores**
  * Added optional dependencies for the new methods
<!-- end of auto-generated comment: release notes by coderabbit.ai -->