### PR TITLE
Polish scRNA differential expression workflows and gallery

### DIFF
--- a/knowledge_base/knowhows/KH-sc-de-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-de-guardrails.md
@@ -16,11 +16,12 @@ source_urls:
 # Single-Cell Differential Expression Guardrails
 
 - **Inspect first**: decide whether the user wants cluster markers or replicate-aware condition DE, because those are different statistical questions.
-- **Standardize external inputs first**: if the user drops in an external `.h5ad` with unclear provenance, recommend `sc-standardize-input` before DE so raw-count and metadata expectations are explicit.
-- **Key wrapper controls**: explain `method`, `groupby`, `group1`, `group2`, `sample_key`, `celltype_key`, and `n_top_genes` before running.
-- **Use method-correct language**: Scanpy `wilcoxon` and `t-test` are exploratory single-cell ranking paths; `mast` is an R-backed hurdle-model path on log-normalized expression; `deseq2_r` is the replicate-aware pseudobulk path on raw counts.
+- **Point to the right upstream step**: cluster-marker DE usually comes after `sc-clustering`; sample-aware condition DE usually comes after labels/annotation and explicit replicate metadata.
+- **Key wrapper controls**: explain `method`, `groupby`, `group1`, `group2`, `sample_key`, `celltype_key`, `n_top_genes`, and any method-specific parameters before running.
+- **Use method-correct language**: Scanpy `wilcoxon`, `t-test`, and `logreg` are exploratory single-cell ranking paths; `mast` is an R-backed hurdle-model path on log-normalized expression; `deseq2_r` is the replicate-aware pseudobulk path on raw counts.
 - **Do not invent unsupported knobs**: the current wrapper does not expose a full DESeq2 design formula editor or Scanpy low-level test parameters.
-- **Respect the matrix contract**: `wilcoxon`, `t-test`, and `mast` should use log-normalized expression, preferably `adata.raw`; `deseq2_r` should use raw counts from `layers["counts"]`.
+- **Respect the matrix contract**: `wilcoxon`, `t-test`, `logreg`, and `mast` should use `X = normalized_expression`; `deseq2_r` should use raw counts from `layers["counts"]`, aligned raw counts in `adata.raw`, or count-like `adata.X`.
 - **Stop for pseudobulk design gaps**: do not run `deseq2_r` until the user has confirmed the condition column, both contrast groups, the replicate column, and the cell-type column.
+- **Stop for clustering gaps**: do not pretend you can produce cluster markers when the object has no cluster/label column yet; send the user to `sc-clustering` first.
 - **Be honest about runtime dependencies**: `mast` and `deseq2_r` are real public R-backed methods and require their corresponding R stacks; if those stacks are missing, fail clearly instead of implying the method still ran.
 - **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-de.md`.

--- a/knowledge_base/skill-guides/singlecell/sc-de.md
+++ b/knowledge_base/skill-guides/singlecell/sc-de.md
@@ -33,13 +33,14 @@ Key properties to check:
 - **Cell-type restriction**:
   - pseudobulk paths often need a meaningful `celltype_key`
 - **Expression layer**:
-  - `wilcoxon`, `t-test`, and `mast` should use log-normalized expression, ideally `adata.raw`
-  - `deseq2_r` should use raw counts, ideally `layers["counts"]`; only use `adata.X` if `X` is still the unnormalized count matrix
+  - `wilcoxon`, `t-test`, `logreg`, and `mast` should use `X = normalized_expression`
+  - `deseq2_r` should use raw counts, ideally `layers["counts"]`; otherwise aligned raw counts in `adata.raw`, and only then count-like `adata.X`
 - **Input provenance**:
-  - if this is an external `.h5ad` and you are not sure where raw counts live, recommend `sc-standardize-input` first
+  - if this is an external `.h5ad`, confirm whether it is already normalized or still raw
+  - if the user wants cluster markers but no cluster column exists yet, run `sc-clustering` first
 
 Important implementation notes in current OmicsClaw:
-- `wilcoxon` and `t-test` are Scanpy exploratory paths
+- `wilcoxon`, `t-test`, and `logreg` are Scanpy exploratory paths
 - the current public wrapper exposes Scanpy exploratory tests, the R-backed `mast` path, and the DESeq2 pseudobulk path
 - `deseq2_r` is the wrapper’s replicate-aware pseudobulk path
 - the wrapper validates required R stacks before entering the `mast` or `deseq2_r` runtime
@@ -50,8 +51,9 @@ Important implementation notes in current OmicsClaw:
 |--------|----------------|----------------------------|-------------|
 | **wilcoxon** | Safest first-pass marker or group ranking | `groupby`, `n_top_genes` | Exploratory, not replicate-aware |
 | **t-test** | Parametric alternative for simple group ranking | `groupby`, `n_top_genes` | Still exploratory |
+| **logreg** | When you want genes that best separate one group from the rest | `groupby`, `logreg_solver`, `n_top_genes` | Still exploratory |
 | **mast** | When a hurdle-model single-cell test is preferred on log-normalized expression | `groupby`, `group1`, `group2`, `n_top_genes` | Needs the R MAST stack and still is not a replicate-aware pseudobulk design |
-| **deseq2_r** | Best formal path for replicate-aware condition DE | `groupby`, `group1`, `group2`, `sample_key`, `celltype_key` | Needs true replicate structure |
+| **deseq2_r** | Best formal path for replicate-aware condition DE | `groupby`, `group1`, `group2`, `sample_key`, `celltype_key`, `pseudobulk_min_cells`, `pseudobulk_min_counts` | Needs true replicate structure |
 
 ## Step 3: Always Show A Parameter Summary Before Running
 
@@ -71,9 +73,11 @@ Tune in this order:
 2. `method`
 3. `n_top_genes`
 4. `group1` / `group2`
+5. method-specific extras such as `logreg_solver`
 
 Guidance:
 - use these when the goal is fast ranking, not formal replicate-aware inference
+- if the user wants cluster markers and no cluster column exists yet, stop and run `sc-clustering` first
 
 ### DESeq2 pseudobulk
 
@@ -82,11 +86,13 @@ Tune in this order:
 2. `group1` / `group2`
 3. `sample_key`
 4. `celltype_key`
+5. `pseudobulk_min_cells` / `pseudobulk_min_counts`
 
 Guidance:
 - choose this path only when the user truly has replicate-level samples
 - `sample_key` and `celltype_key` are as important as the statistical method itself
 - do not silently accept the default `groupby=leiden` for pseudobulk condition DE; make the user confirm the real condition column
+- if pseudobulk aggregation returns no bins, lower the pseudobulk thresholds or revisit sample/cell-type definitions before blaming DESeq2
 
 Important warnings:
 - do not expose a free-form DESeq2 design formula as if the wrapper supports it
@@ -101,6 +107,7 @@ Tune in this order:
 Guidance:
 - use this path when users want an R-backed single-cell DE model on log-normalized expression
 - do not confuse it with the pseudobulk DESeq2 path; it answers a different statistical question
+- if the user only has raw counts, do `sc-preprocessing` first; if the user only has PCA-ready data without cluster labels, do `sc-clustering` first
 
 ## Step 5: What To Say After The Run
 
@@ -112,6 +119,7 @@ Guidance:
 ## Step 6: Explain Outputs Using Method-Correct Language
 
 - describe Scanpy results as ranked marker-style DE outputs
+- describe `logreg` specifically as classifier-style ranking, not a replicate-aware effect estimate
 - describe MAST results as single-cell hurdle-model DE outputs on log-normalized expression
 - describe DESeq2 results as pseudobulk replicate-aware inference
 - describe `de_full.csv` as the full result table and `markers_top.csv` as the condensed export

--- a/skills/singlecell/_lib/preflight.py
+++ b/skills/singlecell/_lib/preflight.py
@@ -167,6 +167,8 @@ def _add_standardization_guidance(
     source_path: str | None = None,
 ) -> None:
     contract = get_input_contract(adata)
+    if get_matrix_contract(adata):
+        return
     if not contract.get("standardized"):
         decision.add_guidance(
             build_standardization_recommendation(source_path=source_path, skill_name=decision.skill_name)
@@ -197,7 +199,13 @@ def _declared_raw_is_normalized(adata: AnnData) -> bool:
 
 
 def _normalized_expression_available(adata: AnnData) -> bool:
-    return _declared_x_is_normalized(adata) or _declared_raw_is_normalized(adata)
+    if _declared_x_is_normalized(adata) or _declared_raw_is_normalized(adata):
+        return True
+    if not x_matrix_kind(adata) and not matrix_looks_count_like(adata.X):
+        return True
+    if adata.raw is not None and adata.raw.shape == adata.shape and not raw_matrix_kind(adata):
+        return not matrix_looks_count_like(adata.raw.X)
+    return False
 
 
 def _aligned_raw_is_count_like(adata: AnnData) -> bool:
@@ -219,6 +227,10 @@ def preflight_sc_de(
     sample_key: str | None,
     celltype_key: str | None,
     source_path: str | None = None,
+    n_top_genes: int | None = None,
+    logreg_solver: str | None = None,
+    pseudobulk_min_cells: int | None = None,
+    pseudobulk_min_counts: int | None = None,
 ) -> PreflightDecision:
     decision = PreflightDecision("sc-de")
     _add_standardization_guidance(decision, adata, source_path=source_path)
@@ -227,6 +239,9 @@ def preflight_sc_de(
         decision.require_confirmation("Provide both `--group1` and `--group2`, or omit both for a full ranking run.")
 
     if method == "deseq2_r":
+        decision.add_guidance(
+            "This path is for replicate-aware condition DE after you already know the comparison groups and have real biological replicates."
+        )
         condition_candidates = _obs_candidates(adata, "condition")
         if not groupby or groupby == "leiden":
             hint = f" Candidate condition-like columns: {_format_candidates(condition_candidates)}." if condition_candidates else ""
@@ -275,15 +290,32 @@ def preflight_sc_de(
                 decision.block(
                     "`deseq2_r` needs raw count-like expression in `layers['counts']`, aligned `adata.raw`, or count-like `adata.X`."
                 )
+        decision.add_guidance(
+            f"Current first-pass settings: `method=deseq2_r`, `groupby={groupby}`, `sample_key={sample_key or 'sample_id'}`, `celltype_key={celltype_key or 'cell_type'}`, `pseudobulk_min_cells={pseudobulk_min_cells}`, `pseudobulk_min_counts={pseudobulk_min_counts}`."
+        )
     else:
+        if not _normalized_expression_available(adata):
+            decision.block(
+                f"`{method}` expects log-normalized expression in `adata.X`. Run `sc-preprocessing` first or provide a processed h5ad with normalized expression."
+            )
         if groupby not in adata.obs.columns and not (groupby == "leiden" and "louvain" in adata.obs.columns):
             candidates = _obs_candidates(adata, "cluster") + _obs_candidates(adata, "condition")
             hint = f" Candidate grouping columns: {_format_candidates(candidates)}." if candidates else ""
-            decision.require_confirmation(f"`--groupby {groupby}` was not found in `adata.obs`." + hint)
-
-        if method == "mast" and not _normalized_expression_available(adata):
-            decision.block(
-                "`mast` expects log-normalized expression. Run `sc-preprocessing` first or provide a processed h5ad with normalized expression."
+            decision.require_confirmation(
+                f"`--groupby {groupby}` was not found in `adata.obs`."
+                + hint
+                + " If you want cluster markers, run `sc-clustering` first; if you want condition DE, point `--groupby` to the condition column."
+            )
+        decision.add_guidance(
+            "Exploratory single-cell DE usually comes after clustering or annotation, and before pathway enrichment or condition-focused follow-up."
+        )
+        if method == "logreg":
+            decision.add_guidance(
+                f"Current first-pass settings: `method=logreg`, `groupby={groupby}`, `n_top_genes={n_top_genes}`, `logreg_solver={logreg_solver}`."
+            )
+        else:
+            decision.add_guidance(
+                f"Current first-pass settings: `method={method}`, `groupby={groupby}`, `group1={group1}`, `group2={group2}`, `n_top_genes={n_top_genes}`."
             )
 
     return decision

--- a/skills/singlecell/_lib/viz/__init__.py
+++ b/skills/singlecell/_lib/viz/__init__.py
@@ -21,6 +21,11 @@ from .markers import (
     plot_marker_fraction_scatter,
     plot_marker_heatmap,
 )
+from .de import (
+    plot_de_effect_summary,
+    plot_de_group_summary,
+    plot_de_rank_panels,
+)
 from .doublet import (
     plot_doublet_call_summary,
     plot_doublet_score_by_group,
@@ -75,6 +80,9 @@ __all__ = [
     "plot_marker_effect_summary",
     "plot_marker_fraction_scatter",
     "plot_marker_cluster_summary",
+    "plot_de_effect_summary",
+    "plot_de_group_summary",
+    "plot_de_rank_panels",
     "plot_doublet_score_distribution",
     "plot_doublet_call_summary",
     "plot_doublet_score_by_group",

--- a/skills/singlecell/_lib/viz/de.py
+++ b/skills/singlecell/_lib/viz/de.py
@@ -1,0 +1,205 @@
+"""Differential-expression visualization helpers for single-cell downstream skills."""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import Union
+
+import pandas as pd
+
+from .core import QC_PALETTE, apply_singlecell_theme, save_figure
+from .embedding import make_categorical_palette
+
+logger = logging.getLogger(__name__)
+
+
+def _natural_group_order(values: list[str]) -> list[str]:
+    def _key(value: str) -> tuple[int, object]:
+        try:
+            num = float(value)
+            if num.is_integer():
+                return (0, int(num))
+            return (0, num)
+        except Exception:
+            return (1, value)
+
+    unique = list(dict.fromkeys(str(v) for v in values))
+    return sorted(unique, key=_key)
+
+
+def _resolve_effect_column(frame: pd.DataFrame) -> str:
+    for column in ("logfoldchanges", "log2FoldChange", "avg_log2FC", "logFC"):
+        if column in frame.columns:
+            valid = pd.to_numeric(frame[column], errors="coerce").notna()
+            if valid.any() and valid.mean() >= 0.6:
+                return column
+    for column in ("scores", "stat"):
+        if column in frame.columns and pd.to_numeric(frame[column], errors="coerce").notna().any():
+            return column
+    for column in ("logfoldchanges", "log2FoldChange", "avg_log2FC", "logFC"):
+        if column in frame.columns and pd.to_numeric(frame[column], errors="coerce").notna().any():
+            return column
+    return "scores"
+
+
+def _resolve_gene_column(frame: pd.DataFrame) -> str:
+    for column in ("names", "gene"):
+        if column in frame.columns:
+            return column
+    raise KeyError("No gene-like column found in DE results")
+
+
+def plot_de_effect_summary(
+    de_top: pd.DataFrame,
+    output_dir: Union[str, Path],
+    *,
+    n_top: int = 3,
+    filename: str = "de_effect_summary.png",
+) -> Path | None:
+    """Plot the strongest DE effect per group as a grouped bar summary."""
+    import matplotlib.pyplot as plt
+
+    output_dir = Path(output_dir)
+    if de_top.empty or "group" not in de_top.columns:
+        return None
+
+    frame = de_top.copy()
+    effect_col = _resolve_effect_column(frame)
+    gene_col = _resolve_gene_column(frame)
+    frame[effect_col] = pd.to_numeric(frame[effect_col], errors="coerce")
+    frame = frame.dropna(subset=[effect_col])
+    if frame.empty:
+        return None
+
+    frame = frame.groupby("group", observed=False).head(n_top).copy()
+    frame["label"] = frame["group"].astype(str) + " · " + frame[gene_col].astype(str)
+    palette = make_categorical_palette(frame["group"].astype(str).tolist())
+    colors = [palette.get(str(group), QC_PALETTE["bar"]) for group in frame["group"]]
+
+    apply_singlecell_theme()
+    height = max(4.8, 0.34 * len(frame) + 1.4)
+    fig, ax = plt.subplots(figsize=(9.6, height))
+    bars = ax.barh(frame["label"], frame[effect_col], color=colors, alpha=0.94)
+    ax.set_xlabel("Effect size" if effect_col not in {"scores", "stat"} else "Ranking score")
+    ax.set_ylabel("")
+    ax.set_title(f"Top {n_top} differential genes per group", fontsize=17, pad=14)
+
+    ordered_groups = _natural_group_order(frame["group"].astype(str).tolist())
+    group_positions = {}
+    for idx, label in enumerate(frame["label"].tolist()):
+        group = str(label).split(" · ", 1)[0]
+        group_positions.setdefault(group, []).append(idx)
+    for group in ordered_groups[:-1]:
+        if group in group_positions:
+            split = max(group_positions[group]) + 0.5
+            ax.axhline(split, color="#CBD5E1", linewidth=1.0, alpha=0.9)
+
+    xpad = max(abs(float(frame[effect_col].max())), 1.0) * 0.03
+    for bar, gene in zip(bars, frame[gene_col].astype(str)):
+        ax.text(
+            bar.get_width() + xpad if bar.get_width() >= 0 else bar.get_width() - xpad,
+            bar.get_y() + bar.get_height() / 2,
+            gene,
+            va="center",
+            ha="left" if bar.get_width() >= 0 else "right",
+            fontsize=8.5,
+            color="#1F2937",
+        )
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_de_group_summary(
+    summary_df: pd.DataFrame,
+    output_dir: Union[str, Path],
+    *,
+    filename: str = "de_group_summary.png",
+) -> Path | None:
+    """Plot DE summary counts by group/cell type with top-gene labels."""
+    import matplotlib.pyplot as plt
+
+    output_dir = Path(output_dir)
+    if summary_df.empty or "group" not in summary_df.columns:
+        return None
+
+    frame = summary_df.copy()
+    metric = "n_significant" if "n_significant" in frame.columns else "n_genes"
+    frame = frame.sort_values(metric, ascending=True)
+    apply_singlecell_theme()
+    height = max(4.4, 0.42 * len(frame) + 1.1)
+    fig, ax = plt.subplots(figsize=(8.8, height))
+    bars = ax.barh(frame["group"].astype(str), frame[metric], color=QC_PALETTE["bar"], alpha=0.92)
+    ax.set_xlabel("Significant genes" if metric == "n_significant" else "Genes tested")
+    ax.set_ylabel("Group")
+    ax.set_title("Differential expression summary by group", fontsize=17, pad=14)
+
+    xmax = max(float(frame[metric].max()), 1.0)
+    if "top_gene" in frame.columns:
+        for bar, gene in zip(bars, frame["top_gene"].fillna("").astype(str)):
+            if not gene:
+                continue
+            ax.text(
+                bar.get_width() + xmax * 0.015,
+                bar.get_y() + bar.get_height() / 2,
+                gene,
+                va="center",
+                fontsize=9,
+                color="#334155",
+            )
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_de_rank_panels(
+    de_top: pd.DataFrame,
+    output_dir: Union[str, Path],
+    *,
+    filename: str = "rank_genes_groups.png",
+) -> Path | None:
+    """Plot faceted top-gene bar panels, one panel per group."""
+    import matplotlib.pyplot as plt
+
+    output_dir = Path(output_dir)
+    if de_top.empty or "group" not in de_top.columns:
+        return None
+
+    frame = de_top.copy()
+    gene_col = _resolve_gene_column(frame)
+    effect_col = _resolve_effect_column(frame)
+    frame[effect_col] = pd.to_numeric(frame[effect_col], errors="coerce")
+    frame = frame.dropna(subset=[effect_col])
+    if frame.empty:
+        return None
+
+    ordered_groups = _natural_group_order(frame["group"].astype(str).tolist())
+    n_groups = len(ordered_groups)
+    ncols = min(4, max(1, n_groups))
+    nrows = math.ceil(n_groups / ncols)
+    apply_singlecell_theme()
+    fig, axes = plt.subplots(nrows, ncols, figsize=(4.8 * ncols, 3.6 * nrows), squeeze=False)
+    palette = make_categorical_palette(ordered_groups)
+
+    for ax in axes.ravel():
+        ax.set_visible(False)
+
+    for ax, group in zip(axes.ravel(), ordered_groups):
+        ax.set_visible(True)
+        subset = frame[frame["group"].astype(str) == group].copy().reset_index(drop=True)
+        subset["rank"] = range(1, len(subset) + 1)
+        color = palette.get(group, QC_PALETTE["accent"])
+        ylabels = subset[gene_col].astype(str).tolist()
+        ypos = list(range(len(subset)))
+        ax.barh(ypos, subset[effect_col], color=color, alpha=0.9)
+        ax.set_yticks(ypos)
+        ax.set_yticklabels(ylabels, fontsize=9)
+        ax.invert_yaxis()
+        ax.set_title(f"{group} vs. rest", fontsize=12, pad=8)
+        ax.set_xlabel("Ranking score" if effect_col in {"scores", "stat"} else "Effect")
+        ax.set_ylabel("")
+        ax.grid(True, axis="y", alpha=0.25)
+
+    fig.suptitle("Top differential signals by group", fontsize=18, y=1.01)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)

--- a/skills/singlecell/_lib/viz/markers.py
+++ b/skills/singlecell/_lib/viz/markers.py
@@ -15,6 +15,20 @@ from .embedding import make_categorical_palette
 logger = logging.getLogger(__name__)
 
 
+def _natural_group_order(values: list[str]) -> list[str]:
+    def _key(value: str) -> tuple[int, object]:
+        try:
+            num = float(value)
+            if num.is_integer():
+                return (0, int(num))
+            return (0, num)
+        except Exception:
+            return (1, value)
+
+    unique = list(dict.fromkeys(str(v) for v in values))
+    return sorted(unique, key=_key)
+
+
 def _choose_effect_column(markers: pd.DataFrame) -> str:
     if "logfoldchanges" in markers.columns:
         valid = pd.to_numeric(markers["logfoldchanges"], errors="coerce").notna()
@@ -273,7 +287,9 @@ def plot_marker_dotplot(
 
     top_df = _top_markers(markers, n_top)
     gene_blocks: list[tuple[str, list[str]]] = []
-    for group, group_df in top_df.groupby("group", sort=False, observed=False):
+    group_order = _natural_group_order(top_df["group"].astype(str).tolist())
+    for group in group_order:
+        group_df = top_df[top_df["group"].astype(str) == group]
         genes = [gene for gene in group_df["names"].astype(str).tolist() if gene in adata.var_names]
         genes = list(dict.fromkeys(genes))
         if genes:
@@ -283,7 +299,7 @@ def plot_marker_dotplot(
 
     apply_singlecell_theme()
 
-    ordered_groups = [str(value) for value in pd.Index(adata.obs[groupby].astype(str)).unique().tolist()]
+    ordered_groups = _natural_group_order(pd.Index(adata.obs[groupby].astype(str)).unique().tolist())
     gene_order: list[str] = []
     source_group_labels: list[str] = []
     block_midpoints: list[tuple[float, str]] = []

--- a/skills/singlecell/scrna/sc-de/SKILL.md
+++ b/skills/singlecell/scrna/sc-de/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: sc-de
 description: >-
-  Differential expression for single-cell RNA-seq using Scanpy marker tests or
-  an R-backed DESeq2 pseudobulk path. The wrapper separates exploratory
-  cluster-level marker ranking from sample-aware pseudobulk analysis.
-version: 0.5.0
+  Differential expression for single-cell RNA-seq using exploratory Scanpy
+  ranking, R-backed MAST, or replicate-aware pseudobulk DESeq2. The wrapper
+  separates cluster/group marker ranking from sample-aware condition DE.
+version: 0.6.0
 author: OmicsClaw
 license: MIT
 tags: [singlecell, differential-expression, markers, wilcoxon, deseq2]
@@ -16,8 +16,13 @@ metadata:
       - "--group1"
       - "--group2"
       - "--groupby"
+      - "--log2fc-threshold"
+      - "--logreg-solver"
       - "--method"
       - "--n-top-genes"
+      - "--padj-threshold"
+      - "--pseudobulk-min-cells"
+      - "--pseudobulk-min-counts"
       - "--sample-key"
     param_hints:
       wilcoxon:
@@ -34,6 +39,13 @@ metadata:
         requires: ["preprocessed_anndata", "scanpy"]
         tips:
           - "--method t-test: Parametric alternative to Wilcoxon."
+      logreg:
+        priority: "groupby -> logreg_solver -> n_top_genes"
+        params: ["groupby", "logreg_solver", "n_top_genes"]
+        defaults: {groupby: "leiden", logreg_solver: "lbfgs", n_top_genes: 10}
+        requires: ["preprocessed_anndata", "scanpy"]
+        tips:
+          - "--method logreg: Logistic-regression ranking, useful when you want genes that best separate one group from the others."
       mast:
         priority: "groupby -> group1/group2 -> n_top_genes"
         params: ["groupby", "group1", "group2", "n_top_genes"]
@@ -42,9 +54,9 @@ metadata:
         tips:
           - "--method mast: R-backed MAST hurdle-model path on log-normalized expression."
       deseq2_r:
-        priority: "groupby -> group1/group2 -> sample_key -> celltype_key"
-        params: ["groupby", "group1", "group2", "sample_key", "celltype_key"]
-        defaults: {sample_key: "sample_id", celltype_key: "cell_type"}
+        priority: "groupby -> group1/group2 -> sample_key -> celltype_key -> pseudobulk thresholds"
+        params: ["groupby", "group1", "group2", "sample_key", "celltype_key", "pseudobulk_min_cells", "pseudobulk_min_counts"]
+        defaults: {sample_key: "sample_id", celltype_key: "cell_type", pseudobulk_min_cells: 10, pseudobulk_min_counts: 1000}
         requires: ["raw_counts_or_raw_layer", "biological_replicates", "R_DESeq2_stack"]
         tips:
           - "--method deseq2_r: Sample-aware pseudobulk path."
@@ -80,7 +92,7 @@ metadata:
 
 ## Core Capabilities
 
-1. **Four DE paths**: Wilcoxon, t-test, MAST, and DESeq2 pseudobulk.
+1. **Five DE paths**: Wilcoxon, t-test, logistic regression, MAST, and DESeq2 pseudobulk.
 2. **Separation of statistical questions**: exploratory single-cell ranking versus replicate-aware pseudobulk inference.
 3. **Matrix-aware contract**: normalized expression for ranking paths, raw counts for DESeq2 pseudobulk.
 4. **Direct DE figure exports**: marker dotplot and rank-gene summary where supported.
@@ -92,8 +104,9 @@ Implemented methods:
 
 1. `wilcoxon`
 2. `t-test`
-3. `mast` for R-backed hurdle-model DE
-4. `deseq2_r` for pseudobulk DE
+3. `logreg`
+4. `mast` for R-backed hurdle-model DE
+5. `deseq2_r` for pseudobulk DE
 
 ## Input Formats
 
@@ -104,18 +117,21 @@ Implemented methods:
 
 ### Input Expectations
 
-- Accepted input: preprocessed `.h5ad`
-- `wilcoxon`, `t-test`, and `mast` expect log-normalized expression, preferably in `adata.raw`
-- `deseq2_r` expects raw counts, preferably in `layers["counts"]`; it may read `adata.X` only when `X` itself is still an unnormalized count matrix, plus `group1`, `group2`, `sample_key`, and `celltype_key`
+- Accepted input: processed `.h5ad`
+- `wilcoxon`, `t-test`, `logreg`, and `mast` expect `X = normalized_expression`
+- `deseq2_r` expects raw counts, preferably in `layers["counts"]`, otherwise aligned raw counts in `adata.raw`, otherwise count-like `adata.X`
 - All methods require a grouping column in `obs`
+- If you want cluster markers, this skill usually comes **after `sc-clustering`**
+- If you want replicate-aware treated-vs-control DE, this skill usually comes **after `sc-cell-annotation`** or another step that defines `celltype_key`
 
 ## Workflow
 
-1. Validate the requested DE mode.
-2. Run Scanpy ranking or pseudobulk DESeq2.
-3. Export full and top-hit tables.
-4. Save `processed.h5ad`, `report.md`, and `result.json`.
-5. Record the chosen method and grouping variables for downstream traceability.
+1. Load the AnnData object and inspect the matrix contract.
+2. Preflight the statistical question: exploratory ranking vs replicate-aware condition DE.
+3. Validate matrix state and required metadata for the requested method.
+4. Run Scanpy ranking, MAST, or pseudobulk DESeq2.
+5. Export tables, figures, `figure_data`, and `processed.h5ad`.
+6. Record method metadata for downstream traceability.
 
 ## CLI Reference
 
@@ -128,21 +144,30 @@ python skills/singlecell/scrna/sc-de/sc_de.py \
   --group1 treated --group2 control --method t-test --output <dir>
 
 python skills/singlecell/scrna/sc-de/sc_de.py \
+  --input <processed.h5ad> --groupby leiden --method logreg \
+  --logreg-solver saga --output <dir>
+
+python skills/singlecell/scrna/sc-de/sc_de.py \
   --input <processed.h5ad> --method deseq2_r \
   --groupby condition --group1 treated --group2 control \
-  --sample-key sample_id --celltype-key cell_type --output <dir>
+  --sample-key sample_id --celltype-key cell_type \
+  --pseudobulk-min-cells 10 --pseudobulk-min-counts 1000 --output <dir>
 ```
 
 ## Public Parameters
 
 | Parameter | Role | Notes |
 |-----------|------|-------|
-| `--method` | DE backend | `wilcoxon`, `t-test`, `mast`, or `deseq2_r` |
+| `--method` | DE backend | `wilcoxon`, `t-test`, `logreg`, `mast`, or `deseq2_r` |
 | `--groupby` | grouping column | core comparison axis |
 | `--group1` / `--group2` | comparison levels | especially important for `mast` and `deseq2_r` |
 | `--n-top-genes` | compact export size | ranking-output control |
+| `--logreg-solver` | logistic-regression optimizer | `logreg` only |
 | `--sample-key` | replicate/sample column | required by `deseq2_r` |
 | `--celltype-key` | pseudobulk aggregation label | used by `deseq2_r` |
+| `--pseudobulk-min-cells` | minimum cells per pseudobulk bin | `deseq2_r` only |
+| `--pseudobulk-min-counts` | minimum counts per pseudobulk bin | `deseq2_r` only |
+| `--padj-threshold` / `--log2fc-threshold` | figure summary thresholds | mostly affects exported volcano/summary figures |
 
 ## Algorithm / Methodology
 
@@ -152,9 +177,10 @@ Current OmicsClaw exploratory DE includes:
 
 1. `wilcoxon`
 2. `t-test`
-3. `mast`
+3. `logreg`
+4. `mast`
 
-These paths answer the cluster-marker or group-ranking question on normalized expression, ideally from `adata.raw`.
+These paths answer the cluster-marker or group-ranking question on normalized expression from `adata.X`.
 
 ### Replicate-aware pseudobulk path
 
@@ -177,21 +203,29 @@ Successful runs write:
 - `result.json`
 - `tables/de_full.csv`
 - `tables/markers_top.csv`
+- `figure_data/manifest.json`
 - `reproducibility/commands.sh`
 
 ### Visualization Contract
 
 The current wrapper writes direct figure outputs rather than a recipe-driven gallery:
 
-- `figures/marker_dotplot.png` when ranking outputs support it
-- `figures/rank_genes_groups.png` when ranking outputs support it
+- exploratory methods:
+  - `figures/marker_dotplot.png`
+  - `figures/rank_genes_groups.png`
+  - `figures/de_effect_summary.png`
+  - `figures/de_group_summary.png`
+- pseudobulk paths:
+  - `figures/pseudobulk_group_summary.png`
+  - per-celltype `*_volcano.png`
+  - per-celltype `*_ma.png`
 
 ### What Users Should Inspect First
 
 1. `report.md`
 2. `tables/de_full.csv`
 3. `tables/markers_top.csv`
-4. `figures/rank_genes_groups.png` when available
+4. `figures/de_group_summary.png` or pseudobulk summary figures
 5. `processed.h5ad`
 
 ## Current Limitations
@@ -203,6 +237,8 @@ The current wrapper writes direct figure outputs rather than a recipe-driven gal
 ## Safety And Guardrails
 
 - Distinguish exploratory marker-style DE from replicate-aware pseudobulk inference before running.
+- If the user only has a base-preprocessed object and wants cluster markers, point them to `sc-clustering` first.
+- If the user wants treated-vs-control inference without replicates, warn that exploratory DE is not replicate-aware.
 - `mast` and `deseq2_r` are real public methods but require their R stacks up front in the current wrapper.
 - Treat `sample_key` and `celltype_key` as part of the statistical design for `deseq2_r`, not as cosmetic metadata.
 - For short execution guardrails, see `knowledge_base/knowhows/KH-sc-de-guardrails.md`.

--- a/skills/singlecell/scrna/sc-de/sc_de.py
+++ b/skills/singlecell/scrna/sc-de/sc_de.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Single-Cell Differential Expression - Scanpy tests plus R pseudobulk DESeq2."""
+"""Single-cell differential expression across exploratory and pseudobulk paths."""
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import tempfile
 import sys
@@ -29,14 +30,33 @@ from omicsclaw.common.report import (
     write_result_json,
 )
 from skills.singlecell._lib import io as sc_io
-from skills.singlecell._lib.adata_utils import store_analysis_metadata
+from skills.singlecell._lib.adata_utils import (
+    ensure_input_contract,
+    get_matrix_contract,
+    infer_x_matrix_kind,
+    matrix_looks_count_like,
+    propagate_singlecell_contracts,
+    raw_matrix_kind,
+    record_matrix_contract,
+    store_analysis_metadata,
+)
 from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
 from skills.singlecell._lib.preflight import apply_preflight, preflight_sc_de
-from skills.singlecell._lib.pseudobulk import aggregate_to_pseudobulk, run_deseq2_analysis
+from skills.singlecell._lib.pseudobulk import (
+    aggregate_to_pseudobulk,
+    plot_ma,
+    plot_volcano,
+    run_deseq2_analysis,
+)
 from omicsclaw.core.dependency_manager import validate_r_environment
 from omicsclaw.core.r_script_runner import RScriptRunner
 
-from skills.singlecell._lib.viz_utils import save_figure
+from skills.singlecell._lib.viz import (
+    plot_de_effect_summary,
+    plot_de_group_summary,
+    plot_de_rank_panels,
+    save_figure,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -53,6 +73,11 @@ METHOD_REGISTRY: dict[str, MethodConfig] = {
     "t-test": MethodConfig(
         name="t-test",
         description="Welch's t-test (scanpy built-in)",
+        dependencies=("scanpy",),
+    ),
+    "logreg": MethodConfig(
+        name="logreg",
+        description="Logistic-regression marker ranking (scanpy built-in)",
         dependencies=("scanpy",),
     ),
     "mast": MethodConfig(
@@ -123,7 +148,15 @@ def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary
         logger.warning("Failed to write README.md: %s", exc)
 
 
-def run_de_scanpy(adata, groupby="leiden", method="wilcoxon", group1=None, group2=None):
+def run_de_scanpy(
+    adata,
+    groupby="leiden",
+    method="wilcoxon",
+    group1=None,
+    group2=None,
+    *,
+    logreg_solver: str = "lbfgs",
+):
     resolved_groupby = groupby
     if resolved_groupby not in adata.obs.columns:
         if resolved_groupby == "leiden" and "louvain" in adata.obs.columns:
@@ -133,12 +166,26 @@ def run_de_scanpy(adata, groupby="leiden", method="wilcoxon", group1=None, group
             raise ValueError(f"Column '{groupby}' not found in adata.obs")
 
     effective_method = method
-    use_raw = adata.raw is not None and adata.raw.shape == adata.shape
+    method_kwargs: dict[str, object] = {"pts": True, "use_raw": False}
+    if method == "logreg":
+        method_kwargs["solver"] = logreg_solver
 
     if group1 and group2:
-        sc.tl.rank_genes_groups(adata, groupby=resolved_groupby, groups=[group1], reference=group2, method=effective_method, pts=True, use_raw=use_raw)
+        sc.tl.rank_genes_groups(
+            adata,
+            groupby=resolved_groupby,
+            groups=[group1],
+            reference=group2,
+            method=effective_method,
+            **method_kwargs,
+        )
     else:
-        sc.tl.rank_genes_groups(adata, groupby=resolved_groupby, method=effective_method, pts=True, use_raw=use_raw)
+        sc.tl.rank_genes_groups(
+            adata,
+            groupby=resolved_groupby,
+            method=effective_method,
+            **method_kwargs,
+        )
 
     result_df = sc.get.rank_genes_groups_df(adata, group=None)
     n_groups = len(result_df["group"].unique()) if "group" in result_df.columns else 0
@@ -147,40 +194,42 @@ def run_de_scanpy(adata, groupby="leiden", method="wilcoxon", group1=None, group
         "groupby": resolved_groupby,
         "n_groups": n_groups,
         "n_genes_tested": int(adata.n_vars),
+        "expression_source": "adata.X",
     }
 
 
-def _matrix_looks_count_like(matrix) -> bool:
-    sample = matrix
-    if hasattr(sample, "shape") and len(sample.shape) == 2:
-        sample = sample[: min(sample.shape[0], 256), : min(sample.shape[1], 256)]
-    if hasattr(sample, "toarray"):
-        sample = sample.toarray()
-    arr = np.asarray(sample)
-    if arr.size == 0:
-        return False
-    if np.any(~np.isfinite(arr)) or np.any(arr < 0):
-        return False
-    return np.allclose(arr, np.round(arr), atol=1e-8)
+def _build_count_like_adata(adata) -> tuple[sc.AnnData, str]:
+    if "counts" in adata.layers and matrix_looks_count_like(adata.layers["counts"]):
+        prepared = adata.copy()
+        prepared.X = adata.layers["counts"].copy()
+        return prepared, "layers.counts"
 
+    if adata.raw is not None and adata.raw.shape == adata.shape and matrix_looks_count_like(adata.raw.X):
+        prepared = sc.AnnData(X=adata.raw.X.copy(), obs=adata.obs.copy(), var=adata.raw.var.copy())
+        prepared.obs_names = adata.obs_names.copy()
+        prepared.var_names = adata.raw.var_names.copy()
+        return prepared, "adata.raw"
 
-def _resolve_deseq2_count_source(adata) -> tuple[str | None, str]:
-    if "counts" in adata.layers:
-        return "counts", "layers.counts"
-
-    matrix_contract = adata.uns.get("omicsclaw_matrix_contract", {}) if isinstance(getattr(adata, "uns", {}), dict) else {}
-    if matrix_contract.get("X") == "raw_counts":
-        return None, "adata.X"
-
-    if _matrix_looks_count_like(adata.X):
-        return None, "adata.X"
+    matrix_contract = get_matrix_contract(adata)
+    if matrix_contract.get("X") == "raw_counts" or matrix_looks_count_like(adata.X):
+        return adata.copy(), "adata.X"
 
     raise ValueError(
-        "deseq2_r requires raw counts in adata.layers['counts'] or an unnormalized count-like adata.X matrix"
+        "deseq2_r requires raw counts in `layers['counts']`, aligned raw counts in `adata.raw`, or an unnormalized count-like `adata.X` matrix."
     )
 
 
-def run_de_deseq2_r_method(adata, *, condition_key: str, group1: str, group2: str, sample_key: str, celltype_key: str):
+def run_de_deseq2_r_method(
+    adata,
+    *,
+    condition_key: str,
+    group1: str,
+    group2: str,
+    sample_key: str,
+    celltype_key: str,
+    pseudobulk_min_cells: int = 10,
+    pseudobulk_min_counts: int = 1000,
+):
     if not group1 or not group2:
         raise ValueError("R pseudobulk DESeq2 requires both --group1 and --group2")
     if sample_key not in adata.obs.columns:
@@ -188,13 +237,14 @@ def run_de_deseq2_r_method(adata, *, condition_key: str, group1: str, group2: st
     if celltype_key not in adata.obs.columns:
         raise ValueError(f"celltype_key '{celltype_key}' not found in adata.obs")
 
-    layer, expression_source = _resolve_deseq2_count_source(adata)
-
+    pb_adata, expression_source = _build_count_like_adata(adata)
     pb = aggregate_to_pseudobulk(
-        adata,
+        pb_adata,
         sample_key=sample_key,
         celltype_key=celltype_key,
-        layer=layer,
+        min_cells=pseudobulk_min_cells,
+        min_counts=pseudobulk_min_counts,
+        layer=None,
     )
     if pb["counts"].empty:
         raise RuntimeError("Pseudobulk aggregation returned no sample-celltype combinations")
@@ -236,16 +286,10 @@ def run_de_mast_method(adata, *, groupby: str, group1: str | None, group2: str |
             raise ValueError(f"Column '{groupby}' not found in adata.obs")
     scripts_dir = _PROJECT_ROOT / "omicsclaw" / "r_scripts"
     runner = RScriptRunner(scripts_dir=scripts_dir, timeout=1800)
-    if adata.raw is not None and adata.raw.shape == adata.shape:
-        export = sc.AnnData(X=adata.raw.X.copy(), obs=adata.obs.copy(), var=adata.raw.var.copy())
-        export.obs_names = adata.obs_names.copy()
-        export.var_names = adata.raw.var_names.copy()
-        expression_source = "adata.raw"
-    else:
-        export = sc.AnnData(X=adata.X.copy(), obs=adata.obs.copy(), var=adata.var.copy())
-        export.obs_names = adata.obs_names.copy()
-        export.var_names = adata.var_names.copy()
-        expression_source = "adata.X"
+    export = sc.AnnData(X=adata.X.copy(), obs=adata.obs.copy(), var=adata.var.copy())
+    export.obs_names = adata.obs_names.copy()
+    export.var_names = adata.var_names.copy()
+    expression_source = "adata.X"
     with tempfile.TemporaryDirectory(prefix="omicsclaw_mast_") as tmpdir:
         tmpdir = Path(tmpdir)
         input_h5ad = tmpdir / "input.h5ad"
@@ -274,7 +318,87 @@ def run_de_mast_method(adata, *, groupby: str, group1: str | None, group2: str |
     }
 
 
-def generate_figures(adata, output_dir: Path, n_top_genes=5) -> list[str]:
+def _write_figure_data(
+    output_dir: Path,
+    *,
+    exploratory_top: pd.DataFrame | None = None,
+    group_summary: pd.DataFrame | None = None,
+    pseudobulk_summary: pd.DataFrame | None = None,
+) -> None:
+    figure_data_dir = output_dir / "figure_data"
+    figure_data_dir.mkdir(exist_ok=True)
+    manifest: dict[str, str] = {}
+    if exploratory_top is not None and not exploratory_top.empty:
+        path = figure_data_dir / "de_top_markers.csv"
+        exploratory_top.to_csv(path, index=False)
+        manifest["de_top_markers"] = path.name
+    if group_summary is not None and not group_summary.empty:
+        path = figure_data_dir / "de_group_summary.csv"
+        group_summary.to_csv(path, index=False)
+        manifest["de_group_summary"] = path.name
+    if pseudobulk_summary is not None and not pseudobulk_summary.empty:
+        path = figure_data_dir / "pseudobulk_summary.csv"
+        pseudobulk_summary.to_csv(path, index=False)
+        manifest["pseudobulk_summary"] = path.name
+    (figure_data_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def _group_summary(full_df: pd.DataFrame, top_df: pd.DataFrame, *, group_col: str = "group", gene_col: str = "names") -> pd.DataFrame:
+    if full_df.empty or group_col not in full_df.columns:
+        return pd.DataFrame()
+    frame = full_df.copy()
+    if "pvals_adj" in frame.columns:
+        frame["significant"] = pd.to_numeric(frame["pvals_adj"], errors="coerce").fillna(1.0) < 0.05
+    elif "padj" in frame.columns:
+        frame["significant"] = pd.to_numeric(frame["padj"], errors="coerce").fillna(1.0) < 0.05
+    else:
+        frame["significant"] = False
+    summary = (
+        frame.groupby(group_col, observed=False)
+        .agg(
+            n_genes=(gene_col, "count"),
+            n_significant=("significant", "sum"),
+        )
+        .reset_index()
+        .rename(columns={group_col: "group"})
+    )
+    top_lookup = (
+        top_df.groupby(group_col, observed=False)
+        .head(1)[[group_col, gene_col]]
+        .rename(columns={group_col: "group", gene_col: "top_gene"})
+    )
+    return summary.merge(top_lookup, on="group", how="left")
+
+
+def _pseudobulk_group_summary(full_df: pd.DataFrame) -> pd.DataFrame:
+    if full_df.empty:
+        return pd.DataFrame()
+    frame = full_df.copy()
+    if "padj" in frame.columns:
+        frame["significant"] = pd.to_numeric(frame["padj"], errors="coerce").fillna(1.0) < 0.05
+    else:
+        frame["significant"] = False
+    group_col = "cell_type" if "cell_type" in frame.columns else "group"
+    gene_col = "gene" if "gene" in frame.columns else "names"
+    summary = (
+        frame.groupby(group_col, observed=False)
+        .agg(
+            n_genes=(gene_col, "count"),
+            n_significant=("significant", "sum"),
+        )
+        .reset_index()
+        .rename(columns={group_col: "group"})
+    )
+    top_lookup = (
+        frame.sort_values("padj", na_position="last")
+        .groupby(group_col, observed=False)
+        .head(1)[[group_col, gene_col]]
+        .rename(columns={group_col: "group", gene_col: "top_gene"})
+    )
+    return summary.merge(top_lookup, on="group", how="left")
+
+
+def generate_scanpy_figures(adata, full_df: pd.DataFrame, top_df: pd.DataFrame, output_dir: Path, n_top_genes=5) -> list[str]:
     figures = []
     try:
         sc.pl.rank_genes_groups_dotplot(adata, n_genes=n_top_genes, show=False)
@@ -285,25 +409,113 @@ def generate_figures(adata, output_dir: Path, n_top_genes=5) -> list[str]:
         logger.warning("Dotplot failed: %s", exc)
 
     try:
-        sc.pl.rank_genes_groups(adata, n_genes=n_top_genes, show=False)
-        p = save_figure(plt.gcf(), output_dir, "rank_genes_groups.png")
-        figures.append(str(p))
-        plt.close()
+        p = plot_de_rank_panels(top_df, output_dir, filename="rank_genes_groups.png")
+        if p is not None:
+            figures.append(str(p))
     except Exception as exc:
         logger.warning("Rank genes plot failed: %s", exc)
+
+    summary_df = _group_summary(full_df, top_df, group_col="group", gene_col="names")
+    try:
+        p = plot_de_effect_summary(top_df, output_dir, n_top=min(3, n_top_genes))
+        if p is not None:
+            figures.append(str(p))
+    except Exception as exc:
+        logger.warning("DE effect summary failed: %s", exc)
+
+    try:
+        p = plot_de_group_summary(summary_df, output_dir)
+        if p is not None:
+            figures.append(str(p))
+    except Exception as exc:
+        logger.warning("DE group summary failed: %s", exc)
+
+    _write_figure_data(output_dir, exploratory_top=top_df, group_summary=summary_df)
+    return figures
+
+
+def generate_tabular_de_figures(
+    full_df: pd.DataFrame,
+    top_df: pd.DataFrame,
+    output_dir: Path,
+    *,
+    group_col: str,
+    gene_col: str,
+) -> list[str]:
+    figures: list[str] = []
+    summary_df = _group_summary(full_df, top_df, group_col=group_col, gene_col=gene_col)
+    try:
+        p = plot_de_effect_summary(top_df.rename(columns={group_col: "group"}), output_dir, n_top=3)
+        if p is not None:
+            figures.append(str(p))
+    except Exception as exc:
+        logger.warning("DE effect summary failed: %s", exc)
+    try:
+        p = plot_de_group_summary(summary_df, output_dir)
+        if p is not None:
+            figures.append(str(p))
+    except Exception as exc:
+        logger.warning("DE group summary failed: %s", exc)
+    _write_figure_data(output_dir, exploratory_top=top_df, group_summary=summary_df)
+    return figures
+
+
+def generate_pseudobulk_figures(full_df: pd.DataFrame, output_dir: Path, *, padj_threshold: float, log2fc_threshold: float) -> list[str]:
+    figures: list[str] = []
+    if full_df.empty:
+        return figures
+
+    group_col = "cell_type" if "cell_type" in full_df.columns else None
+    if group_col is None:
+        return figures
+
+    summary_df = _pseudobulk_group_summary(full_df)
+    try:
+        p = plot_de_group_summary(summary_df, output_dir, filename="pseudobulk_group_summary.png")
+        if p is not None:
+            figures.append(str(p))
+    except Exception as exc:
+        logger.warning("Pseudobulk summary plot failed: %s", exc)
+
+    for cell_type, group_df in full_df.groupby(group_col, observed=False):
+        try:
+            plot_volcano(
+                group_df,
+                str(cell_type),
+                output_dir,
+                padj_threshold=padj_threshold,
+                log2fc_threshold=log2fc_threshold,
+                top_genes=10,
+            )
+            figures.append(str((output_dir / "figures" / f"{cell_type}_volcano.png")))
+        except Exception as exc:
+            logger.warning("Volcano plot failed for %s: %s", cell_type, exc)
+        try:
+            plot_ma(
+                group_df,
+                str(cell_type),
+                output_dir,
+                padj_threshold=padj_threshold,
+            )
+            figures.append(str((output_dir / "figures" / f"{cell_type}_ma.png")))
+        except Exception as exc:
+            logger.warning("MA plot failed for %s: %s", cell_type, exc)
+
+    _write_figure_data(output_dir, pseudobulk_summary=summary_df)
     return figures
 
 
 def write_report(output_dir: Path, summary: dict, input_file: str | None, params: dict) -> None:
     requested_method = str(summary.get("requested_method", params.get("method", summary["method"])))
     executed_method = str(summary.get("executed_method", summary["method"]))
+    group_label = "Cell types analyzed" if executed_method == "deseq2_r" else "Groups"
     header = generate_report_header(
         title="Differential Expression Report",
         skill_name=SKILL_NAME,
         input_files=[Path(input_file)] if input_file else None,
         extra_metadata={
             "Method": executed_method,
-            "Groups": str(summary["n_groups"]),
+            group_label: str(summary["n_groups"]),
         },
     )
 
@@ -311,14 +523,28 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
         "## Summary\n",
         f"- **Requested method**: {requested_method}",
         f"- **Executed method**: {executed_method}",
-        f"- **Groups compared**: {summary['n_groups']}",
+        f"- **{group_label}**: {summary['n_groups']}",
         f"- **Genes tested**: {summary['n_genes_tested']}",
         f"- **Total cells**: {summary.get('n_cells', 'N/A')}",
+        f"- **Expression source**: {summary.get('expression_source', params.get('expression_source', 'adata.X'))}",
         "",
         "## Parameters\n",
     ]
     for k, v in params.items():
         body_lines.append(f"- `{k}`: {v}")
+
+    body_lines.extend(
+        [
+            "",
+            "## Typical Next Step\n",
+            (
+                "- Exploratory marker-style DE usually flows into `sc-cell-annotation`, "
+                "`sc-markers` refinement, or pathway enrichment."
+                if executed_method != "deseq2_r"
+                else "- Pseudobulk condition DE usually flows into enrichment or targeted interpretation of the affected cell types."
+            ),
+        ]
+    )
 
     footer = generate_report_footer()
     (output_dir / "report.md").write_text(header + "\n".join(body_lines) + "\n" + footer)
@@ -329,6 +555,8 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
     cmd += f" --groupby {params['groupby']}"
     cmd += f" --method {params['method']}"
     cmd += f" --n-top-genes {params['n_top_genes']}"
+    if params.get("logreg_solver") is not None:
+        cmd += f" --logreg-solver {params['logreg_solver']}"
     if params.get("group1") is not None:
         cmd += f" --group1 {params['group1']}"
     if params.get("group2") is not None:
@@ -337,6 +565,14 @@ def write_report(output_dir: Path, summary: dict, input_file: str | None, params
         cmd += f" --sample-key {params['sample_key']}"
     if params.get("celltype_key") is not None:
         cmd += f" --celltype-key {params['celltype_key']}"
+    if params.get("pseudobulk_min_cells") is not None:
+        cmd += f" --pseudobulk-min-cells {params['pseudobulk_min_cells']}"
+    if params.get("pseudobulk_min_counts") is not None:
+        cmd += f" --pseudobulk-min-counts {params['pseudobulk_min_counts']}"
+    if params.get("padj_threshold") is not None:
+        cmd += f" --padj-threshold {params['padj_threshold']}"
+    if params.get("log2fc_threshold") is not None:
+        cmd += f" --log2fc-threshold {params['log2fc_threshold']}"
     (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
     _write_repro_requirements(
         repro_dir,
@@ -352,10 +588,15 @@ def main():
     parser.add_argument("--groupby", default="leiden", help="Group column for Scanpy DE or condition column for deseq2_r")
     parser.add_argument("--method", default="wilcoxon", choices=list(METHOD_REGISTRY.keys()))
     parser.add_argument("--n-top-genes", type=int, default=10)
+    parser.add_argument("--logreg-solver", default="lbfgs", choices=["lbfgs", "liblinear", "newton-cg", "sag", "saga"])
     parser.add_argument("--group1", default=None)
     parser.add_argument("--group2", default=None)
     parser.add_argument("--sample-key", default=None, help="Sample/replicate column for pseudobulk R DE")
     parser.add_argument("--celltype-key", default="cell_type", help="Cell type column for pseudobulk R DE")
+    parser.add_argument("--pseudobulk-min-cells", type=int, default=10, help="Minimum cells per sample-celltype pseudobulk bin")
+    parser.add_argument("--pseudobulk-min-counts", type=int, default=1000, help="Minimum total counts per sample-celltype pseudobulk bin")
+    parser.add_argument("--padj-threshold", type=float, default=0.05, help="Adjusted p-value threshold for DE summary plots")
+    parser.add_argument("--log2fc-threshold", type=float, default=1.0, help="log2 fold-change threshold for volcano/summary plots")
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
@@ -363,13 +604,29 @@ def main():
 
     if args.demo:
         adata, _ = sc_io.load_repo_demo_data("pbmc3k_processed")
+        ensure_input_contract(adata)
         input_file = None
     else:
         if not args.input_path:
             raise ValueError("--input required when not using --demo")
-        adata = sc.read_h5ad(args.input_path)
-        sc_io.maybe_warn_standardize_first(adata, source_path=args.input_path, skill_name=SKILL_NAME)
+        adata = sc_io.smart_load(args.input_path, skill_name=SKILL_NAME, preserve_all=True)
         input_file = args.input_path
+
+    if not get_matrix_contract(adata):
+        inferred_x_kind = infer_x_matrix_kind(adata)
+        inferred_raw_kind = None
+        if adata.raw is not None and adata.raw.shape == adata.shape and matrix_looks_count_like(adata.raw.X):
+            inferred_raw_kind = "raw_counts_snapshot"
+        elif adata.raw is not None and adata.raw.shape == adata.shape:
+            inferred_raw_kind = "normalized_expression"
+        layers_contract = {"counts": "raw_counts"} if "counts" in adata.layers else {}
+        record_matrix_contract(
+            adata,
+            x_kind=inferred_x_kind,
+            raw_kind=inferred_raw_kind,
+            layers=layers_contract,
+            producer_skill="input_h5ad",
+        )
 
     logger.info("Input: %d cells x %d genes", adata.n_obs, adata.n_vars)
     method = validate_method_choice(args.method, METHOD_REGISTRY)
@@ -383,6 +640,10 @@ def main():
             sample_key=args.sample_key,
             celltype_key=args.celltype_key,
             source_path=input_file,
+            n_top_genes=args.n_top_genes,
+            logreg_solver=args.logreg_solver,
+            pseudobulk_min_cells=args.pseudobulk_min_cells,
+            pseudobulk_min_counts=args.pseudobulk_min_counts,
         ),
         logger,
     )
@@ -399,21 +660,37 @@ def main():
             group2=args.group2,
             sample_key=args.sample_key or "sample_id",
             celltype_key=args.celltype_key,
+            pseudobulk_min_cells=args.pseudobulk_min_cells,
+            pseudobulk_min_counts=args.pseudobulk_min_counts,
         )
         full_df.to_csv(tables_dir / "de_full.csv", index=False)
         sig_df = full_df.sort_values("padj", na_position="last")
         sig_df.to_csv(tables_dir / "markers_top.csv", index=False)
+        generate_pseudobulk_figures(
+            full_df,
+            output_dir,
+            padj_threshold=args.padj_threshold,
+            log2fc_threshold=args.log2fc_threshold,
+        )
     elif method == "mast":
         full_df, summary = run_de_mast_method(adata, groupby=args.groupby, group1=args.group1, group2=args.group2)
-        top_df = full_df.sort_values(["padj", "pvalue"], na_position="last").groupby("group").head(args.n_top_genes)
+        top_df = full_df.sort_values(["padj", "pvalue"], na_position="last").groupby("group", observed=False).head(args.n_top_genes)
         full_df.to_csv(tables_dir / "de_full.csv", index=False)
         top_df.to_csv(tables_dir / "markers_top.csv", index=False)
+        generate_tabular_de_figures(full_df, top_df, output_dir, group_col="group", gene_col="gene")
     else:
-        full_df, summary = run_de_scanpy(adata, args.groupby, method, args.group1, args.group2)
-        top_df = full_df.groupby("group").head(args.n_top_genes)
+        full_df, summary = run_de_scanpy(
+            adata,
+            args.groupby,
+            method,
+            args.group1,
+            args.group2,
+            logreg_solver=args.logreg_solver,
+        )
+        top_df = full_df.groupby("group", observed=False).head(args.n_top_genes)
         full_df.to_csv(tables_dir / "de_full.csv", index=False)
         top_df.to_csv(tables_dir / "markers_top.csv", index=False)
-        generate_figures(adata, output_dir, min(5, args.n_top_genes))
+        generate_scanpy_figures(adata, full_df, top_df, output_dir, min(5, args.n_top_genes))
 
     summary["n_cells"] = int(adata.n_obs)
     summary.setdefault("requested_method", method)
@@ -425,14 +702,30 @@ def main():
         "requested_method": summary["requested_method"],
         "executed_method": summary["executed_method"],
         "n_top_genes": args.n_top_genes,
+        "logreg_solver": args.logreg_solver if method == "logreg" else None,
         "group1": args.group1,
         "group2": args.group2,
         "sample_key": args.sample_key,
         "celltype_key": args.celltype_key,
-        "expression_source": summary.get("expression_source", ("adata.raw" if (adata.raw is not None and adata.raw.shape == adata.shape and method != "deseq2_r") else ("layers.counts" if "counts" in adata.layers else "adata.X"))),
+        "pseudobulk_min_cells": args.pseudobulk_min_cells if method == "deseq2_r" else None,
+        "pseudobulk_min_counts": args.pseudobulk_min_counts if method == "deseq2_r" else None,
+        "padj_threshold": args.padj_threshold,
+        "log2fc_threshold": args.log2fc_threshold,
+        "expression_source": summary.get("expression_source", "adata.X"),
     }
 
     write_report(output_dir, summary, input_file, params)
+
+    source_matrix_contract = get_matrix_contract(adata)
+    propagate_singlecell_contracts(
+        adata,
+        adata,
+        producer_skill=SKILL_NAME,
+        x_kind=source_matrix_contract.get("X") or infer_x_matrix_kind(adata),
+        raw_kind=source_matrix_contract.get("raw") or raw_matrix_kind(adata),
+        primary_cluster_key=source_matrix_contract.get("primary_cluster_key"),
+    )
+    store_analysis_metadata(adata, SKILL_NAME, summary["executed_method"], params)
 
     output_h5ad = output_dir / "processed.h5ad"
     adata.write_h5ad(output_h5ad)
@@ -453,7 +746,6 @@ def main():
         "data": result_data,
     }
     write_standard_run_artifacts(output_dir, result_payload, summary)
-    store_analysis_metadata(adata, SKILL_NAME, summary["executed_method"], params)
 
     print(f"Success: {SKILL_NAME}")
     print(f"  Output: {output_dir}")

--- a/skills/singlecell/scrna/sc-de/tests/test_sc_de.py
+++ b/skills/singlecell/scrna/sc-de/tests/test_sc_de.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import anndata as ad
 import pytest
 
 SKILL_SCRIPT = Path(__file__).resolve().parent.parent / "sc_de.py"
@@ -57,3 +58,33 @@ def test_demo_result_json(tmp_output):
     data = json.loads((tmp_output / "result.json").read_text())
     assert data["skill"] == "sc-de"
     assert "summary" in data
+
+
+def test_logreg_demo_runs(tmp_output):
+    """Logistic-regression DE should run in demo mode."""
+    result = subprocess.run(
+        [sys.executable, str(SKILL_SCRIPT), "--demo", "--method", "logreg", "--output", str(tmp_output)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    report = (tmp_output / "report.md").read_text()
+    assert "logreg" in report
+
+
+def test_processed_output_carries_contract_and_analysis(tmp_output):
+    """processed.h5ad should persist matrix contract and DE analysis metadata."""
+    result = subprocess.run(
+        [sys.executable, str(SKILL_SCRIPT), "--demo", "--output", str(tmp_output)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    adata = ad.read_h5ad(tmp_output / "processed.h5ad")
+    assert "omicsclaw_matrix_contract" in adata.uns
+    assert "omicsclaw_input_contract" in adata.uns
+    assert "omicsclaw_sc-de" in adata.uns


### PR DESCRIPTION
## Summary
- align `sc-de` with the singlecell contract by using normalized `adata.X` for exploratory DE and explicit raw-count sources for pseudobulk `deseq2_r`
- add `logreg` as an exploratory DE method and expose method-specific parameters/guidance for `logreg`, `mast`, and `deseq2_r`
- improve DE outputs with `figure_data`, effect/group summary plots, pseudobulk volcano/MA plots, and stronger upstream/downstream guidance
- fix `processed.h5ad` persistence so contracts and analysis metadata are written before save, and sync `SKILL.md`, knowhow, guide, and tests

## Validation
- `source /data/liying_environ/anaconda3_liying/bin/activate && conda activate omicsclaw && python -m pytest -q skills/singlecell/scrna/sc-de/tests/test_sc_de.py tests/test_sc_preflight.py tests/test_knowhow.py tests/test_registry.py`
- smoke outputs generated under:
  - `output/review_sc_de_wilcoxon`
  - `output/review_sc_de_logreg`
  - `output/review_sc_de_mast`
  - `output/review_sc_de_deseq2`

## Notes
- exploratory methods now assume `X = normalized_expression`; they no longer silently prefer `adata.raw`
- `deseq2_r` still focuses on pairwise contrasts, but now surfaces pseudobulk binning thresholds explicitly and reports the actual count source used
- pseudobulk smoke validation used a locally constructed raw-count test input with explicit `condition`, `sample_id`, and `cell_type` columns to exercise the full DESeq2 path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added logistic regression (`logreg`) as a new differential expression analysis method.
  * Added configurable parameters: `--logreg-solver`, `--pseudobulk-min-cells`, `--pseudobulk-min-counts`, `--padj-threshold`, and `--log2fc-threshold`.
  * Added new visualization outputs: effect summaries, group summaries, and ranked gene panels.

* **Improvements**
  * Updated expression layer guidance—exploratory methods now use normalized expression from `adata.X`.
  * Enhanced workflow guidance for clustering prerequisites and preprocessing order.
  * Improved raw count source detection for DESeq2 analysis.

* **Documentation**
  * Updated skill documentation and guardrails with refined method-specific wording and input requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->