### PR TITLE
Add scRNA statistical enrichment skill with ORA and GSEA

### DIFF
--- a/knowledge_base/knowhows/KH-sc-de-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-de-guardrails.md
@@ -24,4 +24,5 @@ source_urls:
 - **Stop for pseudobulk design gaps**: do not run `deseq2_r` until the user has confirmed the condition column, both contrast groups, the replicate column, and the cell-type column.
 - **Stop for clustering gaps**: do not pretend you can produce cluster markers when the object has no cluster/label column yet; send the user to `sc-clustering` first.
 - **Be honest about runtime dependencies**: `mast` and `deseq2_r` are real public R-backed methods and require their corresponding R stacks; if those stacks are missing, fail clearly instead of implying the method still ran.
+- **Point to the next step**: DE results usually flow into `sc-enrichment` for statistical term interpretation, or `sc-pathway-scoring` when the user instead wants per-cell signature activity.
 - **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-de.md`.

--- a/knowledge_base/knowhows/KH-sc-enrichment-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-enrichment-guardrails.md
@@ -1,0 +1,33 @@
+---
+doc_id: sc-enrichment-guardrails
+domain: singlecell
+skill: sc-enrichment
+critical_rule: MUST distinguish statistical enrichment from per-cell pathway scoring before running sc-enrichment
+summary: Guardrails for single-cell ORA / GSEA on marker or DE rankings.
+related_skills: [sc-enrichment, sc-pathway-scoring, sc-markers, sc-de]
+---
+
+# Guardrails
+
+- **State the question first**:
+  - `sc-enrichment` = statistical enrichment on marker / DE rankings
+  - `sc-pathway-scoring` = per-cell signature activity
+- **Check the upstream source**:
+  - clustered h5ad + `groupby` can auto-rank markers
+  - `sc-markers` output directory can usually be reused directly
+  - `sc-de` output directory is preferred for condition-aware enrichment
+- **Do not hide the gene-set source**:
+  - user must provide a local GMT/JSON or a built-in database key
+  - if a built-in key may require downloading, say so explicitly
+- **Explain the installation path simply**:
+  - Python side: `sc-enrichment` and `sc-pathway-scoring` share the same `singlecell-enrichment` extra
+  - R side: `engine=r` is best installed through conda/mamba prebuilt Bioconductor packages, not ad-hoc source compilation
+- **Method meaning**:
+  - `ora` for thresholded positive genes
+  - `gsea` for full ranked lists
+- **Engine meaning**:
+  - `engine=auto` prefers the R clusterProfiler path when available
+  - `engine=python` keeps the run fully in Python
+  - `engine=r` expects `clusterProfiler` and `enrichplot`
+- **Point to the next step**:
+  - after `sc-enrichment`, users usually go to biological interpretation, `sc-cell-annotation`, or `sc-pathway-scoring`

--- a/knowledge_base/knowhows/KH-sc-input-contract-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-input-contract-guardrails.md
@@ -4,7 +4,7 @@ title: Single-Cell Input Contract Guardrails
 doc_type: knowhow
 critical_rule: MUST decide whether the input can be standardized safely, whether key scientific parameters need user confirmation, or whether required metadata/content is missing and analysis must pause
 domains: [singlecell]
-related_skills: [sc-standardize-input, sc-qc, sc-preprocessing, sc-filter, sc-ambient-removal, sc-doublet-detection, sc-cell-annotation, sc-pseudotime, sc-velocity, sc-batch-integration, sc-de, sc-markers, sc-grn, sc-cell-communication, sc-pathway-scoring]
+related_skills: [sc-standardize-input, sc-qc, sc-preprocessing, sc-filter, sc-ambient-removal, sc-doublet-detection, sc-cell-annotation, sc-pseudotime, sc-velocity, sc-batch-integration, sc-de, sc-markers, sc-enrichment, sc-grn, sc-cell-communication, sc-pathway-scoring]
 phases: [before_run, on_warning]
 search_terms: [singlecell input contract, standardize input, missing metadata, ask user, confirm parameters, insufficient data, 单细胞输入合同, 缺少元数据, 参数确认]
 priority: 1.0

--- a/knowledge_base/knowhows/KH-sc-markers-guardrails.md
+++ b/knowledge_base/knowhows/KH-sc-markers-guardrails.md
@@ -20,5 +20,5 @@ source_urls:
 - **Use method-correct language**: `wilcoxon`, `t-test`, and `logreg` are alternative ranking modes for the same cluster-marker question.
 - **Do not overclaim certainty**: top-ranked markers are candidate discriminative genes, not final cell-type labels by themselves.
 - **Do not confuse with condition DE**: if the user wants treated-vs-control, point them to `sc-de`.
-- **Point to the next step**: after reviewing markers, the usual next branch is `sc-cell-annotation`.
+- **Point to the next step**: after reviewing markers, the usual next branches are `sc-cell-annotation` and `sc-enrichment`.
 - **For detailed parameter strategies**: see `knowledge_base/skill-guides/singlecell/sc-markers.md`.

--- a/knowledge_base/skill-guides/singlecell/sc-enrichment.md
+++ b/knowledge_base/skill-guides/singlecell/sc-enrichment.md
@@ -1,0 +1,174 @@
+---
+doc_id: skill-guide-sc-enrichment
+domain: singlecell
+title: Single-cell statistical enrichment guide
+skill: sc-enrichment
+related_skills: [sc-enrichment]
+version: 0.1.0
+status: implementation-aligned
+---
+
+# sc-enrichment
+
+## What It Is
+
+`sc-enrichment` performs **statistical enrichment** on marker or DE rankings.
+
+Use it for questions like:
+- “What GO / KEGG terms explain this cluster?”
+- “Which Hallmark pathways are enriched in this differential expression contrast?”
+
+Do **not** use it when you want a per-cell signature score on the embedding.  
+That job belongs to `sc-pathway-scoring`.
+
+Quick beginner translation:
+
+- `sc-enrichment`: “which GO/KEGG/Hallmark terms are statistically enriched?”
+- `sc-pathway-scoring`: “how active is this gene set in each cell?”
+
+## Typical Workflow Position
+
+Common paths:
+
+1. `sc-clustering` -> `sc-markers` -> `sc-enrichment`
+2. `sc-clustering` -> `sc-de` -> `sc-enrichment`
+3. `sc-cell-annotation` -> `sc-de` -> `sc-enrichment`
+
+If the user only gives a processed h5ad, the wrapper can auto-rank cluster-vs-rest markers first.
+
+## Methods
+
+| Method | Best for | Key inputs |
+|--------|----------|------------|
+| `ora` | thresholded marker / DEG lists | gene-set source, optional h5ad `groupby`, ORA cutoffs |
+| `gsea` | full ranked lists and subtle coordinated shifts | gene-set source, ranking metric, GSEA size/permutation controls |
+
+Implementation engines:
+
+- `engine=auto`
+  - prefer R `clusterProfiler/enrichplot` when available
+  - otherwise fall back to the Python implementation
+- `engine=python`
+  - local Python execution only
+- `engine=r`
+  - require R packages `clusterProfiler` and `enrichplot`
+
+## Installation Advice
+
+### Python dependency
+
+`sc-enrichment` and `sc-pathway-scoring` share the same Python extra:
+
+```bash
+pip install -e ".[singlecell-enrichment]"
+```
+
+This is the correct first install step for both skills.
+
+### R dependency
+
+If the user wants `engine=r`, the stable recommendation is:
+
+- install prebuilt Bioconductor packages into the **same conda environment**
+- do **not** default to source compilation inside R unless you really have to
+
+Why:
+
+- source installs are slower
+- version mismatches are more common
+- old packages left in the private R library can override newer conda packages
+
+## Required Inputs
+
+Real runs need one gene-set source:
+
+- `--gene-sets <local.gmt/json>`
+- or `--gene-set-db <hallmark|kegg|go_bp|go_cc|go_mf|reactome>`
+- or `--gene-set-from-markers <sc-markers-output-dir-or-table>`
+
+If the input is a plain h5ad and not an upstream output directory, the wrapper also needs a usable cluster / cell-type column for automatic ranking.
+
+So the truly required inputs are:
+
+1. `input`
+2. `output`
+3. one gene-set source
+
+Everything else can start from defaults.
+
+## Beginner Translation Of Key Parameters
+
+- `groupby`
+  - when auto-ranking from h5ad, this decides which labels are compared
+- `ranking_method`
+  - how the wrapper generates marker rankings from h5ad before enrichment
+- `engine`
+  - choose Python, R, or auto-prefer-R execution
+- `ora_padj_cutoff`
+  - which genes count as significant enough to enter ORA
+- `ora_log2fc_cutoff`
+  - how strong a fold change a gene should have before ORA uses it
+- `gsea_ranking_metric`
+  - which ranking column drives preranked GSEA
+- `top_terms`
+  - how many top terms are emphasized in figures and the report
+
+## Gene-set Sources
+
+Built-in library keys currently include:
+
+- `hallmark`
+- `kegg`
+- `go_bp`
+- `go_cc`
+- `go_mf`
+- `reactome`
+
+Users can also provide a custom GMT/JSON file, which is the right choice for lab-specific marker signatures.
+
+Practical advice:
+
+- use `gene_set_db` when you want quick GO/KEGG/Hallmark interpretation
+- use `gene_sets` when you already have a lab-defined marker/signature file
+- use `gene_set_from_markers` when you want to turn one or more cluster marker lists into enrichment gene sets directly
+- first-time `gene_set_db` resolution may need network access to populate cache
+
+## Marker-derived Gene Sets
+
+This is useful when the user says something like:
+
+- “用 cluster 2 的 top100 marker 做富集”
+- “把 T cell 和 NK 的 marker 当成 gene set”
+
+Current parameters:
+
+- `--gene-set-from-markers <sc-markers-output-dir-or-table>`
+- `--marker-group <group or comma-separated groups>`
+- `--marker-top-n <N|all>`
+
+Behavior:
+
+- if `marker_group` is omitted, each marker group becomes its own gene set
+- if `marker_group` is provided, only those groups are converted
+- if `marker_top_n=all`, the full exported marker list for each selected group is used
+
+## Output Meaning
+
+- `tables/enrichment_results.csv`
+  - all tested terms
+- `tables/enrichment_significant.csv`
+  - statistically significant subset
+- `tables/ranking_input.csv`
+  - the ranking that actually drove ORA/GSEA
+- `figures/top_terms_bar.png`
+  - top enriched terms across groups
+- `figures/group_term_dotplot.png`
+  - which terms are strongest in which groups
+- `figures/group_enrichment_summary.png`
+  - how many significant terms each group has
+- `figures/gsea_running_scores.png`
+  - top running enrichment-score panels for GSEA
+- `figures/enrichmap.png`
+  - term-overlap network summarizing how enriched terms relate to each other
+- `figures/ridgeplot.png`
+  - ranking-metric distributions for top enriched terms

--- a/knowledge_base/skill-guides/singlecell/sc-pathway-scoring.md
+++ b/knowledge_base/skill-guides/singlecell/sc-pathway-scoring.md
@@ -28,6 +28,7 @@ Typical order:
 4. interpret pathway activity, then continue to `sc-de` or refined annotation if needed
 
 If the user only says “do enrichment”, first explain that this wrapper scores pathway activity **per cell**, then optionally summarizes it by a label column.
+If the user actually wants GO / KEGG / Reactome term **significance**, redirect them to `sc-enrichment` instead.
 
 ## Step 2: Check The Gene-Set Source
 

--- a/knowledge_base/skill-guides/singlecell/sc-rna-quickstart.md
+++ b/knowledge_base/skill-guides/singlecell/sc-rna-quickstart.md
@@ -34,6 +34,11 @@ Use this guide when the user says something like:
 This guide is intentionally opinionated and focuses on the current mainstream
 OmicsClaw scRNA path.
 
+Important beginner distinction:
+
+- `sc-enrichment` = statistical GO / KEGG / Hallmark term enrichment on marker or DE rankings
+- `sc-pathway-scoring` = per-cell pathway / signature activity scoring
+
 ## The Default Route
 
 For a normal 10x scRNA project, the recommended path is:
@@ -48,6 +53,9 @@ For a normal 10x scRNA project, the recommended path is:
    - `sc-batch-integration` if there are multiple batches / donors / libraries
 7. `sc-clustering`
 8. downstream analysis such as:
+   - `sc-markers`
+   - `sc-enrichment`
+   - `sc-pathway-scoring`
    - `sc-cell-annotation`
    - `sc-de`
    - `sc-pseudotime`

--- a/omicsclaw/core/r_dependency_manager.py
+++ b/omicsclaw/core/r_dependency_manager.py
@@ -72,9 +72,13 @@ R_TIER_PACKAGES: dict[str, list[str]] = {
         "SingleCellExperiment",
         "zellkonverter",
     ],
-    "singlecell-enrichment": [
+    "singlecell-pathway-scoring": [
         "AUCell",
         "GSEABase",
+    ],
+    "singlecell-enrichment": [
+        "clusterProfiler",
+        "enrichplot",
     ],
     # Spatial
     "spatial-deconv": [

--- a/omicsclaw/core/registry.py
+++ b/omicsclaw/core/registry.py
@@ -1011,6 +1011,21 @@ _HARDCODED_SKILLS: dict[str, dict[str, Any]] = {
         "requires_preprocessed": True,
         "saves_h5ad": True,
     },
+    "sc-enrichment": {
+        "domain": "singlecell",
+        "alias": "sc-enrichment",
+        "script": SKILLS_DIR / "singlecell" / "scrna" / "sc-enrichment" / "sc_enrichment.py",
+        "demo_args": ["--demo"],
+        "description": "Statistical GO/KEGG/Reactome/Hallmark enrichment on marker or DE rankings (ORA, preranked GSEA)",
+        "allowed_extra_flags": {
+            "--method", "--engine", "--groupby", "--ranking-method", "--gene-sets", "--gene-set-db", "--species",
+            "--top-terms", "--ora-padj-cutoff", "--ora-log2fc-cutoff", "--ora-max-genes",
+            "--gsea-ranking-metric", "--gsea-min-size", "--gsea-max-size", "--gsea-permutation-num",
+            "--gsea-weight", "--gsea-seed",
+        },
+        "requires_preprocessed": True,
+        "saves_h5ad": True,
+    },
     "sc-grn": {
         "domain": "singlecell",
         "alias": "sc-grn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ singlecell-velocity = [
 ]
 
 singlecell-enrichment = [
-    "gseapy>=1.0.0",                  # sc-pathway-scoring: library-backed pathway scoring
+    "gseapy>=1.0.0",                  # sc-enrichment / sc-pathway-scoring: gene-set libraries and enrichment helpers
 ]
 
 # --------------------------------------------------------------------------- #

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_by": "scripts/generate_catalog.py",
-  "skill_count": 85,
+  "skill_count": 86,
   "skills": [
     {
       "name": "bulkrna-batch-correction",
@@ -1024,6 +1024,28 @@
         "scdblfinder",
         "scds",
         "qc"
+      ],
+      "trigger_keywords": []
+    },
+    {
+      "name": "sc-enrichment",
+      "cli_alias": "sc-enrichment",
+      "description": "Statistical enrichment analysis for single-cell RNA-seq using ORA or preranked GSEA on marker or differential-expression rankings. This skill is for GO/KEGG/Reactome/Hallmark term significance, not per-cell pathway activity scoring.",
+      "version": "0.1.0",
+      "status": "mvp",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python omicsclaw.py run sc-enrichment --demo",
+      "tags": [
+        "singlecell",
+        "enrichment",
+        "ORA",
+        "GSEA",
+        "GO",
+        "KEGG",
+        "Reactome",
+        "Hallmark"
       ],
       "trigger_keywords": []
     },

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -142,6 +142,8 @@ List all available skills with status (ready/planned) and descriptions.
 | integration, batch correction, harmony | sc-batch-integration | Batch correction |
 | differential expression, pseudobulk | sc-de | Differential expression |
 | marker genes, find markers | sc-markers | Marker gene detection |
+| cluster enrichment, marker enrichment, single-cell gsea | sc-enrichment | Statistical enrichment on marker / DE rankings |
+| pathway scoring, signature score | sc-pathway-scoring | Per-cell pathway / signature activity scoring |
 | gene regulatory network, grn, pyscenic | sc-grn | Gene regulatory network |
 
 ### Genomics Keywords → Skills

--- a/skills/orchestrator/omics_orchestrator.py
+++ b/skills/orchestrator/omics_orchestrator.py
@@ -102,6 +102,13 @@ _FALLBACK_KEYWORD_MAPS = {
         "cell communication": "sc-cell-communication",
         "ligand receptor": "sc-cell-communication",
         "cellchat": "sc-cell-communication",
+        "single-cell enrichment": "sc-enrichment",
+        "single cell enrichment": "sc-enrichment",
+        "cluster enrichment": "sc-enrichment",
+        "marker enrichment": "sc-enrichment",
+        "cluster gsea": "sc-enrichment",
+        "pathway scoring": "sc-pathway-scoring",
+        "signature score": "sc-pathway-scoring",
     },
     "genomics": {
         "variant call": "genomics-variant-calling",

--- a/skills/singlecell/_lib/dependency_manager.py
+++ b/skills/singlecell/_lib/dependency_manager.py
@@ -59,7 +59,7 @@ DEPENDENCY_REGISTRY: dict[str, DependencyInfo] = {
 
     # DE
     "pydeseq2": DependencyInfo("pydeseq2", "pip install pydeseq2", "DESeq2 in Python"),
-    "gseapy": DependencyInfo("gseapy", 'pip install -e ".[singlecell-enrichment]"', "Library-backed pathway gene sets"),
+    "gseapy": DependencyInfo("gseapy", 'pip install -e ".[singlecell-enrichment]"', "Single-cell statistical enrichment and pathway-library resolution"),
 }
 
 

--- a/skills/singlecell/_lib/preflight.py
+++ b/skills/singlecell/_lib/preflight.py
@@ -1463,6 +1463,160 @@ def preflight_sc_pathway_scoring(
     return decision
 
 
+def preflight_sc_enrichment(
+    adata: AnnData,
+    *,
+    method: str,
+    engine: str,
+    groupby: str | None,
+    gene_sets_path: str | None,
+    gene_set_db: str | None = None,
+    gene_set_from_markers: str | None = None,
+    marker_group: str | None = None,
+    marker_top_n: str | None = None,
+    source_mode: str | None = None,
+    source_path: str | None = None,
+    ranking_method: str | None = None,
+    demo: bool = False,
+) -> PreflightDecision:
+    decision = PreflightDecision("sc-enrichment")
+    _add_standardization_guidance(decision, adata, source_path=source_path)
+
+    if not demo and not gene_sets_path and not gene_set_db and not gene_set_from_markers:
+        decision.block(
+            "`sc-enrichment` needs a gene-set source. Provide one of: `--gene-sets <local.gmt/json>`, `--gene-set-db <hallmark|kegg|go_bp|...>`, or `--gene-set-from-markers <sc-markers-output>` unless `--demo` is used."
+        )
+
+    if gene_set_db and find_spec("gseapy") is None:
+        decision.block(
+            "`--gene-set-db` needs the optional Python package `gseapy`, which is not installed in the current environment."
+        )
+    elif gene_set_db:
+        decision.add_guidance(
+            f"`--gene-set-db {gene_set_db}` will try to resolve a built-in gene-set library automatically. The first run may need network access to populate the local cache."
+        )
+
+    if gene_set_from_markers:
+        decision.add_guidance(
+            "`--gene-set-from-markers` will convert marker genes into one or more custom gene sets for enrichment."
+        )
+        if marker_group:
+            decision.add_guidance(
+                f"Only marker group(s) `{marker_group}` will be turned into gene sets."
+            )
+        else:
+            decision.add_guidance(
+                "No `--marker-group` was provided, so each marker group in the source table will become its own gene set."
+            )
+        if marker_top_n:
+            decision.add_guidance(
+                f"Marker-derived gene sets will keep `marker_top_n={marker_top_n}` per group."
+            )
+
+    decision.add_guidance(
+        "`sc-enrichment` does statistical term enrichment on marker or DE rankings. If you want per-cell pathway activity scores instead, use `sc-pathway-scoring`."
+    )
+
+    r_missing: list[str] = []
+    if engine in {"auto", "r"}:
+        try:
+            from omicsclaw.core.r_dependency_manager import check_r_tier
+
+            _, r_missing = check_r_tier("singlecell-enrichment")
+        except Exception:
+            r_missing = ["clusterProfiler", "enrichplot"]
+
+    if engine == "r":
+        if r_missing:
+            decision.block(
+                "R enrichment engine needs the singlecell enrichment R stack. "
+                f"Missing packages: {', '.join(r_missing)}."
+            )
+        decision.add_guidance(
+            "`--engine r` will use the clusterProfiler / enrichplot stack and can emit richer statistical enrichment figures such as enrichmap and ridgeplot."
+        )
+    elif engine == "auto":
+        if r_missing:
+            decision.add_guidance(
+                "The R clusterProfiler stack is not fully available, so `engine=auto` would fall back to the Python implementation. "
+                f"Missing R packages: {', '.join(r_missing)}."
+            )
+        else:
+            decision.add_guidance(
+                "The R clusterProfiler stack is available, so `engine=auto` will prefer the richer clusterProfiler / enrichplot implementation."
+            )
+        decision.add_guidance(
+            "`--engine auto` will prefer the R clusterProfiler path when its packages are installed, and otherwise fall back to the Python implementation."
+        )
+    else:
+        decision.add_guidance(
+            "`--engine python` keeps the run fully in Python and does not require the R clusterProfiler stack."
+        )
+
+    if source_mode in {"markers_table", "de_table"}:
+        decision.add_guidance(
+            f"This run will reuse an exported ranking table from `{source_mode}` instead of recomputing markers."
+        )
+    else:
+        if not _normalized_expression_available(adata):
+            decision.block(
+                "`sc-enrichment` auto-ranking expects normalized expression in `adata.X`. Run `sc-preprocessing` first, or provide an output directory from `sc-markers` / `sc-de`."
+            )
+
+        cluster_candidates = []
+        for family in ("cluster", "cell_type"):
+            for column in _obs_candidates(adata, family):
+                if column not in cluster_candidates:
+                    cluster_candidates.append(column)
+
+        if groupby:
+            if groupby not in adata.obs.columns:
+                if cluster_candidates:
+                    decision.require_field(
+                        "groupby",
+                        f"`--groupby {groupby}` was not found. Confirm which cluster/label column should drive automatic ranking: {_format_candidates(cluster_candidates)}.",
+                        aliases=["groupby", "cluster_key"],
+                        flag="--groupby",
+                        choices=cluster_candidates,
+                    )
+                else:
+                    decision.block(
+                        "Automatic enrichment from h5ad needs a cluster/cell-type column in `adata.obs`. Run `sc-clustering` first or provide an output directory from `sc-markers` / `sc-de`."
+                    )
+        elif cluster_candidates:
+            decision.add_guidance(
+                f"No `--groupby` was provided, so automatic ranking will use `{cluster_candidates[0]}`. Other plausible columns: {_format_candidates(cluster_candidates)}."
+            )
+        else:
+            decision.block(
+                "Automatic enrichment from h5ad needs a cluster/cell-type column in `adata.obs`. Run `sc-clustering` first or provide an output directory from `sc-markers` / `sc-de`."
+            )
+
+        if source_mode == "auto_cluster_ranking":
+            decision.add_guidance(
+                f"This run will first compute cluster-vs-rest rankings with `ranking_method={ranking_method or 'wilcoxon'}` and then run `{method}` on those rankings."
+            )
+
+    if method == "ora":
+        decision.add_guidance(
+            "ORA is the right first choice when you already have a thresholded marker or DEG list and want the most enriched terms quickly."
+        )
+    else:
+        decision.add_guidance(
+            "GSEA keeps the full ranked gene list, so it is better when subtle coordinated shifts matter more than hard DEG thresholds."
+        )
+        if source_mode == "markers_table":
+            decision.add_guidance(
+                "A plain marker table is usually thresholded, so this wrapper may rebuild a fuller ranking from `processed.h5ad` for GSEA."
+            )
+
+    decision.add_guidance(
+        "Typical workflow: `sc-clustering` or `sc-de` -> `sc-enrichment` -> interpret terms; use `sc-pathway-scoring` only when you want per-cell signature activity."
+    )
+
+    return decision
+
+
 def apply_preflight(decision: PreflightDecision, logger) -> None:
     """Emit user-facing guidance and raise on blocking conditions."""
     decision.emit(logger)

--- a/skills/singlecell/_lib/stat_enrichment.py
+++ b/skills/singlecell/_lib/stat_enrichment.py
@@ -1,0 +1,585 @@
+"""Statistical enrichment helpers for single-cell gene list and ranked-list analysis."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import scanpy as sc
+from scipy import stats as scipy_stats
+
+from .dependency_manager import get as get_dependency
+
+logger = logging.getLogger(__name__)
+
+GENE_SET_DB_ALIASES = {
+    "hallmark": {"human": "MSigDB_Hallmark_2020", "mouse": "MSigDB_Hallmark_2020"},
+    "kegg": {"human": "KEGG_2021_Human", "mouse": "KEGG_2021_Mouse"},
+    "reactome": {"human": "Reactome_2022", "mouse": "Reactome_2022"},
+    "go_bp": {"human": "GO_Biological_Process_2023", "mouse": "GO_Biological_Process_2023"},
+    "go_cc": {"human": "GO_Cellular_Component_2023", "mouse": "GO_Cellular_Component_2023"},
+    "go_mf": {"human": "GO_Molecular_Function_2023", "mouse": "GO_Molecular_Function_2023"},
+}
+
+RANKING_METRIC_PREFERENCE = ("stat", "scores", "logfoldchanges", "log2FoldChange")
+
+
+def _human_to_mouse_symbol(gene: str) -> str:
+    if not gene:
+        return gene
+    return gene[0].upper() + gene[1:].lower()
+
+
+def build_demo_gene_sets(species: str = "human") -> dict[str, list[str]]:
+    """Return a compact PBMC-style demo gene-set library."""
+    human_sets = {
+        "T_cell_signature": ["LTB", "IL32", "MALAT1", "LTB", "LDHB", "LTB", "MALAT1", "IL7R", "LTB", "MALAT1"],
+        "Cytotoxic_NK_signature": ["NKG7", "GNLY", "PRF1", "GZMB", "CTSW", "CCL5", "KLRD1", "TRAC", "HCST", "TYROBP"],
+        "B_cell_signature": ["MS4A1", "CD79A", "CD79B", "CD74", "HLA-DRA", "HLA-DPB1", "HLA-DQA1", "CD79A", "MS4A1", "CD74"],
+        "Monocyte_inflammatory": ["S100A8", "S100A9", "FCN1", "LYZ", "TYROBP", "LST1", "FCER1G", "LGALS3", "CTSS", "SAT1"],
+        "Antigen_presentation": ["HLA-DPA1", "HLA-DPB1", "HLA-DRA", "HLA-DRB1", "CD74", "CST3", "FCER1A", "HLA-DQA1", "HLA-DQB1", "CYBA"],
+        "Platelet_signature": ["PPBP", "PF4", "SDPR", "GNG11", "NRGN", "GP9", "TUBB1", "ITM2B", "SPARC", "CLU"],
+    }
+    if species == "mouse":
+        return {
+            key: [_human_to_mouse_symbol(gene) for gene in genes]
+            for key, genes in human_sets.items()
+        }
+    return human_sets
+
+
+def read_gene_sets(path: str | Path) -> dict[str, list[str]]:
+    """Load gene sets from GMT or JSON."""
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Gene-set file not found: {file_path}")
+    if file_path.suffix.lower() == ".json":
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("JSON gene-set file must map term -> gene list.")
+        return {
+            str(term): [str(gene) for gene in genes if str(gene).strip()]
+            for term, genes in payload.items()
+            if isinstance(genes, (list, tuple))
+        }
+
+    gene_sets: dict[str, list[str]] = {}
+    for raw_line in file_path.read_text(encoding="utf-8").splitlines():
+        parts = raw_line.rstrip("\n").split("\t")
+        if len(parts) < 3:
+            continue
+        term = str(parts[0]).strip()
+        members = [str(item).strip() for item in parts[2:] if str(item).strip()]
+        if term and members:
+            gene_sets[term] = members
+    if not gene_sets:
+        raise ValueError(f"No valid gene sets parsed from {file_path}")
+    return gene_sets
+
+
+def write_gene_sets_gmt(gene_sets: dict[str, list[str]], output_path: str | Path) -> Path:
+    """Write gene sets to GMT."""
+    output = Path(output_path)
+    lines = ["\t".join([name, "omicsclaw"] + list(dict.fromkeys(genes))) for name, genes in gene_sets.items()]
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return output
+
+
+def _resolve_gene_set_library_name(gene_set_db: str, species: str) -> str:
+    normalized_db = str(gene_set_db).strip().lower()
+    normalized_species = str(species).strip().lower()
+    alias = GENE_SET_DB_ALIASES.get(normalized_db)
+    if alias:
+        return alias.get(normalized_species, alias.get("human", gene_set_db))
+    return str(gene_set_db).strip()
+
+
+def fetch_gene_sets_from_library(gene_set_db: str, *, species: str) -> tuple[dict[str, list[str]], str]:
+    """Resolve gene sets through GSEApy's library downloader."""
+    gp = get_dependency("gseapy")
+    if gp is None:
+        raise ImportError("gseapy is required for `--gene-set-db` but is not installed.")
+
+    organism = "Human" if species.lower().startswith("human") else "Mouse"
+    resolved = _resolve_gene_set_library_name(gene_set_db, species)
+    try:
+        gene_sets = gp.get_library(name=resolved, organism=organism)
+    except TypeError:
+        gene_sets = gp.get_library(resolved, organism=organism)
+    if not gene_sets:
+        raise RuntimeError(f"Resolved library `{resolved}` returned no gene sets.")
+    return {
+        str(name): [str(gene) for gene in genes if str(gene).strip()]
+        for name, genes in gene_sets.items()
+        if genes
+    }, resolved
+
+
+def canonicalize_gene_sets(gene_sets: dict[str, list[str]], universe: pd.Index | list[str]) -> dict[str, list[str]]:
+    """Restrict gene sets to the observed gene universe."""
+    universe_set = {str(gene) for gene in universe}
+    out: dict[str, list[str]] = {}
+    for term, genes in gene_sets.items():
+        overlap = list(dict.fromkeys(str(gene) for gene in genes if str(gene) in universe_set))
+        if overlap:
+            out[str(term)] = overlap
+    return out
+
+
+def auto_rank_markers(
+    adata,
+    *,
+    groupby: str,
+    method: str = "wilcoxon",
+) -> pd.DataFrame:
+    """Compute full cluster-vs-rest rankings from normalized expression."""
+    if groupby not in adata.obs.columns:
+        raise ValueError(f"groupby column `{groupby}` not found in `adata.obs`.")
+    key = f"rank_genes_groups__sc_enrichment__{method.replace('-', '_')}"
+    sc.tl.rank_genes_groups(
+        adata,
+        groupby=groupby,
+        method=method,
+        corr_method="benjamini-hochberg",
+        use_raw=False,
+        n_genes=adata.n_vars,
+        pts=True,
+        key_added=key,
+    )
+    frames: list[pd.DataFrame] = []
+    for group in sorted(adata.obs[groupby].dropna().astype(str).unique().tolist(), key=str):
+        df = sc.get.rank_genes_groups_df(adata, group=group, key=key)
+        if df.empty:
+            continue
+        df.insert(0, "group", str(group))
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame()
+    out = pd.concat(frames, ignore_index=True)
+    for column in ("scores", "logfoldchanges", "pvals", "pvals_adj"):
+        if column in out.columns:
+            out[column] = pd.to_numeric(out[column], errors="coerce")
+    return out
+
+
+def normalize_ranking_table(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize markers/DE tables to a shared single-cell enrichment schema."""
+    out = df.copy()
+    rename_map = {}
+    if "names" in out.columns and "gene" not in out.columns:
+        rename_map["names"] = "gene"
+    if "cell_type" in out.columns and "group" not in out.columns:
+        rename_map["cell_type"] = "group"
+    if "log2FoldChange" in out.columns and "logfoldchanges" not in out.columns:
+        rename_map["log2FoldChange"] = "logfoldchanges"
+    if "padj" in out.columns and "pvals_adj" not in out.columns:
+        rename_map["padj"] = "pvals_adj"
+    if "pvalue" in out.columns and "pvals" not in out.columns:
+        rename_map["pvalue"] = "pvals"
+    out = out.rename(columns=rename_map)
+    if "group" not in out.columns:
+        out["group"] = "all"
+    if "gene" not in out.columns:
+        raise ValueError("Ranking table must contain a gene column (`gene` or `names`).")
+    for column in ("scores", "logfoldchanges", "pvals", "pvals_adj", "stat"):
+        if column in out.columns:
+            out[column] = pd.to_numeric(out[column], errors="coerce")
+    out["group"] = out["group"].astype(str)
+    out["gene"] = out["gene"].astype(str)
+    return out
+
+
+def resolve_ranking_metric(ranking_df: pd.DataFrame, requested: str = "auto") -> str:
+    """Choose the ranking metric for preranked GSEA."""
+    if requested != "auto" and requested in ranking_df.columns and pd.to_numeric(ranking_df[requested], errors="coerce").notna().any():
+        return requested
+    for metric in RANKING_METRIC_PREFERENCE:
+        if metric in ranking_df.columns and pd.to_numeric(ranking_df[metric], errors="coerce").notna().any():
+            return metric
+    raise ValueError("Could not resolve a usable ranking metric for GSEA.")
+
+
+def _benjamini_hochberg(pvalues: np.ndarray) -> np.ndarray:
+    pv = np.asarray(pvalues, dtype=float)
+    n = len(pv)
+    if n == 0:
+        return pv
+    order = np.argsort(pv)
+    sorted_p = pv[order]
+    adjusted = np.empty(n, dtype=float)
+    adjusted[-1] = sorted_p[-1]
+    for i in range(n - 2, -1, -1):
+        rank = i + 1
+        adjusted[i] = min(sorted_p[i] * n / rank, adjusted[i + 1])
+    adjusted = np.clip(adjusted, 0.0, 1.0)
+    result = np.empty(n, dtype=float)
+    result[order] = adjusted
+    return result
+
+
+def _run_hypergeometric_ora(
+    gene_list: list[str],
+    gene_sets: dict[str, list[str]],
+    *,
+    background_size: int,
+) -> pd.DataFrame:
+    """Local ORA fallback using a hypergeometric test."""
+    query = set(gene_list)
+    n = len(query)
+    if n == 0:
+        return pd.DataFrame()
+
+    records: list[dict[str, object]] = []
+    for term, pathway_genes in gene_sets.items():
+        pathway = set(pathway_genes)
+        overlap_genes = sorted(query & pathway)
+        k = len(overlap_genes)
+        K = len(pathway)
+        if k == 0:
+            continue
+        pval = float(scipy_stats.hypergeom.sf(k - 1, background_size, K, n))
+        expected = max(n * (K / max(background_size, 1)), 1e-9)
+        odds_ratio = float(k / expected) if expected > 0 else np.nan
+        combined_score = float(-np.log10(max(pval, 1e-300)) * odds_ratio)
+        records.append(
+            {
+                "Term": term,
+                "Overlap": f"{k}/{K}",
+                "P-value": pval,
+                "Adjusted P-value": np.nan,
+                "Odds Ratio": odds_ratio,
+                "Combined Score": combined_score,
+                "Genes": ";".join(overlap_genes),
+            }
+        )
+    df = pd.DataFrame(records)
+    if df.empty:
+        return df
+    df["Adjusted P-value"] = _benjamini_hochberg(df["P-value"].to_numpy())
+    return df.sort_values("Adjusted P-value", ascending=True).reset_index(drop=True)
+
+
+def _fallback_prerank_gsea(
+    ranking: pd.Series,
+    gene_sets: dict[str, list[str]],
+    *,
+    min_size: int,
+    max_size: int,
+    permutation_num: int,
+    seed: int,
+) -> pd.DataFrame:
+    """Lightweight rank-based GSEA fallback via permutation of mean scores."""
+    ranking = ranking.dropna()
+    ranking = ranking[~ranking.index.duplicated(keep="first")]
+    if ranking.empty:
+        return pd.DataFrame()
+
+    genes = ranking.index.to_numpy()
+    scores = ranking.to_numpy(dtype=float)
+    gene_to_position = {gene: idx for idx, gene in enumerate(genes)}
+    rng = np.random.default_rng(seed)
+    records: list[dict[str, object]] = []
+
+    for term, members in gene_sets.items():
+        positions = [gene_to_position[g] for g in members if g in gene_to_position]
+        if not (min_size <= len(positions) <= max_size):
+            continue
+        observed = float(scores[positions].mean())
+        null = np.array(
+            [
+                float(scores[rng.choice(len(scores), size=len(positions), replace=False)].mean())
+                for _ in range(max(10, int(permutation_num)))
+            ]
+        )
+        null_mean = float(null.mean())
+        null_std = float(null.std()) if float(null.std()) > 0 else 1.0
+        es = observed - null_mean
+        nes = es / null_std
+        pval = float((np.sum(np.abs(null - null_mean) >= abs(es)) + 1) / (len(null) + 1))
+        lead_genes = [gene for gene in ranking.sort_values(ascending=False).index.tolist() if gene in set(members)][:15]
+        records.append(
+            {
+                "Term": term,
+                "ES": es,
+                "NES": nes,
+                "NOM p-val": pval,
+                "FDR q-val": np.nan,
+                "Lead_genes": ";".join(lead_genes),
+            }
+        )
+    df = pd.DataFrame(records)
+    if df.empty:
+        return df
+    df["FDR q-val"] = _benjamini_hochberg(df["NOM p-val"].to_numpy())
+    return df.sort_values("FDR q-val", ascending=True).reset_index(drop=True)
+
+
+def _standardize_ora_results(
+    df: pd.DataFrame,
+    *,
+    group: str,
+    source: str,
+    library_mode: str,
+    engine: str,
+    n_input_genes: int,
+) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame()
+    out = df.copy().rename(
+        columns={
+            "Term": "gene_set",
+            "P-value": "pvalue",
+            "Adjusted P-value": "pvalue_adj",
+            "Combined Score": "score",
+            "Odds Ratio": "odds_ratio",
+            "Overlap": "overlap",
+            "Genes": "genes",
+        }
+    )
+    out["group"] = str(group)
+    out["term"] = out.get("gene_set", "")
+    out["source"] = source
+    out["library_mode"] = library_mode
+    out["engine"] = engine
+    out["method_used"] = "ora"
+    out["n_input_genes"] = int(n_input_genes)
+    out["gene_count"] = out["overlap"].astype(str).str.split("/").str[0].astype(float) if "overlap" in out.columns else np.nan
+    for column in ("pvalue", "pvalue_adj", "score", "odds_ratio", "gene_count"):
+        if column in out.columns:
+            out[column] = pd.to_numeric(out[column], errors="coerce")
+    desired = [
+        "group", "term", "gene_set", "source", "library_mode", "engine", "method_used",
+        "score", "odds_ratio", "gene_count", "overlap", "pvalue", "pvalue_adj", "genes", "n_input_genes",
+    ]
+    for column in desired:
+        if column not in out.columns:
+            out[column] = np.nan
+    return out[desired]
+
+
+def _standardize_gsea_results(
+    df: pd.DataFrame,
+    *,
+    group: str,
+    source: str,
+    library_mode: str,
+    engine: str,
+    ranking_metric: str,
+) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame()
+    out = df.copy().rename(
+        columns={
+            "Term": "gene_set",
+            "NES": "nes",
+            "ES": "es",
+            "NOM p-val": "pvalue",
+            "FDR q-val": "pvalue_adj",
+            "Lead_genes": "leading_edge",
+        }
+    )
+    out["group"] = str(group)
+    out["term"] = out.get("gene_set", "")
+    out["source"] = source
+    out["library_mode"] = library_mode
+    out["engine"] = engine
+    out["method_used"] = "gsea"
+    out["ranking_metric"] = ranking_metric
+    out["score"] = pd.to_numeric(out["nes"], errors="coerce") if "nes" in out.columns else np.nan
+    for column in ("pvalue", "pvalue_adj", "nes", "es", "score"):
+        if column in out.columns:
+            out[column] = pd.to_numeric(out[column], errors="coerce")
+    desired = [
+        "group", "term", "gene_set", "source", "library_mode", "engine", "method_used",
+        "ranking_metric", "score", "nes", "es", "pvalue", "pvalue_adj", "leading_edge",
+    ]
+    for column in desired:
+        if column not in out.columns:
+            out[column] = np.nan
+    return out[desired]
+
+
+def run_ora(
+    ranking_df: pd.DataFrame,
+    *,
+    source: str,
+    library_mode: str,
+    gene_sets: dict[str, list[str]],
+    background_genes: list[str],
+    ora_padj_cutoff: float,
+    ora_log2fc_cutoff: float,
+    ora_max_genes: int,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Run ORA per group on positive ranked genes."""
+    all_records: list[pd.DataFrame] = []
+    warnings: list[str] = []
+    input_gene_counts: dict[str, int] = {}
+
+    for group, group_df in ranking_df.groupby("group", sort=False):
+        filtered = group_df.dropna(subset=["gene"]).copy()
+        if "pvals_adj" in filtered.columns and pd.to_numeric(filtered["pvals_adj"], errors="coerce").notna().any():
+            filtered = filtered[pd.to_numeric(filtered["pvals_adj"], errors="coerce").fillna(np.inf) <= float(ora_padj_cutoff)]
+
+        effect_source = None
+        for candidate in ("logfoldchanges", "scores", "stat"):
+            if candidate in filtered.columns and pd.to_numeric(filtered[candidate], errors="coerce").notna().any():
+                effect_source = candidate
+                break
+        if effect_source == "logfoldchanges":
+            filtered = filtered[pd.to_numeric(filtered["logfoldchanges"], errors="coerce").fillna(-np.inf) >= float(ora_log2fc_cutoff)]
+        elif effect_source in {"scores", "stat"}:
+            filtered = filtered[pd.to_numeric(filtered[effect_source], errors="coerce").fillna(-np.inf) > 0]
+
+        filtered = filtered.head(int(ora_max_genes))
+        genes = filtered["gene"].astype(str).tolist()
+        input_gene_counts[str(group)] = len(genes)
+        if not genes:
+            warnings.append(
+                f"Group `{group}` had no positive genes after ORA filtering (`ora_padj_cutoff={ora_padj_cutoff}`, `ora_log2fc_cutoff={ora_log2fc_cutoff}`)."
+            )
+            continue
+
+        res = _run_hypergeometric_ora(
+            genes,
+            gene_sets,
+            background_size=max(len(background_genes), len(set(background_genes))),
+        )
+        engine = "hypergeometric_local"
+
+        std = _standardize_ora_results(
+            res,
+            group=str(group),
+            source=source,
+            library_mode=library_mode,
+            engine=engine,
+            n_input_genes=len(genes),
+        )
+        all_records.append(std)
+
+    enrich_df = pd.concat(all_records, ignore_index=True) if all_records else pd.DataFrame()
+    return enrich_df, {"warnings": warnings, "n_input_genes_by_group": input_gene_counts}
+
+
+def run_gsea(
+    ranking_df: pd.DataFrame,
+    *,
+    source: str,
+    library_mode: str,
+    gene_sets: dict[str, list[str]],
+    ranking_metric: str,
+    gsea_min_size: int,
+    gsea_max_size: int,
+    gsea_permutation_num: int,
+    gsea_weight: float,
+    gsea_seed: int,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Run preranked GSEA per group."""
+    gp = get_dependency("gseapy")
+    all_records: list[pd.DataFrame] = []
+    warnings: list[str] = []
+    ranking_by_group: dict[str, pd.Series] = {}
+
+    for group, group_df in ranking_df.groupby("group", sort=False):
+        metric = resolve_ranking_metric(group_df, ranking_metric)
+        ranked = (
+            group_df[["gene", metric]]
+            .dropna()
+            .drop_duplicates(subset=["gene"], keep="first")
+            .set_index("gene")[metric]
+            .sort_values(ascending=False)
+        )
+        ranking_by_group[str(group)] = ranked
+        if len(ranked) < 10:
+            warnings.append(f"Group `{group}` had fewer than 10 ranked genes after filtering; skipping GSEA.")
+            continue
+
+        engine = "gseapy.prerank"
+        try:
+            if gp is None:
+                raise ImportError("gseapy not installed")
+            pre = gp.prerank(
+                rnk=ranked,
+                gene_sets=gene_sets,
+                min_size=int(gsea_min_size),
+                max_size=int(gsea_max_size),
+                permutation_num=int(gsea_permutation_num),
+                weight=float(gsea_weight),
+                outdir=None,
+                seed=int(gsea_seed),
+                verbose=False,
+            )
+            if hasattr(pre, "res2d") and isinstance(pre.res2d, pd.DataFrame):
+                res = pre.res2d.copy()
+            else:
+                raise RuntimeError("gseapy prerank returned no tabular result")
+            if res.empty:
+                raise RuntimeError("gseapy prerank returned an empty GSEA result table")
+        except Exception as exc:
+            warnings.append(f"Group `{group}` GSEA fell back to a local rank-based method: {exc}")
+            res = _fallback_prerank_gsea(
+                ranked,
+                gene_sets,
+                min_size=int(gsea_min_size),
+                max_size=int(gsea_max_size),
+                permutation_num=int(gsea_permutation_num),
+                seed=int(gsea_seed),
+            )
+            engine = "rank_based_fallback"
+
+        std = _standardize_gsea_results(
+            res,
+            group=str(group),
+            source=source,
+            library_mode=library_mode,
+            engine=engine,
+            ranking_metric=metric,
+        )
+        all_records.append(std)
+
+    enrich_df = pd.concat(all_records, ignore_index=True) if all_records else pd.DataFrame()
+    return enrich_df, {"warnings": warnings, "ranking_by_group": ranking_by_group}
+
+
+def sort_results(df: pd.DataFrame) -> pd.DataFrame:
+    """Sort enrichment results by significance or score."""
+    if df.empty:
+        return df
+    out = df.copy()
+    if "pvalue_adj" in out.columns and pd.to_numeric(out["pvalue_adj"], errors="coerce").notna().any():
+        return out.sort_values("pvalue_adj", ascending=True, na_position="last", kind="mergesort")
+    if "nes" in out.columns and pd.to_numeric(out["nes"], errors="coerce").notna().any():
+        return out.sort_values("nes", key=lambda s: pd.to_numeric(s, errors="coerce").abs(), ascending=False, na_position="last", kind="mergesort")
+    if "score" in out.columns and pd.to_numeric(out["score"], errors="coerce").notna().any():
+        return out.sort_values("score", key=lambda s: pd.to_numeric(s, errors="coerce").abs(), ascending=False, na_position="last", kind="mergesort")
+    return out
+
+
+def select_top_terms(df: pd.DataFrame, *, top_terms: int, per_group: int = 3) -> pd.DataFrame:
+    """Select a compact set of top terms without letting one group dominate."""
+    if df.empty:
+        return df
+    ordered = sort_results(df)
+    groups = ordered["group"].astype(str).dropna().unique().tolist() if "group" in ordered.columns else []
+    rows: list[pd.DataFrame] = []
+    used: set[tuple[str, str]] = set()
+    for group in groups:
+        group_df = ordered[ordered["group"].astype(str) == group].head(per_group)
+        if not group_df.empty:
+            rows.append(group_df)
+            used.update((str(group), str(term)) for term in group_df["term"].astype(str))
+    combined = pd.concat(rows, ignore_index=True) if rows else ordered.head(top_terms)
+    if len(combined) < top_terms:
+        remainder = ordered[
+            ~ordered.apply(lambda row: (str(row.get("group", "")), str(row.get("term", ""))) in used, axis=1)
+        ].head(max(top_terms - len(combined), 0))
+        combined = pd.concat([combined, remainder], ignore_index=True)
+    return combined.head(top_terms).reset_index(drop=True)
+
+
+def sanitize_term_slug(text: str) -> str:
+    """Convert a term or group into a filename-safe slug."""
+    return re.sub(r"[^A-Za-z0-9_]+", "_", str(text)).strip("_")[:80]

--- a/skills/singlecell/_lib/viz/__init__.py
+++ b/skills/singlecell/_lib/viz/__init__.py
@@ -33,6 +33,15 @@ from .enrichment import (
     plot_pathway_score_distributions,
     plot_top_gene_sets_bar,
 )
+from .stat_enrichment import (
+    compute_running_score_curve,
+    plot_enrichment_enrichmap,
+    plot_enrichment_group_summary,
+    plot_enrichment_group_term_dotplot,
+    plot_enrichment_ridgeplot,
+    plot_enrichment_top_terms_bar,
+    plot_gsea_running_score_panels,
+)
 from .doublet import (
     plot_doublet_call_summary,
     plot_doublet_score_by_group,
@@ -95,6 +104,13 @@ __all__ = [
     "plot_group_mean_dotplot",
     "plot_pathway_score_distributions",
     "plot_enrichment_embedding_panels",
+    "plot_enrichment_top_terms_bar",
+    "plot_enrichment_group_term_dotplot",
+    "plot_enrichment_group_summary",
+    "plot_enrichment_enrichmap",
+    "plot_enrichment_ridgeplot",
+    "compute_running_score_curve",
+    "plot_gsea_running_score_panels",
     "plot_doublet_score_distribution",
     "plot_doublet_call_summary",
     "plot_doublet_score_by_group",

--- a/skills/singlecell/_lib/viz/stat_enrichment.py
+++ b/skills/singlecell/_lib/viz/stat_enrichment.py
@@ -1,0 +1,459 @@
+"""Visualization primitives for single-cell statistical enrichment."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import networkx as nx
+
+from .core import QC_PALETTE, apply_singlecell_theme, save_figure
+
+
+def _sort_groups(groups: list[str]) -> list[str]:
+    def _key(item: str):
+        text = str(item)
+        return (0, int(text)) if text.isdigit() else (1, text)
+
+    return sorted(groups, key=_key)
+
+
+def _display_group_label(group: str) -> str:
+    text = str(group)
+    return f"cluster {text}" if text.isdigit() else text
+
+
+def plot_enrichment_top_terms_bar(
+    top_df: pd.DataFrame,
+    output_dir: Path,
+    *,
+    filename: str = "top_terms_bar.png",
+    title: str = "Top enriched terms by group",
+) -> Path | None:
+    if top_df.empty:
+        return None
+    apply_singlecell_theme()
+    plot_df = top_df.copy()
+    plot_df["group"] = plot_df["group"].astype(str)
+    if "pvalue_adj" in plot_df.columns and plot_df["pvalue_adj"].notna().any():
+        plot_df["display_score"] = -np.log10(pd.to_numeric(plot_df["pvalue_adj"], errors="coerce").clip(lower=1e-300))
+        x_label = "-log10(adjusted p-value)"
+    elif "nes" in plot_df.columns and plot_df["nes"].notna().any():
+        plot_df["display_score"] = pd.to_numeric(plot_df["nes"], errors="coerce")
+        x_label = "NES"
+    else:
+        plot_df["display_score"] = pd.to_numeric(plot_df.get("score"), errors="coerce")
+        x_label = "Score"
+
+    palette = sns.color_palette("tab20", n_colors=max(plot_df["group"].nunique(), 3))
+    ordered_groups = _sort_groups(plot_df["group"].dropna().unique().tolist())
+    group_to_color = {group: palette[idx % len(palette)] for idx, group in enumerate(ordered_groups)}
+    plot_df["y_label"] = plot_df.apply(lambda row: f"{_display_group_label(row['group'])} · {row['term']}", axis=1)
+
+    fig, ax = plt.subplots(figsize=(11, max(5.5, 0.45 * len(plot_df))))
+    sns.barplot(
+        data=plot_df,
+        x="display_score",
+        y="y_label",
+        hue="group",
+        dodge=False,
+        palette=group_to_color,
+        ax=ax,
+    )
+    ax.set_title(title, fontsize=18, fontweight="semibold", pad=14)
+    ax.set_xlabel(x_label, fontsize=12)
+    ax.set_ylabel("")
+    ax.legend(title="Group", frameon=False, bbox_to_anchor=(1.01, 1.0), loc="upper left")
+    for patch, value in zip(ax.patches, plot_df["display_score"].fillna(0.0).tolist()):
+        if math.isfinite(value):
+            ax.text(
+                patch.get_width() + max(abs(patch.get_width()) * 0.02, 0.05),
+                patch.get_y() + patch.get_height() / 2,
+                f"{value:.2f}",
+                va="center",
+                fontsize=9,
+                color="#4D4D4D",
+            )
+    x_min = float(pd.to_numeric(plot_df["display_score"], errors="coerce").min())
+    x_max = float(pd.to_numeric(plot_df["display_score"], errors="coerce").max())
+    span = max(abs(x_max - x_min), 1.0)
+    ax.set_xlim(x_min - 0.08 * span, x_max + 0.18 * span)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_enrichment_group_term_dotplot(
+    top_df: pd.DataFrame,
+    output_dir: Path,
+    *,
+    filename: str = "group_term_dotplot.png",
+    title: str = "Group-by-term enrichment overview",
+) -> Path | None:
+    if top_df.empty or "group" not in top_df.columns or "term" not in top_df.columns:
+        return None
+    apply_singlecell_theme()
+    plot_df = top_df.copy()
+    if "pvalue_adj" in plot_df.columns and plot_df["pvalue_adj"].notna().any():
+        plot_df["dot_size"] = -np.log10(pd.to_numeric(plot_df["pvalue_adj"], errors="coerce").clip(lower=1e-300))
+    else:
+        plot_df["dot_size"] = 1.0
+    if "nes" in plot_df.columns and plot_df["nes"].notna().any():
+        plot_df["dot_color"] = pd.to_numeric(plot_df["nes"], errors="coerce")
+        cmap = "RdBu_r"
+        color_label = "NES"
+    else:
+        plot_df["dot_color"] = pd.to_numeric(plot_df.get("score"), errors="coerce")
+        cmap = "mako"
+        color_label = "Score"
+    plot_df["group"] = plot_df["group"].astype(str)
+    group_order = _sort_groups(plot_df["group"].dropna().unique().tolist())
+    display_map = {group: _display_group_label(group) for group in group_order}
+    term_order = plot_df.groupby("term")["dot_size"].max().sort_values(ascending=False).index.tolist()
+    plot_df["group_display"] = plot_df["group"].map(display_map)
+    group_display_order = [display_map[group] for group in group_order]
+    plot_df["group_display"] = pd.Categorical(plot_df["group_display"], categories=group_display_order, ordered=True)
+    plot_df["term"] = pd.Categorical(plot_df["term"], categories=term_order, ordered=True)
+
+    fig, ax = plt.subplots(figsize=(max(8, 0.9 * len(group_order) + 5), max(5.5, 0.42 * len(term_order))))
+    sns.scatterplot(
+        data=plot_df,
+        x="group_display",
+        y="term",
+        size="dot_size",
+        sizes=(40, 420),
+        hue="dot_color",
+        palette=cmap,
+        hue_norm=None,
+        edgecolor="white",
+        linewidth=0.6,
+        ax=ax,
+        legend=False,
+    )
+    ax.set_title(title, fontsize=18, fontweight="semibold", pad=14)
+    ax.set_xlabel("Group", fontsize=12)
+    ax.set_ylabel("Term", fontsize=12)
+    ax.tick_params(axis="x", labelrotation=0, labelsize=10)
+    ax.tick_params(axis="y", labelsize=10)
+    ax.invert_yaxis()
+    ax.grid(axis="x", alpha=0.2)
+    norm = plt.Normalize(plot_df["dot_color"].min(), plot_df["dot_color"].max())
+    sm = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax, pad=0.02, shrink=0.75)
+    cbar.set_label(color_label)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_enrichment_group_summary(
+    summary_df: pd.DataFrame,
+    output_dir: Path,
+    *,
+    filename: str = "group_enrichment_summary.png",
+    title: str = "Enrichment summary by group",
+) -> Path | None:
+    if summary_df.empty:
+        return None
+    apply_singlecell_theme()
+    plot_df = summary_df.copy()
+    plot_df["group"] = plot_df["group"].astype(str)
+    plot_df = plot_df.set_index("group").loc[_sort_groups(plot_df["group"].tolist())].reset_index()
+    plot_df["group_display"] = plot_df["group"].map(_display_group_label)
+    fig, axes = plt.subplots(1, 2, figsize=(12, max(4.8, 0.55 * len(plot_df))), gridspec_kw={"width_ratios": [1.2, 1.0]})
+    sns.barplot(data=plot_df, y="group_display", x="n_significant", color=QC_PALETTE["bar"], ax=axes[0])
+    axes[0].set_title("Significant terms", fontsize=14, fontweight="semibold")
+    axes[0].set_xlabel("Count")
+    axes[0].set_ylabel("")
+    sns.barplot(data=plot_df, y="group_display", x="top_abs_score", color=QC_PALETTE["accent"], ax=axes[1])
+    axes[1].set_title("Top absolute effect", fontsize=14, fontweight="semibold")
+    axes[1].set_xlabel("Absolute score")
+    axes[1].set_ylabel("")
+    fig.suptitle(title, fontsize=18, fontweight="semibold", y=1.02)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def compute_running_score_curve(
+    ranking: pd.Series,
+    gene_set: list[str],
+    *,
+    weight: float = 1.0,
+) -> pd.DataFrame:
+    """Compute the classic running enrichment-score curve for a ranked gene list."""
+    ranking = ranking.dropna()
+    ranking = ranking[~ranking.index.duplicated(keep="first")]
+    genes = ranking.index.astype(str).tolist()
+    scores = ranking.to_numpy(dtype=float)
+    membership = np.array([gene in set(map(str, gene_set)) for gene in genes], dtype=bool)
+    n_hits = int(membership.sum())
+    if n_hits == 0:
+        return pd.DataFrame(columns=["position", "gene", "rank_score", "hit", "running_score"])
+
+    hit_weights = np.abs(scores[membership]) ** float(weight)
+    hit_weights_sum = float(hit_weights.sum()) if float(hit_weights.sum()) > 0 else 1.0
+    miss_penalty = 1.0 / max(len(genes) - n_hits, 1)
+    running = []
+    hit_ptr = 0
+    current = 0.0
+    for idx, (gene, score, is_hit) in enumerate(zip(genes, scores, membership, strict=False), start=1):
+        if is_hit:
+            current += hit_weights[hit_ptr] / hit_weights_sum
+            hit_ptr += 1
+        else:
+            current -= miss_penalty
+        running.append(
+            {
+                "position": idx,
+                "gene": gene,
+                "rank_score": float(score),
+                "hit": bool(is_hit),
+                "running_score": float(current),
+            }
+        )
+    return pd.DataFrame(running)
+
+
+def plot_gsea_running_score_panels(
+    running_tables: dict[tuple[str, str], pd.DataFrame],
+    output_dir: Path,
+    *,
+    filename: str = "gsea_running_scores.png",
+    title: str = "Top GSEA running scores",
+) -> Path | None:
+    valid_items = [(key, table) for key, table in running_tables.items() if not table.empty]
+    if not valid_items:
+        return None
+    apply_singlecell_theme()
+    n_panels = len(valid_items)
+    n_cols = min(2, n_panels)
+    n_rows = math.ceil(n_panels / n_cols)
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(12, 4.2 * n_rows), squeeze=False)
+    axes_flat = axes.flatten()
+    palette = sns.color_palette("Set2", n_colors=n_panels)
+
+    for idx, ((group, term), table) in enumerate(valid_items):
+        ax = axes_flat[idx]
+        color = palette[idx % len(palette)]
+        ax.plot(table["position"], table["running_score"], color=color, linewidth=2.2)
+        ax.axhline(0, color="#666666", linestyle="--", linewidth=0.8, alpha=0.6)
+        hit_positions = table.loc[table["hit"], "position"].to_numpy()
+        if len(hit_positions):
+            ymin, ymax = ax.get_ylim()
+            tick_top = ymin + 0.12 * (ymax - ymin)
+            ax.vlines(hit_positions, ymin=ymin, ymax=tick_top, color="#444444", linewidth=0.8, alpha=0.55)
+        ax.set_title(f"{group}: {term}", fontsize=12, fontweight="semibold")
+        ax.set_xlabel("Ranked gene position")
+        ax.set_ylabel("Running ES")
+    for ax in axes_flat[n_panels:]:
+        ax.axis("off")
+    fig.suptitle(title, fontsize=18, fontweight="semibold", y=1.02)
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_enrichment_ridgeplot(
+    top_terms_df: pd.DataFrame,
+    ranking_df: pd.DataFrame,
+    gene_sets: dict[str, list[str]],
+    output_dir: Path,
+    *,
+    filename: str = "ridgeplot.png",
+    title: str = "Ranking distributions for enriched terms",
+) -> Path | None:
+    if top_terms_df.empty or ranking_df.empty:
+        return None
+    apply_singlecell_theme()
+
+    rows: list[dict[str, object]] = []
+    for _, row in top_terms_df.head(8).iterrows():
+        group = str(row.get("group", ""))
+        term = str(row.get("term", ""))
+        genes = set(map(str, gene_sets.get(term, [])))
+        if not genes:
+            continue
+        group_df = ranking_df[ranking_df["group"].astype(str) == group].copy()
+        metric = None
+        for candidate in ("stat", "scores", "logfoldchanges", "log2FoldChange", "score"):
+            if candidate in group_df.columns and pd.to_numeric(group_df[candidate], errors="coerce").notna().any():
+                metric = candidate
+                break
+        if metric is None:
+            continue
+        hits = group_df[group_df["gene"].astype(str).isin(genes)].copy()
+        if hits.empty:
+            continue
+        hits["value"] = pd.to_numeric(hits[metric], errors="coerce")
+        hits["group_term"] = f"{_display_group_label(group)} · {term}"
+        rows.extend(hits[["group_term", "value"]].dropna().to_dict(orient="records"))
+
+    if not rows:
+        return None
+
+    plot_df = pd.DataFrame(rows)
+    order = plot_df.groupby("group_term")["value"].median().sort_values(ascending=False).index.tolist()
+    fig, ax = plt.subplots(figsize=(11, max(5, 0.55 * len(order))))
+    sns.violinplot(
+        data=plot_df,
+        x="value",
+        y="group_term",
+        order=order,
+        orient="h",
+        inner=None,
+        cut=0,
+        linewidth=0.9,
+        palette=sns.color_palette("crest", n_colors=max(len(order), 3)),
+        ax=ax,
+    )
+    ax.axvline(0, color="#666666", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax.set_title(title, fontsize=18, fontweight="semibold", pad=14)
+    ax.set_xlabel("Ranking metric value")
+    ax.set_ylabel("")
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)
+
+
+def plot_enrichment_enrichmap(
+    top_terms_df: pd.DataFrame,
+    gene_sets: dict[str, list[str]],
+    output_dir: Path,
+    *,
+    filename: str = "enrichmap.png",
+    title: str = "Term-overlap network",
+) -> Path | None:
+    if top_terms_df.empty:
+        return None
+    apply_singlecell_theme()
+
+    selected = top_terms_df.head(20).copy()
+    selected["term"] = selected["term"].astype(str)
+    selected["group"] = selected["group"].astype(str)
+    if "pvalue_adj" in selected.columns and pd.to_numeric(selected["pvalue_adj"], errors="coerce").notna().any():
+        selected = selected.sort_values("pvalue_adj", ascending=True, na_position="last")
+    elif "score" in selected.columns and pd.to_numeric(selected["score"], errors="coerce").notna().any():
+        selected = selected.sort_values("score", key=lambda s: pd.to_numeric(s, errors="coerce").abs(), ascending=False, na_position="last")
+    selected = selected.drop_duplicates(subset=["term"], keep="first").head(12)
+    if len(selected) < 2:
+        return None
+
+    graph = nx.Graph()
+    for _, row in selected.iterrows():
+        term = str(row["term"])
+        group = _display_group_label(str(row.get("group", "")))
+        node_id = term
+        score = float(pd.to_numeric(pd.Series([row.get("score")]), errors="coerce").fillna(0.0).iloc[0])
+        graph.add_node(node_id, score=score, group=group, term=term, label=term)
+
+    selected_records = selected.to_dict(orient="records")
+    for i, row_a in enumerate(selected_records):
+        node_a = str(row_a["term"])
+        genes_a = set(map(str, gene_sets.get(str(row_a["term"]), [])))
+        for row_b in selected_records[i + 1:]:
+            node_b = str(row_b["term"])
+            genes_b = set(map(str, gene_sets.get(str(row_b["term"]), [])))
+            if not genes_a or not genes_b:
+                continue
+            overlap = len(genes_a & genes_b)
+            union = len(genes_a | genes_b)
+            if overlap == 0 or union == 0:
+                continue
+            jaccard = overlap / union
+            if jaccard >= 0.1:
+                graph.add_edge(node_a, node_b, weight=jaccard, overlap=overlap)
+
+    if graph.number_of_edges() == 0:
+        return None
+
+    pos = nx.spring_layout(graph, seed=42, weight="weight")
+    fig, ax = plt.subplots(figsize=(11.5, 8.5))
+    node_scores = np.array([max(abs(graph.nodes[node].get("score", 0.0)), 0.1) for node in graph.nodes], dtype=float)
+    node_sizes = 420 + 950 * (node_scores / max(node_scores.max(), 1.0))
+    edge_widths = [1.4 + 8 * graph.edges[edge]["weight"] for edge in graph.edges]
+    groups = [graph.nodes[node]["group"] for node in graph.nodes]
+    unique_groups = _sort_groups(list(dict.fromkeys(groups)))
+    palette = sns.color_palette("Spectral", n_colors=max(len(unique_groups), 3))
+    group_to_color = {group: palette[idx % len(palette)] for idx, group in enumerate(unique_groups)}
+    node_colors = [group_to_color[graph.nodes[node]["group"]] for node in graph.nodes]
+    nx.draw_networkx_edges(graph, pos, width=edge_widths, alpha=0.22, edge_color="#7A7A7A", ax=ax)
+    nx.draw_networkx_nodes(
+        graph,
+        pos,
+        node_size=node_sizes,
+        node_color=node_colors,
+        linewidths=1.2,
+        edgecolors="white",
+        alpha=0.92,
+        ax=ax,
+    )
+
+    texts = []
+    for node, (x, y) in pos.items():
+        label = graph.nodes[node]["label"]
+        texts.append(
+            ax.text(
+                x,
+                y,
+                label,
+                fontsize=8.6,
+                fontweight="semibold",
+                ha="center",
+                va="center",
+                color="#1F1F1F",
+                bbox={
+                    "boxstyle": "round,pad=0.18",
+                    "facecolor": "white",
+                    "edgecolor": "none",
+                    "alpha": 0.82,
+                },
+                zorder=5,
+            )
+        )
+
+    try:
+        from adjustText import adjust_text
+
+        adjust_text(
+            texts,
+            ax=ax,
+            expand=(1.15, 1.25),
+            force_text=(0.45, 0.55),
+            force_static=(0.25, 0.25),
+            arrowprops={
+                "arrowstyle": "-",
+                "color": "#8A8A8A",
+                "lw": 0.6,
+                "alpha": 0.55,
+            },
+        )
+    except Exception:
+        pass
+
+    legend_handles = [
+        plt.Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="none",
+            markerfacecolor=group_to_color[group],
+            markeredgecolor="white",
+            markeredgewidth=1.0,
+            markersize=10,
+            label=group,
+        )
+        for group in unique_groups
+    ]
+    if legend_handles:
+        ax.legend(
+            handles=legend_handles,
+            title="Main group",
+            frameon=False,
+            bbox_to_anchor=(1.02, 1.0),
+            loc="upper left",
+        )
+    ax.set_title(title, fontsize=18, fontweight="semibold", pad=14)
+    ax.axis("off")
+    fig.tight_layout()
+    return save_figure(fig, output_dir, filename)

--- a/skills/singlecell/scrna/sc-enrichment/SKILL.md
+++ b/skills/singlecell/scrna/sc-enrichment/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: sc-enrichment
+description: >-
+  Statistical enrichment analysis for single-cell RNA-seq using ORA or
+  preranked GSEA on marker or differential-expression rankings. This skill is
+  for GO/KEGG/Reactome/Hallmark term significance, not per-cell pathway
+  activity scoring.
+version: 0.1.0
+author: OmicsClaw
+license: MIT
+tags: [singlecell, enrichment, ORA, GSEA, GO, KEGG, Reactome, Hallmark]
+metadata:
+  omicsclaw:
+    domain: singlecell
+    allowed_extra_flags:
+      - "--gene-set-db"
+      - "--gene-set-from-markers"
+      - "--gene-sets"
+      - "--engine"
+      - "--groupby"
+      - "--gsea-max-size"
+      - "--gsea-min-size"
+      - "--gsea-permutation-num"
+      - "--gsea-ranking-metric"
+      - "--gsea-seed"
+      - "--gsea-weight"
+      - "--marker-group"
+      - "--marker-top-n"
+      - "--method"
+      - "--ora-log2fc-cutoff"
+      - "--ora-max-genes"
+      - "--ora-padj-cutoff"
+      - "--ranking-method"
+      - "--species"
+      - "--top-terms"
+    param_hints:
+      ora:
+        priority: "gene_sets/gene_set_db/gene_set_from_markers -> engine -> upstream ranking source -> groupby/ranking_method -> ora thresholds"
+        params: ["gene_sets", "gene_set_db", "gene_set_from_markers", "marker_group", "marker_top_n", "engine", "groupby", "ranking_method", "ora_padj_cutoff", "ora_log2fc_cutoff", "ora_max_genes", "species", "top_terms"]
+        defaults: {engine: "auto", ranking_method: "wilcoxon", ora_padj_cutoff: 0.05, ora_log2fc_cutoff: 0.25, ora_max_genes: 200, species: "human", top_terms: 18}
+        requires: ["gene_set_source", "normalized_expression_or_upstream_ranking"]
+        tips:
+          - "--method ora: best for thresholded marker/DE gene lists when you want the most enriched terms quickly."
+          - "If you only provide a processed h5ad, the wrapper can auto-rank cluster markers first using `ranking_method`."
+          - "If you already ran `sc-markers` or `sc-de`, passing that output directory lets the wrapper reuse exported rankings."
+      gsea:
+        priority: "gene_sets/gene_set_db/gene_set_from_markers -> engine -> upstream ranking source -> groupby/ranking_method -> gsea ranking controls"
+        params: ["gene_sets", "gene_set_db", "gene_set_from_markers", "marker_group", "marker_top_n", "engine", "groupby", "ranking_method", "gsea_ranking_metric", "gsea_min_size", "gsea_max_size", "gsea_permutation_num", "gsea_weight", "gsea_seed", "species", "top_terms"]
+        defaults: {engine: "auto", ranking_method: "wilcoxon", gsea_ranking_metric: "auto", gsea_min_size: 5, gsea_max_size: 500, gsea_permutation_num: 100, gsea_weight: 1.0, gsea_seed: 123, species: "human", top_terms: 18}
+        requires: ["gene_set_source", "full_ranked_gene_list"]
+        tips:
+          - "--method gsea: keeps the full ranking and is better when subtle coordinated shifts matter more than hard DEG thresholds."
+          - "If the input is a filtered marker table, OmicsClaw may rebuild a fuller ranking from `processed.h5ad`."
+          - "`gsea_ranking_metric=auto` prefers `stat`, then `scores`, then `logfoldchanges`."
+    saves_h5ad: true
+    requires_preprocessed: true
+    requires:
+      bins: [python3]
+      env: []
+      config: []
+    emoji: "🧭"
+    homepage: https://github.com/TianGzlab/OmicsClaw
+    os: [macos, linux]
+    install:
+      - kind: pip
+        package: gseapy
+        bins: []
+      - kind: pip
+        package: scanpy
+        bins: []
+    trigger_keywords:
+      - sc enrichment
+      - single-cell enrichment
+      - GO enrichment
+      - KEGG enrichment
+      - GSEA
+      - ORA
+      - pathway enrichment
+---
+
+# Single-Cell Statistical Enrichment
+
+## Why This Exists
+
+- **Without it**: users jump from marker genes to pathway interpretation with ad-hoc exports and no clear distinction between statistical enrichment and per-cell pathway scoring.
+- **With it**: OmicsClaw can reuse `sc-markers` / `sc-de` outputs or auto-rank a clustered h5ad, then run ORA or preranked GSEA with standardized outputs.
+- **Why OmicsClaw**: it keeps the workflow local-first, makes upstream/downstream guidance explicit, and preserves the singlecell output contract.
+
+## Core Capabilities
+
+1. **ORA** on positive marker / DEG lists.
+2. **Preranked GSEA** on full group-specific rankings.
+3. **Flexible upstream intake**:
+   - output directory from `sc-markers`
+   - output directory from `sc-de`
+   - processed `.h5ad` with automatic cluster-vs-rest ranking
+4. **Marker-derived custom gene sets**:
+   - convert one or more `sc-markers` groups into gene sets directly
+4. **Local-first gene-set sources**:
+   - local `.gmt` / `.json`
+   - built-in library keys via `--gene-set-db`
+5. **Standard outputs**:
+   - `processed.h5ad`
+   - figures, tables, figure-ready CSV exports
+   - report and reproducibility helpers
+
+## Scope Boundary
+
+This skill performs **statistical enrichment**.
+
+- Use `sc-enrichment` when you want GO / KEGG / Reactome / Hallmark terms that are statistically over-represented or enriched.
+- Use `sc-pathway-scoring` when you want a pathway/signature score for each individual cell.
+
+In plain language:
+
+- `sc-enrichment` answers: “which biological terms are significantly enriched?”
+- `sc-pathway-scoring` answers: “how active is this gene signature in each cell?”
+
+## Input Formats
+
+| Format | Supported? | Notes |
+|--------|------------|-------|
+| `sc-markers` output directory | yes | reuses `tables/markers_all.csv` when possible |
+| `sc-de` output directory | yes | reuses `tables/de_full.csv` when possible |
+| processed `.h5ad` | yes | auto-ranks cluster-vs-rest markers when needed |
+| `--demo` | yes | PBMC-style demo with built-in demo gene sets |
+
+## Input Expectations
+
+- A gene-set source is required unless `--demo` is used:
+  - `--gene-sets <local.gmt/json>`
+  - or `--gene-set-db <hallmark|kegg|go_bp|go_cc|go_mf|reactome>`
+  - or `--gene-set-from-markers <sc-markers-output-dir-or-table>`
+- If you pass a plain `.h5ad`, the wrapper expects normalized expression in `adata.X` and a usable cluster/cell-type column.
+- If you want condition DE enrichment with biological replicates, run `sc-de` first and then pass that output directory here.
+- If you use `--gene-set-from-markers`, you can additionally specify:
+  - `--marker-group <cluster or comma-separated groups>`
+  - `--marker-top-n <N|all>`
+
+## Environment And Installation
+
+### Python side
+
+Both `sc-enrichment` and `sc-pathway-scoring` share the same Python extra:
+
+```bash
+pip install -e ".[singlecell-enrichment]"
+```
+
+This installs `gseapy`, which is needed for:
+
+- built-in library keys such as `--gene-set-db hallmark`
+- Python GSEA execution
+- local-first enrichment fallback helpers
+
+### R side
+
+If you want `--engine r`, the most reliable path is to install **prebuilt**
+Bioconductor packages into the same conda environment instead of compiling
+everything from source inside R.
+
+Recommended approach:
+
+```bash
+micromamba install -p <your_conda_prefix> -y \
+  --override-channels \
+  -c https://conda.anaconda.org/conda-forge \
+  -c https://conda.anaconda.org/bioconda \
+  bioconductor-clusterprofiler bioconductor-enrichplot bioconductor-ggtree
+```
+
+Human explanation:
+
+- `engine=python` needs the Python extra only
+- `engine=r` additionally needs the R `clusterProfiler/enrichplot` stack
+- `engine=auto` prefers the R path when that stack is installed, and otherwise
+  falls back to the Python implementation
+
+Important note:
+
+- OmicsClaw uses the current conda environment's `Rscript` and prioritizes that
+  environment's private R library path
+- if old package versions are left in the private R library, they can override
+  newer packages that already exist inside the conda environment
+
+## Workflow
+
+1. Load the upstream output or processed h5ad.
+2. Preflight the question:
+   - statistical enrichment here
+   - per-cell activity scoring belongs in `sc-pathway-scoring`
+3. Resolve the ranking source:
+   - reuse marker / DE tables
+   - or auto-rank cluster markers from h5ad
+4. Resolve gene sets from a local file or built-in database key.
+5. Run ORA or preranked GSEA.
+6. Export tables, figures, `figure_data`, report, and `processed.h5ad`.
+
+## CLI Reference
+
+```bash
+python omicsclaw.py run sc-enrichment \
+  --input <sc-markers-output-dir> \
+  --method ora \
+  --engine auto \
+  --gene-set-db go_bp \
+  --output <dir>
+
+python omicsclaw.py run sc-enrichment \
+  --input <processed.h5ad> \
+  --groupby leiden \
+  --method gsea \
+  --engine r \
+  --gene-sets <local.gmt> \
+  --output <dir>
+
+python omicsclaw.py run sc-enrichment \
+  --input <sc-de-output-dir> \
+  --method ora \
+  --gene-set-from-markers <sc-markers-output-dir> \
+  --marker-group "CD4 T cells,CD8 T cells" \
+  --marker-top-n 100 \
+  --output <dir>
+
+python omicsclaw.py run sc-enrichment --demo --method ora --output <dir>
+```
+
+## Public Parameters
+
+| Parameter | Role |
+|-----------|------|
+| `--method` | `ora` or `gsea` |
+| `--engine` | `auto`, `python`, or `r` |
+| `--gene-sets` | local GMT/JSON gene-set file |
+| `--gene-set-db` | built-in library key (`hallmark`, `kegg`, `go_bp`, `reactome`, …) |
+| `--gene-set-from-markers` | derive gene sets directly from a `sc-markers` output directory or marker table |
+| `--marker-group` | which marker groups to convert into gene sets (comma-separated); omit to convert all groups |
+| `--marker-top-n` | how many marker genes to keep per selected group, or `all` |
+| `--groupby` | grouping column when auto-ranking from h5ad |
+| `--ranking-method` | marker-ranking method used for auto-generated rankings |
+| `--top-terms` | how many terms to emphasize in figures/reports |
+| `--ora-padj-cutoff` | ORA significance filter on the input ranking |
+| `--ora-log2fc-cutoff` | ORA effect-size filter when fold change exists |
+| `--ora-max-genes` | maximum input genes per group for ORA |
+| `--gsea-ranking-metric` | which column drives preranked GSEA |
+| `--gsea-min-size` / `--gsea-max-size` | gene-set size limits for GSEA |
+| `--gsea-permutation-num` | permutation count for GSEA |
+| `--gsea-weight` | weighting exponent for GSEA |
+| `--gsea-seed` | deterministic GSEA seed |
+
+### Which parameters are truly required?
+
+For real runs, the minimum required information is:
+
+1. input source
+2. output directory
+3. one gene-set source
+
+That means:
+
+- `--input ...` or `--demo`
+- `--output ...`
+- and one of:
+  - `--gene-sets ...`
+  - `--gene-set-db ...`
+  - `--gene-set-from-markers ...`
+
+Everything else has a default and can be tuned later.
+
+## Output Contract
+
+Successful runs write:
+
+- `processed.h5ad`
+- `report.md`
+- `result.json`
+- `tables/enrichment_results.csv`
+- `tables/enrichment_significant.csv`
+- `tables/group_summary.csv`
+- `tables/ranking_input.csv`
+- `figure_data/manifest.json`
+- `reproducibility/commands.sh`
+
+### Visualization Contract
+
+The standard gallery focuses on:
+
+- top enriched terms across groups
+- group-by-term comparison
+- group summary
+- GSEA running-score details when applicable
+- when `engine=r` and the R stack is available, supplementary clusterProfiler figures such as enrichmap and ridgeplot
+
+## Beginner Guidance
+
+- After clustering and marker discovery, use `sc-enrichment` to ask “what biology do these groups represent?”
+- If you instead want “where is this pathway active in the embedding?”, use `sc-pathway-scoring`.
+- If you need stronger condition-aware rankings first, run `sc-de` before enrichment.
+
+## Related Skills
+
+- `sc-markers`
+- `sc-de`
+- `sc-pathway-scoring`
+- `sc-cell-annotation`

--- a/skills/singlecell/scrna/sc-enrichment/rscripts/sc_clusterprofiler_enrichment.R
+++ b/skills/singlecell/scrna/sc-enrichment/rscripts/sc_clusterprofiler_enrichment.R
@@ -1,0 +1,184 @@
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 6) {
+  stop(
+    paste(
+      "Usage: sc_clusterprofiler_enrichment.R",
+      "<method: ora|gsea>",
+      "<ranking_csv>",
+      "<universe_txt>",
+      "<gene_sets_gmt>",
+      "<output_dir>",
+      "<top_terms>",
+      "[min_size max_size permutation_num seed]"
+    )
+  )
+}
+
+method <- args[[1]]
+ranking_csv <- args[[2]]
+universe_txt <- args[[3]]
+gene_sets_gmt <- args[[4]]
+output_dir <- args[[5]]
+top_terms <- as.integer(args[[6]])
+min_size <- if (length(args) >= 7) as.integer(args[[7]]) else 10L
+max_size <- if (length(args) >= 8) as.integer(args[[8]]) else 500L
+permutation_num <- if (length(args) >= 9) as.integer(args[[9]]) else 100L
+seed <- if (length(args) >= 10) as.integer(args[[10]]) else 123L
+
+dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+suppressPackageStartupMessages({
+  library(clusterProfiler)
+  library(enrichplot)
+  library(ggplot2)
+})
+
+ranking_df <- read.csv(ranking_csv, check.names = FALSE, stringsAsFactors = FALSE)
+if (!all(c("group", "gene") %in% colnames(ranking_df))) {
+  stop("ranking_csv must contain columns: group, gene")
+}
+universe <- readLines(universe_txt, warn = FALSE)
+term2gene <- clusterProfiler::read.gmt(gene_sets_gmt)
+if (!all(c("term", "gene") %in% tolower(colnames(term2gene)))) {
+  colnames(term2gene)[1:2] <- c("term", "gene")
+} else {
+  colnames(term2gene)[1:2] <- c("term", "gene")
+}
+term2gene <- unique(term2gene[, c("term", "gene")])
+
+groups <- unique(as.character(ranking_df$group))
+results_list <- list()
+result_objs <- list()
+
+for (grp in groups) {
+  df_sub <- subset(ranking_df, as.character(group) == grp)
+  if (nrow(df_sub) == 0) {
+    next
+  }
+
+  if (identical(method, "ora")) {
+    genes <- unique(as.character(df_sub$gene))
+    if (length(genes) == 0) {
+      next
+    }
+    enr <- tryCatch(
+      clusterProfiler::enricher(
+        gene = genes,
+        TERM2GENE = term2gene,
+        universe = universe,
+        minGSSize = min_size,
+        maxGSSize = max_size,
+        pvalueCutoff = 1,
+        pAdjustMethod = "BH"
+      ),
+      error = function(e) NULL
+    )
+    if (is.null(enr) || nrow(as.data.frame(enr)) == 0) {
+      next
+    }
+    res <- as.data.frame(enr)
+    res$group <- grp
+    results_list[[grp]] <- res
+    result_objs[[grp]] <- enr
+  } else {
+    score_col <- if ("score" %in% colnames(df_sub)) "score" else if ("scores" %in% colnames(df_sub)) "scores" else stop("GSEA ranking needs a score column")
+    gene_list <- df_sub[[score_col]]
+    names(gene_list) <- as.character(df_sub$gene)
+    gene_list <- sort(gene_list, decreasing = TRUE)
+    gene_list <- gene_list[!duplicated(names(gene_list))]
+    gsea_res <- tryCatch(
+      clusterProfiler::GSEA(
+        geneList = gene_list,
+        TERM2GENE = term2gene,
+        minGSSize = min_size,
+        maxGSSize = max_size,
+        pvalueCutoff = 1,
+        pAdjustMethod = "BH",
+        seed = TRUE,
+        by = "fgsea",
+        verbose = FALSE,
+        eps = 0
+      ),
+      error = function(e) NULL
+    )
+    if (is.null(gsea_res) || nrow(as.data.frame(gsea_res)) == 0) {
+      next
+    }
+    res <- as.data.frame(gsea_res)
+    res$group <- grp
+    results_list[[grp]] <- res
+    result_objs[[grp]] <- gsea_res
+  }
+}
+
+if (length(results_list) == 0) {
+  write.csv(data.frame(), file.path(output_dir, "clusterprofiler_results.csv"), row.names = FALSE)
+  quit(status = 0)
+}
+
+all_results <- do.call(rbind, results_list)
+write.csv(all_results, file.path(output_dir, "clusterprofiler_results.csv"), row.names = FALSE)
+
+signif_col <- if ("p.adjust" %in% colnames(all_results)) "p.adjust" else if ("qvalues" %in% colnames(all_results)) "qvalues" else NULL
+score_col <- if ("NES" %in% colnames(all_results)) "NES" else if ("Count" %in% colnames(all_results)) "Count" else "p.adjust"
+
+if (!is.null(signif_col)) {
+  all_results <- all_results[order(all_results[[signif_col]], decreasing = FALSE), , drop = FALSE]
+}
+
+best_group <- names(result_objs)[1]
+best_obj <- result_objs[[best_group]]
+if (!is.null(signif_col)) {
+  sig_by_group <- sapply(results_list, function(df) sum(df[[signif_col]] <= 0.05, na.rm = TRUE))
+  if (length(sig_by_group) > 0) {
+    best_group <- names(sig_by_group)[which.max(sig_by_group)]
+    best_obj <- result_objs[[best_group]]
+  }
+}
+
+fig_dir <- file.path(output_dir, "r_figures")
+dir.create(fig_dir, recursive = TRUE, showWarnings = FALSE)
+
+safe_plot <- function(expr, filename, width = 10, height = 8) {
+  tryCatch({
+    png(file.path(fig_dir, filename), width = width, height = height, units = "in", res = 180)
+    print(expr)
+    dev.off()
+  }, error = function(e) {
+    try(dev.off(), silent = TRUE)
+  })
+}
+
+safe_plot(barplot(best_obj, showCategory = min(top_terms, 15)) + ggtitle(sprintf("%s (%s)", toupper(method), best_group)), paste0(method, "_barplot_r.png"))
+safe_plot(dotplot(best_obj, showCategory = min(top_terms, 15)) + ggtitle(sprintf("%s (%s)", toupper(method), best_group)), paste0(method, "_dotplot_r.png"))
+
+if (identical(method, "gsea")) {
+  safe_plot(ridgeplot(best_obj, showCategory = min(top_terms, 15)) + ggtitle(sprintf("Ridgeplot (%s)", best_group)), "gsea_ridgeplot.png", width = 11, height = 8)
+  if (nrow(as.data.frame(best_obj)) >= 3) {
+    sim_obj <- tryCatch(pairwise_termsim(best_obj), error = function(e) NULL)
+    if (!is.null(sim_obj)) {
+      safe_plot(emapplot(sim_obj, showCategory = min(top_terms, 25)) + ggtitle(sprintf("Enrichmap (%s)", best_group)), "gsea_enrichmap.png", width = 11, height = 9)
+    }
+  }
+  best_term <- tryCatch(as.data.frame(best_obj)$ID[[1]], error = function(e) NULL)
+  if (!is.null(best_term)) {
+    safe_plot(gseaplot2(best_obj, geneSetID = best_term, title = sprintf("%s (%s)", best_term, best_group)), "gsea_running_score_r.png", width = 10, height = 8)
+  }
+} else {
+  if (nrow(as.data.frame(best_obj)) >= 3) {
+    sim_obj <- tryCatch(pairwise_termsim(best_obj), error = function(e) NULL)
+    if (!is.null(sim_obj)) {
+      safe_plot(emapplot(sim_obj, showCategory = min(top_terms, 25)) + ggtitle(sprintf("Enrichmap (%s)", best_group)), "ora_enrichmap.png", width = 11, height = 9)
+    }
+  }
+}
+
+figures <- list.files(fig_dir, pattern = "\\.png$", full.names = FALSE)
+metadata_lines <- c(
+  "{",
+  sprintf('  "method": "%s",', method),
+  sprintf('  "best_group": "%s",', best_group),
+  paste0('  "figures": ["', paste(figures, collapse = '", "'), '"]'),
+  "}"
+)
+writeLines(metadata_lines, file.path(output_dir, "r_plot_metadata.json"))

--- a/skills/singlecell/scrna/sc-enrichment/sc_enrichment.py
+++ b/skills/singlecell/scrna/sc-enrichment/sc_enrichment.py
@@ -1,0 +1,1098 @@
+#!/usr/bin/env python3
+"""Single-cell statistical enrichment on marker or DE rankings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+try:
+    import anndata
+
+    anndata.settings.allow_write_nullable_strings = True
+except Exception:
+    pass
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from omicsclaw.common.checksums import sha256_file
+from omicsclaw.common.report import (
+    generate_report_footer,
+    generate_report_header,
+    load_result_json,
+    write_output_readme,
+    write_result_json,
+)
+from omicsclaw.core.dependency_manager import validate_r_environment
+from omicsclaw.core.r_script_runner import RScriptRunner
+from skills.singlecell._lib import io as sc_io
+from skills.singlecell._lib.adata_utils import (
+    ensure_input_contract,
+    get_matrix_contract,
+    infer_x_matrix_kind,
+    propagate_singlecell_contracts,
+    store_analysis_metadata,
+)
+from skills.singlecell._lib.export import save_h5ad
+from skills.singlecell._lib.method_config import MethodConfig, validate_method_choice
+from skills.singlecell._lib.preflight import (
+    _format_candidates,
+    _obs_candidates,
+    apply_preflight,
+    preflight_sc_enrichment,
+)
+from skills.singlecell._lib.stat_enrichment import (
+    auto_rank_markers,
+    build_demo_gene_sets,
+    canonicalize_gene_sets,
+    fetch_gene_sets_from_library,
+    normalize_ranking_table,
+    run_gsea,
+    run_ora,
+    sanitize_term_slug,
+    select_top_terms,
+    sort_results,
+    write_gene_sets_gmt,
+    read_gene_sets,
+)
+from skills.singlecell._lib.viz import (
+    compute_running_score_curve,
+    plot_enrichment_enrichmap,
+    plot_enrichment_group_summary,
+    plot_enrichment_group_term_dotplot,
+    plot_enrichment_ridgeplot,
+    plot_enrichment_top_terms_bar,
+    plot_gsea_running_score_panels,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+SKILL_NAME = "sc-enrichment"
+SKILL_VERSION = "0.1.0"
+SCRIPT_REL_PATH = "skills/singlecell/scrna/sc-enrichment/sc_enrichment.py"
+R_SCRIPTS_DIR = Path(__file__).resolve().parent / "rscripts"
+
+METHOD_REGISTRY: dict[str, MethodConfig] = {
+    "ora": MethodConfig(
+        name="ora",
+        description="Over-representation analysis on positive markers / DE genes",
+        dependencies=(),
+    ),
+    "gsea": MethodConfig(
+        name="gsea",
+        description="Preranked gene set enrichment on full marker / DE rankings",
+        dependencies=(),
+    ),
+}
+
+
+def _write_repro_requirements(repro_dir: Path, packages: list[str]) -> None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version as get_version
+    except ImportError:  # pragma: no cover
+        PackageNotFoundError = Exception
+        from importlib_metadata import version as get_version  # type: ignore
+
+    lines: list[str] = []
+    for pkg in packages:
+        try:
+            lines.append(f"{pkg}=={get_version(pkg)}")
+        except PackageNotFoundError:
+            continue
+        except Exception:
+            continue
+    (repro_dir / "requirements.txt").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def write_standard_run_artifacts(output_dir: Path, result_payload: dict, summary: dict) -> None:
+    notebook_path = None
+    try:
+        from omicsclaw.common.notebook_export import write_analysis_notebook
+
+        notebook_path = write_analysis_notebook(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Single-cell statistical enrichment on marker or DE rankings.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "ora"),
+            script_path=Path(__file__).resolve(),
+            actual_command=[sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]],
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Failed to write analysis notebook: %s", exc)
+
+    try:
+        write_output_readme(
+            output_dir,
+            skill_alias=SKILL_NAME,
+            description="Single-cell statistical enrichment on marker or DE rankings.",
+            result_payload=result_payload,
+            preferred_method=summary.get("method", "ora"),
+            notebook_path=notebook_path,
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Failed to write README.md: %s", exc)
+
+
+def _resolve_groupby(adata, requested_groupby: str | None) -> tuple[str | None, list[str], str | None]:
+    candidates = []
+    matrix_contract = get_matrix_contract(adata)
+    primary_cluster_key = matrix_contract.get("primary_cluster_key")
+    if primary_cluster_key and primary_cluster_key in adata.obs.columns:
+        candidates.append(str(primary_cluster_key))
+    for family in ("cluster", "cell_type"):
+        for column in _obs_candidates(adata, family):
+            if column not in candidates:
+                candidates.append(column)
+
+    if requested_groupby:
+        return (requested_groupby if requested_groupby in adata.obs.columns else None), candidates, None
+    if not candidates:
+        return None, candidates, None
+    auto_groupby = candidates[0]
+    guidance = (
+        f"No `--groupby` was provided, so cluster-vs-rest rankings will use `{auto_groupby}`. "
+        f"Other plausible label columns: {_format_candidates(candidates)}."
+    )
+    return auto_groupby, candidates, guidance
+
+
+def _load_adata(input_path: Path):
+    adata = sc_io.smart_load(str(input_path), skill_name=SKILL_NAME, preserve_all=True)
+    ensure_input_contract(adata)
+    return adata
+
+
+def _detect_ranking_source_from_dir(
+    input_dir: Path,
+    *,
+    method: str,
+    adata,
+    groupby: str | None,
+    ranking_method: str,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    tables_dir = input_dir / "tables"
+    markers_path = tables_dir / "markers_all.csv"
+    de_path = tables_dir / "de_full.csv"
+    result_json_path = input_dir / "result.json"
+    upstream_skill = None
+    if result_json_path.exists():
+        try:
+            upstream_skill = json.loads(result_json_path.read_text(encoding="utf-8")).get("skill")
+        except Exception:
+            upstream_skill = None
+
+    if method == "ora" and markers_path.exists():
+        return normalize_ranking_table(pd.read_csv(markers_path)), {
+            "ranking_source": "markers_table",
+            "upstream_skill": upstream_skill or "sc-markers",
+            "auto_ranked": False,
+        }
+
+    if de_path.exists():
+        return normalize_ranking_table(pd.read_csv(de_path)), {
+            "ranking_source": "de_table",
+            "upstream_skill": upstream_skill or "sc-de",
+            "auto_ranked": False,
+        }
+
+    resolved_groupby, candidates, guidance = _resolve_groupby(adata, groupby)
+    if not resolved_groupby:
+        raise ValueError(
+            "This directory did not contain reusable ranking tables, and no valid `groupby` column was found in `processed.h5ad` "
+            f"for automatic cluster-vs-rest ranking. Candidate columns: {_format_candidates(candidates)}."
+        )
+    ranking_df = auto_rank_markers(adata, groupby=resolved_groupby, method=ranking_method)
+    return normalize_ranking_table(ranking_df), {
+        "ranking_source": "auto_cluster_ranking",
+        "upstream_skill": upstream_skill or "processed_h5ad",
+        "auto_ranked": True,
+        "groupby": resolved_groupby,
+        "guidance": guidance,
+    }
+
+
+def _load_input_context(
+    *,
+    input_path: str | None,
+    demo: bool,
+    method: str,
+    groupby: str | None,
+    ranking_method: str,
+    output_dir: Path,
+) -> tuple[object, pd.DataFrame, dict[str, object], str | None]:
+    if demo:
+        adata, _ = sc_io.load_repo_demo_data("pbmc3k_processed")
+        ensure_input_contract(adata)
+        resolved_groupby, candidates, guidance = _resolve_groupby(adata, groupby)
+        if not resolved_groupby:
+            raise ValueError(
+                "Demo single-cell enrichment needs a cluster/cell-type column for auto-ranking, but none was found."
+            )
+        ranking_df = normalize_ranking_table(auto_rank_markers(adata, groupby=resolved_groupby, method=ranking_method))
+        source_meta = {
+            "input_mode": "demo",
+            "ranking_source": "auto_cluster_ranking",
+            "upstream_skill": "demo_pbmc3k_processed",
+            "auto_ranked": True,
+            "groupby": resolved_groupby,
+            "guidance": guidance,
+            "candidate_groupby": candidates,
+        }
+        return adata, ranking_df, source_meta, None
+
+    if not input_path:
+        raise ValueError("--input is required unless `--demo` is used.")
+
+    path = Path(input_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input path not found: {path}")
+
+    if path.is_dir():
+        processed_h5ad = path / "processed.h5ad"
+        if not processed_h5ad.exists():
+            raise FileNotFoundError(
+                f"Input directory `{path}` does not contain `processed.h5ad`. "
+                "Pass a standard output directory from `sc-markers`/`sc-de` or a processed h5ad directly."
+            )
+        adata = _load_adata(processed_h5ad)
+        ranking_df, source_meta = _detect_ranking_source_from_dir(
+            path,
+            method=method,
+            adata=adata,
+            groupby=groupby,
+            ranking_method=ranking_method,
+        )
+        source_meta["input_mode"] = "upstream_output_dir"
+        source_meta["input_path"] = str(path)
+        return adata, ranking_df, source_meta, str(processed_h5ad)
+
+    if path.suffix.lower() != ".h5ad":
+        raise ValueError(
+            "sc-enrichment currently accepts a processed `.h5ad`, or an output directory from `sc-markers` / `sc-de`."
+        )
+
+    adata = _load_adata(path)
+    resolved_groupby, candidates, guidance = _resolve_groupby(adata, groupby)
+    if not resolved_groupby:
+        raise ValueError(
+            "Direct h5ad input needs a cluster/cell-type column for automatic ranking. "
+            f"Candidate columns: {_format_candidates(candidates)}."
+        )
+    ranking_df = normalize_ranking_table(auto_rank_markers(adata, groupby=resolved_groupby, method=ranking_method))
+    source_meta = {
+        "input_mode": "h5ad_auto_ranking",
+        "ranking_source": "auto_cluster_ranking",
+        "upstream_skill": "input_h5ad",
+        "auto_ranked": True,
+        "groupby": resolved_groupby,
+        "guidance": guidance,
+        "candidate_groupby": candidates,
+    }
+    return adata, ranking_df, source_meta, str(path)
+
+
+def _resolve_gene_sets(
+    *,
+    demo: bool,
+    species: str,
+    gene_sets_path: str | None,
+    gene_set_db: str | None,
+    gene_set_from_markers: str | None,
+    marker_group: str | None,
+    marker_top_n: str,
+    gene_universe: list[str],
+    output_dir: Path,
+) -> tuple[dict[str, list[str]], Path, dict[str, object]]:
+    if demo:
+        gene_sets = canonicalize_gene_sets(build_demo_gene_sets(species=species), gene_universe)
+        resolved_path = write_gene_sets_gmt(gene_sets, output_dir / "demo_gene_sets.gmt")
+        return gene_sets, resolved_path, {
+            "requested_source": "omicsclaw_demo",
+            "resolved_source": "omicsclaw_demo",
+            "library_mode": "builtin_demo",
+        }
+
+    if gene_sets_path:
+        raw_sets = read_gene_sets(gene_sets_path)
+        gene_sets = canonicalize_gene_sets(raw_sets, gene_universe)
+        resolved_path = write_gene_sets_gmt(gene_sets, output_dir / "resolved_gene_sets.gmt")
+        return gene_sets, resolved_path, {
+            "requested_source": str(gene_sets_path),
+            "resolved_source": str(Path(gene_sets_path).name),
+            "library_mode": "local_file",
+        }
+
+    if gene_set_from_markers:
+        marker_source = Path(gene_set_from_markers)
+        marker_table = marker_source
+        if marker_source.is_dir():
+            marker_table = marker_source / "tables" / "markers_all.csv"
+        if not marker_table.exists():
+            raise FileNotFoundError(
+                f"`--gene-set-from-markers` did not resolve to a marker table. Expected `markers_all.csv` at {marker_table}."
+            )
+        markers_df = pd.read_csv(marker_table)
+        if "group" not in markers_df.columns or "names" not in markers_df.columns:
+            raise ValueError("Marker gene-set source must contain `group` and `names` columns.")
+        groups = markers_df["group"].astype(str)
+        requested_groups = [item.strip() for item in str(marker_group).split(",") if item.strip()] if marker_group else []
+        selected_groups = requested_groups or groups.dropna().unique().tolist()
+        top_n_value = str(marker_top_n).strip().lower()
+        limit = None if top_n_value == "all" else int(top_n_value)
+        gene_sets_raw: dict[str, list[str]] = {}
+        for group in selected_groups:
+            group_df = markers_df[groups == str(group)].copy()
+            if group_df.empty:
+                continue
+            if "pvals_adj" in group_df.columns:
+                group_df = group_df.sort_values("pvals_adj", ascending=True, na_position="last")
+            elif "scores" in group_df.columns:
+                group_df = group_df.sort_values("scores", ascending=False, na_position="last")
+            if limit is not None:
+                group_df = group_df.head(limit)
+            genes = [str(gene).strip() for gene in group_df["names"].dropna().astype(str).tolist() if str(gene).strip()]
+            if genes:
+                gene_sets_raw[str(group)] = list(dict.fromkeys(genes))
+        gene_sets = canonicalize_gene_sets(gene_sets_raw, gene_universe)
+        if not gene_sets:
+            raise ValueError(
+                "No valid marker-derived gene sets remained after applying group selection and gene-universe overlap."
+            )
+        resolved_path = write_gene_sets_gmt(gene_sets, output_dir / "marker_gene_sets.gmt")
+        return gene_sets, resolved_path, {
+            "requested_source": str(gene_set_from_markers),
+            "resolved_source": str(marker_table.name),
+            "library_mode": "marker_gene_sets",
+            "marker_groups": selected_groups,
+            "marker_top_n": marker_top_n,
+        }
+
+    if not gene_set_db:
+        raise ValueError("Provide either `--gene-sets <local.gmt>` or `--gene-set-db <hallmark|kegg|...>`.")
+
+    raw_sets, resolved_source = fetch_gene_sets_from_library(gene_set_db, species=species)
+    gene_sets = canonicalize_gene_sets(raw_sets, gene_universe)
+    resolved_path = write_gene_sets_gmt(gene_sets, output_dir / f"{sanitize_term_slug(resolved_source)}.gmt")
+    return gene_sets, resolved_path, {
+        "requested_source": gene_set_db,
+        "resolved_source": resolved_source,
+        "library_mode": "remote_library",
+    }
+
+
+def _r_stack_available() -> tuple[bool, list[str]]:
+    required = ["clusterProfiler", "enrichplot"]
+    try:
+        validate_r_environment(required_r_packages=required)
+        return True, []
+    except Exception:
+        runner = RScriptRunner(scripts_dir=R_SCRIPTS_DIR, timeout=30, verbose=False)
+        return False, runner.get_missing_packages(required) if runner.check_r_available() else required
+
+
+def _resolve_engine(requested: str) -> tuple[str, list[str]]:
+    if requested == "python":
+        return "python", []
+    available, missing = _r_stack_available()
+    if requested == "r":
+        if not available:
+            raise ImportError(
+                "R enrichment engine requires `clusterProfiler` and `enrichplot`.\n"
+                f"Missing packages: {', '.join(missing) or 'unknown'}"
+            )
+        return "r", []
+    if available:
+        return "r", []
+    return "python", missing
+
+
+def _build_ora_gene_table(
+    ranking_df: pd.DataFrame,
+    *,
+    ora_padj_cutoff: float,
+    ora_log2fc_cutoff: float,
+    ora_max_genes: int,
+) -> pd.DataFrame:
+    rows: list[pd.DataFrame] = []
+    for group, group_df in ranking_df.groupby("group", sort=False):
+        filtered = group_df.dropna(subset=["gene"]).copy()
+        if "pvals_adj" in filtered.columns and pd.to_numeric(filtered["pvals_adj"], errors="coerce").notna().any():
+            filtered = filtered[pd.to_numeric(filtered["pvals_adj"], errors="coerce").fillna(np.inf) <= float(ora_padj_cutoff)]
+        effect_source = None
+        for candidate in ("logfoldchanges", "scores", "stat"):
+            if candidate in filtered.columns and pd.to_numeric(filtered[candidate], errors="coerce").notna().any():
+                effect_source = candidate
+                break
+        if effect_source == "logfoldchanges":
+            filtered = filtered[pd.to_numeric(filtered["logfoldchanges"], errors="coerce").fillna(-np.inf) >= float(ora_log2fc_cutoff)]
+        elif effect_source in {"scores", "stat"}:
+            filtered = filtered[pd.to_numeric(filtered[effect_source], errors="coerce").fillna(-np.inf) > 0]
+        filtered = filtered.head(int(ora_max_genes))
+        if filtered.empty:
+            continue
+        frame = filtered[["group", "gene"]].copy()
+        rows.append(frame)
+    return pd.concat(rows, ignore_index=True) if rows else pd.DataFrame(columns=["group", "gene"])
+
+
+def _run_clusterprofiler_engine(
+    *,
+    method: str,
+    ranking_df: pd.DataFrame,
+    background_genes: list[str],
+    gene_sets_path: Path,
+    output_dir: Path,
+    top_terms: int,
+    ora_padj_cutoff: float,
+    ora_log2fc_cutoff: float,
+    ora_max_genes: int,
+    gsea_ranking_metric: str,
+    gsea_min_size: int,
+    gsea_max_size: int,
+    gsea_permutation_num: int,
+    gsea_seed: int,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    runner = RScriptRunner(scripts_dir=R_SCRIPTS_DIR, timeout=7200)
+    r_input_dir = output_dir / "reproducibility" / "r_engine_inputs"
+    r_input_dir.mkdir(parents=True, exist_ok=True)
+    background_path = r_input_dir / "background_genes.txt"
+    background_path.write_text("\n".join(dict.fromkeys(background_genes)) + "\n", encoding="utf-8")
+
+    if method == "ora":
+        r_input = _build_ora_gene_table(
+            ranking_df,
+            ora_padj_cutoff=ora_padj_cutoff,
+            ora_log2fc_cutoff=ora_log2fc_cutoff,
+            ora_max_genes=ora_max_genes,
+        )
+    else:
+        rows: list[pd.DataFrame] = []
+        for group, group_df in ranking_df.groupby("group", sort=False):
+            metric = group_df.copy()
+            metric_name = group_df.attrs.get("ranking_metric", gsea_ranking_metric)
+            if metric_name == "auto":
+                metric_name = "stat" if "stat" in group_df.columns else ("scores" if "scores" in group_df.columns else "logfoldchanges")
+            metric["score"] = pd.to_numeric(metric[metric_name], errors="coerce")
+            rows.append(metric[["group", "gene", "score"]])
+        r_input = pd.concat(rows, ignore_index=True) if rows else pd.DataFrame(columns=["group", "gene", "score"])
+
+    ranking_csv = r_input_dir / ("ora_input.csv" if method == "ora" else "gsea_input.csv")
+    r_input.to_csv(ranking_csv, index=False)
+
+    runner.run_script(
+        "sc_clusterprofiler_enrichment.R",
+        args=[
+            method,
+            str(ranking_csv),
+            str(background_path),
+            str(gene_sets_path),
+            str(output_dir),
+            str(top_terms),
+            str(gsea_min_size),
+            str(gsea_max_size),
+            str(gsea_permutation_num),
+            str(gsea_seed),
+        ],
+        output_dir=output_dir,
+        expected_outputs=["clusterprofiler_results.csv"],
+    )
+
+    result_path = output_dir / "clusterprofiler_results.csv"
+    if not result_path.exists():
+        return pd.DataFrame(), {"warnings": ["clusterProfiler returned no output table."], "engine": "r.clusterProfiler"}
+
+    res = pd.read_csv(result_path)
+    if res.empty:
+        return res, {"warnings": ["clusterProfiler returned an empty result table."], "engine": "r.clusterProfiler"}
+
+    metadata_path = output_dir / "r_plot_metadata.json"
+    plot_metadata = {}
+    if metadata_path.exists():
+        try:
+            plot_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except Exception:
+            plot_metadata = {}
+    r_fig_dir = output_dir / "r_figures"
+    if r_fig_dir.exists():
+        figures_dir = output_dir / "figures"
+        figures_dir.mkdir(parents=True, exist_ok=True)
+        for png in r_fig_dir.glob("*.png"):
+            shutil.copy2(png, figures_dir / png.name)
+
+    if method == "ora":
+        standardized = res.rename(
+            columns={
+                "Description": "term",
+                "ID": "gene_set",
+                "pvalue": "pvalue",
+                "p.adjust": "pvalue_adj",
+                "Count": "gene_count",
+                "GeneRatio": "overlap",
+                "qvalue": "qvalue",
+            }
+        )
+        standardized["term"] = standardized.get("term", standardized.get("gene_set", "")).astype(str)
+        standardized["gene_set"] = standardized.get("gene_set", standardized.get("term", "")).astype(str)
+        standardized["score"] = -np.log10(pd.to_numeric(standardized["pvalue_adj"], errors="coerce").clip(lower=1e-300))
+        standardized["odds_ratio"] = np.nan
+        standardized["genes"] = standardized.get("geneID", standardized.get("genes", "")).astype(str).str.replace("/", ";", regex=False)
+        standardized["source"] = "clusterProfiler"
+        standardized["library_mode"] = "r_clusterprofiler"
+        standardized["engine"] = "r.clusterProfiler"
+        standardized["method_used"] = "ora"
+        standardized["n_input_genes"] = standardized.groupby("group")["gene_count"].transform("max")
+        desired = ["group", "term", "gene_set", "source", "library_mode", "engine", "method_used", "score", "odds_ratio", "gene_count", "overlap", "pvalue", "pvalue_adj", "genes", "n_input_genes"]
+    else:
+        standardized = res.rename(
+            columns={
+                "Description": "term",
+                "ID": "gene_set",
+                "NES": "nes",
+                "enrichmentScore": "es",
+                "pvalue": "pvalue",
+                "p.adjust": "pvalue_adj",
+                "core_enrichment": "leading_edge",
+            }
+        )
+        standardized["term"] = standardized.get("term", standardized.get("gene_set", "")).astype(str)
+        standardized["gene_set"] = standardized.get("gene_set", standardized.get("term", "")).astype(str)
+        standardized["score"] = pd.to_numeric(standardized["nes"], errors="coerce")
+        standardized["source"] = "clusterProfiler"
+        standardized["library_mode"] = "r_clusterprofiler"
+        standardized["engine"] = "r.clusterProfiler"
+        standardized["method_used"] = "gsea"
+        standardized["ranking_metric"] = gsea_ranking_metric
+        desired = ["group", "term", "gene_set", "source", "library_mode", "engine", "method_used", "ranking_metric", "score", "nes", "es", "pvalue", "pvalue_adj", "leading_edge"]
+    for column in desired:
+        if column not in standardized.columns:
+            standardized[column] = np.nan
+    return standardized[desired], {
+        "warnings": [],
+        "engine": "r.clusterProfiler",
+        "plot_metadata": plot_metadata,
+    }
+
+
+def _build_group_summary(enrich_df: pd.DataFrame, *, fdr_threshold: float) -> pd.DataFrame:
+    if enrich_df.empty:
+        return pd.DataFrame(columns=["group", "n_terms", "n_significant", "top_term", "top_abs_score", "best_pvalue_adj"])
+
+    frame = enrich_df.copy()
+    if "score" not in frame.columns:
+        frame["score"] = np.nan
+    frame["score"] = pd.to_numeric(frame["score"], errors="coerce")
+    frame["pvalue_adj"] = pd.to_numeric(frame.get("pvalue_adj"), errors="coerce")
+    rows: list[dict[str, object]] = []
+    for group, group_df in frame.groupby("group", sort=False):
+        ordered = sort_results(group_df)
+        top_row = ordered.iloc[0] if not ordered.empty else pd.Series(dtype=object)
+        rows.append(
+            {
+                "group": str(group),
+                "n_terms": int(len(group_df)),
+                "n_significant": int(group_df["pvalue_adj"].fillna(np.inf).le(float(fdr_threshold)).sum()) if "pvalue_adj" in group_df.columns else 0,
+                "top_term": str(top_row.get("term", "")),
+                "top_abs_score": abs(float(pd.to_numeric(pd.Series([top_row.get("score")]), errors="coerce").fillna(0.0).iloc[0])),
+                "best_pvalue_adj": float(pd.to_numeric(group_df["pvalue_adj"], errors="coerce").min()) if "pvalue_adj" in group_df.columns else np.nan,
+            }
+        )
+    summary_df = pd.DataFrame(rows)
+    summary_df = summary_df.sort_values(
+        by=["n_significant", "top_abs_score", "n_terms", "group"],
+        ascending=[False, False, False, True],
+        kind="mergesort",
+    ).reset_index(drop=True)
+    return summary_df
+
+
+def _write_tables(
+    output_dir: Path,
+    *,
+    enrich_df: pd.DataFrame,
+    group_summary_df: pd.DataFrame,
+    ranking_df: pd.DataFrame,
+    top_terms_df: pd.DataFrame,
+    gsea_running_tables: dict[tuple[str, str], pd.DataFrame] | None = None,
+) -> dict[str, str]:
+    tables_dir = output_dir / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    figure_data_dir = output_dir / "figure_data"
+    figure_data_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "enrichment_results": "enrichment_results.csv",
+        "enrichment_significant": "enrichment_significant.csv",
+        "group_summary": "group_summary.csv",
+        "ranking_input": "ranking_input.csv",
+        "top_terms": "top_terms.csv",
+    }
+    enrich_df.to_csv(tables_dir / files["enrichment_results"], index=False)
+    significant_df = enrich_df.copy()
+    if "pvalue_adj" in significant_df.columns:
+        significant_df = significant_df[pd.to_numeric(significant_df["pvalue_adj"], errors="coerce").fillna(np.inf) <= 0.05]
+    significant_df.to_csv(tables_dir / files["enrichment_significant"], index=False)
+    group_summary_df.to_csv(tables_dir / files["group_summary"], index=False)
+    ranking_df.to_csv(tables_dir / files["ranking_input"], index=False)
+    top_terms_df.to_csv(tables_dir / files["top_terms"], index=False)
+
+    for key, value in files.items():
+        source = tables_dir / value
+        target = figure_data_dir / value
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    if gsea_running_tables:
+        running_rows = []
+        for (group, term), table in gsea_running_tables.items():
+            if table.empty:
+                continue
+            frame = table.copy()
+            frame.insert(0, "term", term)
+            frame.insert(0, "group", group)
+            running_rows.append(frame)
+        if running_rows:
+            running_df = pd.concat(running_rows, ignore_index=True)
+            files["gsea_running_scores"] = "gsea_running_scores.csv"
+            running_df.to_csv(tables_dir / files["gsea_running_scores"], index=False)
+            running_df.to_csv(figure_data_dir / files["gsea_running_scores"], index=False)
+
+    (figure_data_dir / "manifest.json").write_text(
+        json.dumps({"skill": SKILL_NAME, "available_files": files}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return files
+
+
+def _render_figures(
+    output_dir: Path,
+    *,
+    enrich_df: pd.DataFrame,
+    top_terms_df: pd.DataFrame,
+    group_summary_df: pd.DataFrame,
+    method: str,
+    ranking_by_group: dict[str, pd.Series] | None,
+    ranking_df: pd.DataFrame,
+    gene_sets: dict[str, list[str]],
+) -> None:
+    plot_enrichment_top_terms_bar(top_terms_df, output_dir)
+    plot_enrichment_group_term_dotplot(top_terms_df, output_dir)
+    plot_enrichment_group_summary(group_summary_df, output_dir)
+    plot_enrichment_enrichmap(top_terms_df, gene_sets, output_dir)
+    plot_enrichment_ridgeplot(top_terms_df, ranking_df, gene_sets, output_dir)
+    if method != "gsea":
+        return
+    if not ranking_by_group:
+        ranking_by_group = {}
+        metric = None
+        for candidate in ("stat", "scores", "logfoldchanges", "log2FoldChange", "score"):
+            if candidate in ranking_df.columns and pd.to_numeric(ranking_df[candidate], errors="coerce").notna().any():
+                metric = candidate
+                break
+        if metric is not None:
+            for group, group_df in ranking_df.groupby("group", sort=False):
+                ranking_by_group[str(group)] = (
+                    group_df[["gene", metric]]
+                    .dropna()
+                    .drop_duplicates(subset=["gene"], keep="first")
+                    .set_index("gene")[metric]
+                    .sort_values(ascending=False)
+                )
+    running_tables: dict[tuple[str, str], pd.DataFrame] = {}
+    for _, row in top_terms_df.head(4).iterrows():
+        group = str(row.get("group", ""))
+        term = str(row.get("term", ""))
+        ranking = ranking_by_group.get(group)
+        genes = gene_sets.get(term)
+        if ranking is None or not genes:
+            continue
+        running_tables[(group, term)] = compute_running_score_curve(ranking, genes)
+    plot_gsea_running_score_panels(running_tables, output_dir)
+
+
+def _write_report(
+    output_dir: Path,
+    *,
+    summary: dict,
+    params: dict,
+    input_file: str | None,
+    group_summary_df: pd.DataFrame,
+) -> None:
+    header = generate_report_header(
+        title="Single-Cell Statistical Enrichment Report",
+        skill_name=SKILL_NAME,
+        input_files=[Path(input_file)] if input_file else None,
+        extra_metadata={
+            "Method": summary["method"],
+            "Ranking source": summary["ranking_source"],
+            "Groups": str(summary["n_groups"]),
+            "Significant terms": str(summary["n_significant_terms"]),
+        },
+    )
+
+    lines = [
+        "## Summary\n",
+        f"- **Method**: `{summary['method']}`",
+        f"- **Requested engine**: `{summary['requested_engine']}`",
+        f"- **Resolved engine**: `{summary['resolved_engine']}`",
+        f"- **Engine(s)**: {summary['engine_summary']}",
+        f"- **Ranking source**: `{summary['ranking_source']}`",
+        f"- **Gene-set source**: `{summary['resolved_source']}` ({summary['library_mode']})",
+        f"- **Groups tested**: {summary['n_groups']}",
+        f"- **Terms tested**: {summary['n_terms_tested']}",
+        f"- **Significant terms (`p_adj <= {summary['fdr_threshold']}`)**: {summary['n_significant_terms']}",
+        "",
+        "## What This Skill Does\n",
+        "- `sc-enrichment` performs **statistical enrichment** on marker or DE rankings.",
+        "- Use it when you want GO / KEGG / Reactome / Hallmark terms that are statistically over-represented or enriched.",
+        "- If you instead want a **per-cell pathway activity score**, use `sc-pathway-scoring`.",
+        "",
+        "## First-pass Settings\n",
+        f"- `method`: {params['method']}",
+        f"- `groupby`: {params.get('groupby', 'embedded in ranking table')}",
+        f"- `ranking_method` (auto-ranking only): {params.get('ranking_method')}",
+        f"- `gene_sets`: {params.get('gene_sets')}",
+        f"- `gene_set_db`: {params.get('gene_set_db')}",
+        f"- `species`: {params.get('species')}",
+    ]
+
+    if params["method"] == "ora":
+        lines.extend(
+            [
+                f"- `ora_padj_cutoff`: {params['ora_padj_cutoff']}",
+                f"- `ora_log2fc_cutoff`: {params['ora_log2fc_cutoff']}",
+                f"- `ora_max_genes`: {params['ora_max_genes']}",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"- `gsea_ranking_metric`: {params['gsea_ranking_metric']}",
+                f"- `gsea_min_size`: {params['gsea_min_size']}",
+                f"- `gsea_max_size`: {params['gsea_max_size']}",
+                f"- `gsea_permutation_num`: {params['gsea_permutation_num']}",
+                f"- `gsea_weight`: {params['gsea_weight']}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Beginner Notes\n",
+            "- If you just finished clustering and want biological interpretation, this skill can auto-rank cluster markers from a processed h5ad.",
+            "- If you already ran `sc-markers` or `sc-de`, passing that output directory reuses the exported ranking table when possible.",
+            "- For condition DE enrichment with biological replicates, run `sc-de` first and then pass its output directory here.",
+            "",
+            "## Recommended Next Steps\n",
+            "- Use `sc-cell-annotation` if enriched terms suggest a clearer lineage interpretation than your current labels.",
+            "- Use `sc-pathway-scoring` if you want to project a specific signature back to each individual cell.",
+            "- Revisit `sc-de` if you need a cleaner ranked list or a replicate-aware condition contrast before enrichment.",
+            "",
+            "## Output Files\n",
+            "- `processed.h5ad` — downstream-facing AnnData with enrichment metadata attached.",
+            "- `tables/enrichment_results.csv` — all tested terms.",
+            "- `tables/enrichment_significant.csv` — significant subset.",
+            "- `tables/group_summary.csv` — counts of significant terms and the strongest term per group.",
+            "- `tables/ranking_input.csv` — the gene ranking actually used for enrichment.",
+            "- `figures/` — bar/dot/summary plus GSEA running-score panels when applicable.",
+        ]
+    )
+
+    if summary.get("warnings"):
+        lines.extend(["", "## Warnings\n"])
+        for warning in summary["warnings"]:
+            lines.append(f"- {warning}")
+
+    if not group_summary_df.empty:
+        lines.extend(["", "## Top-term snapshot\n"])
+        for _, row in group_summary_df.head(8).iterrows():
+            lines.append(
+                f"- `{row['group']}`: top term `{row['top_term']}` with {int(row['n_significant'])} significant terms"
+            )
+
+    report = header + "\n".join(lines) + "\n" + generate_report_footer()
+    (output_dir / "report.md").write_text(report, encoding="utf-8")
+
+
+def _write_reproducibility(output_dir: Path, *, params: dict, input_file: str | None, demo: bool) -> None:
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    parts = ["python", SCRIPT_REL_PATH]
+    if demo:
+        parts.append("--demo")
+    elif input_file:
+        parts.extend(["--input", input_file])
+    else:
+        parts.extend(["--input", "<input>"])
+    parts.extend(["--output", str(output_dir), "--method", params["method"]])
+    for key in ("groupby", "gene_sets", "gene_set_db", "gene_set_from_markers", "marker_group", "marker_top_n", "species", "top_terms", "ranking_method"):
+        value = params.get(key)
+        if value not in (None, ""):
+            parts.extend([f"--{key.replace('_', '-')}", str(value)])
+    if params["method"] == "ora":
+        for key in ("ora_padj_cutoff", "ora_log2fc_cutoff", "ora_max_genes"):
+            parts.extend([f"--{key.replace('_', '-')}", str(params[key])])
+    else:
+        for key in ("gsea_ranking_metric", "gsea_min_size", "gsea_max_size", "gsea_permutation_num", "gsea_weight", "gsea_seed"):
+            parts.extend([f"--{key.replace('_', '-')}", str(params[key])])
+    command = " ".join(shlex.quote(part) for part in parts)
+    (repro_dir / "commands.sh").write_text(f"#!/bin/bash\n{command}\n", encoding="utf-8")
+    _write_repro_requirements(repro_dir, ["scanpy", "anndata", "numpy", "pandas", "matplotlib", "seaborn", "gseapy"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Single-cell statistical enrichment")
+    parser.add_argument("--input", dest="input_path")
+    parser.add_argument("--output", dest="output_dir", required=True)
+    parser.add_argument("--demo", action="store_true")
+    parser.add_argument("--method", choices=list(METHOD_REGISTRY.keys()), default="ora")
+    parser.add_argument("--engine", choices=["auto", "python", "r"], default="auto")
+    parser.add_argument("--groupby", default=None)
+    parser.add_argument("--ranking-method", default="wilcoxon", choices=["wilcoxon", "t-test", "logreg"])
+    parser.add_argument("--gene-sets", dest="gene_sets_path", default=None)
+    parser.add_argument("--gene-set-db", dest="gene_set_db", default=None)
+    parser.add_argument("--gene-set-from-markers", dest="gene_set_from_markers", default=None)
+    parser.add_argument("--marker-group", dest="marker_group", default=None, help="Comma-separated marker groups to convert into gene sets")
+    parser.add_argument("--marker-top-n", dest="marker_top_n", default="100", help="How many marker genes to keep per group, or `all`")
+    parser.add_argument("--species", choices=["human", "mouse"], default="human")
+    parser.add_argument("--top-terms", type=int, default=18)
+    parser.add_argument("--ora-padj-cutoff", type=float, default=0.05)
+    parser.add_argument("--ora-log2fc-cutoff", type=float, default=0.25)
+    parser.add_argument("--ora-max-genes", type=int, default=200)
+    parser.add_argument("--gsea-ranking-metric", default="auto", choices=["auto", "stat", "scores", "logfoldchanges", "log2FoldChange"])
+    parser.add_argument("--gsea-min-size", type=int, default=5)
+    parser.add_argument("--gsea-max-size", type=int, default=500)
+    parser.add_argument("--gsea-permutation-num", type=int, default=100)
+    parser.add_argument("--gsea-weight", type=float, default=1.0)
+    parser.add_argument("--gsea-seed", type=int, default=123)
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    method = validate_method_choice(args.method, METHOD_REGISTRY)
+    adata, ranking_df, source_meta, input_file = _load_input_context(
+        input_path=args.input_path,
+        demo=args.demo,
+        method=method,
+        groupby=args.groupby,
+        ranking_method=args.ranking_method,
+        output_dir=output_dir,
+    )
+
+    apply_preflight(
+        preflight_sc_enrichment(
+            adata,
+            method=method,
+            engine=args.engine,
+            groupby=args.groupby or source_meta.get("groupby"),
+            gene_sets_path=args.gene_sets_path,
+            gene_set_db=args.gene_set_db,
+            gene_set_from_markers=args.gene_set_from_markers,
+            marker_group=args.marker_group,
+            marker_top_n=args.marker_top_n,
+            source_mode=str(source_meta.get("ranking_source")),
+            source_path=input_file,
+            ranking_method=args.ranking_method,
+            demo=args.demo,
+        ),
+        logger,
+    )
+
+    gene_sets, resolved_gene_sets_path, gene_set_meta = _resolve_gene_sets(
+        demo=args.demo,
+        species=args.species,
+        gene_sets_path=args.gene_sets_path,
+        gene_set_db=args.gene_set_db,
+        gene_set_from_markers=args.gene_set_from_markers,
+        marker_group=args.marker_group,
+        marker_top_n=args.marker_top_n,
+        gene_universe=adata.var_names.astype(str).tolist(),
+        output_dir=output_dir,
+    )
+    if not gene_sets:
+        raise ValueError("No overlapping genes remained after aligning the selected gene sets to the dataset gene universe.")
+
+    params = {
+        "method": method,
+        "engine": args.engine,
+        "groupby": source_meta.get("groupby", args.groupby),
+        "ranking_method": args.ranking_method,
+        "gene_sets": str(resolved_gene_sets_path),
+        "gene_set_db": args.gene_set_db,
+        "gene_set_from_markers": args.gene_set_from_markers,
+        "marker_group": args.marker_group,
+        "marker_top_n": args.marker_top_n,
+        "species": args.species,
+        "top_terms": args.top_terms,
+        "ora_padj_cutoff": args.ora_padj_cutoff,
+        "ora_log2fc_cutoff": args.ora_log2fc_cutoff,
+        "ora_max_genes": args.ora_max_genes,
+        "gsea_ranking_metric": args.gsea_ranking_metric,
+        "gsea_min_size": args.gsea_min_size,
+        "gsea_max_size": args.gsea_max_size,
+        "gsea_permutation_num": args.gsea_permutation_num,
+        "gsea_weight": args.gsea_weight,
+        "gsea_seed": args.gsea_seed,
+    }
+
+    ranking_df = normalize_ranking_table(ranking_df)
+    resolved_engine, missing_r_packages = _resolve_engine(args.engine)
+    if resolved_engine == "r":
+        enrich_df, method_meta = _run_clusterprofiler_engine(
+            method=method,
+            ranking_df=ranking_df,
+            background_genes=adata.var_names.astype(str).tolist(),
+            gene_sets_path=resolved_gene_sets_path,
+            output_dir=output_dir,
+            top_terms=args.top_terms,
+            ora_padj_cutoff=args.ora_padj_cutoff,
+            ora_log2fc_cutoff=args.ora_log2fc_cutoff,
+            ora_max_genes=args.ora_max_genes,
+            gsea_ranking_metric=args.gsea_ranking_metric,
+            gsea_min_size=args.gsea_min_size,
+            gsea_max_size=args.gsea_max_size,
+            gsea_permutation_num=args.gsea_permutation_num,
+            gsea_seed=args.gsea_seed,
+        )
+        ranking_by_group = None
+    else:
+        if args.engine == "auto" and missing_r_packages:
+            logger.info(
+                "R clusterProfiler stack is not fully available (%s); using Python enrichment engine.",
+                ", ".join(missing_r_packages),
+            )
+        if method == "ora":
+            enrich_df, method_meta = run_ora(
+                ranking_df,
+                source=str(gene_set_meta["resolved_source"]),
+                library_mode=str(gene_set_meta["library_mode"]),
+                gene_sets=gene_sets,
+                background_genes=adata.var_names.astype(str).tolist(),
+                ora_padj_cutoff=args.ora_padj_cutoff,
+                ora_log2fc_cutoff=args.ora_log2fc_cutoff,
+                ora_max_genes=args.ora_max_genes,
+            )
+            ranking_by_group = None
+        else:
+            enrich_df, method_meta = run_gsea(
+                ranking_df,
+                source=str(gene_set_meta["resolved_source"]),
+                library_mode=str(gene_set_meta["library_mode"]),
+                gene_sets=gene_sets,
+                ranking_metric=args.gsea_ranking_metric,
+                gsea_min_size=args.gsea_min_size,
+                gsea_max_size=args.gsea_max_size,
+                gsea_permutation_num=args.gsea_permutation_num,
+                gsea_weight=args.gsea_weight,
+                gsea_seed=args.gsea_seed,
+            )
+            ranking_by_group = method_meta.get("ranking_by_group")
+
+    enrich_df = sort_results(enrich_df)
+    if args.engine == "auto" and resolved_engine == "python" and missing_r_packages:
+        method_meta.setdefault("warnings", []).append(
+            "R clusterProfiler engine was unavailable and this run used the Python implementation instead. "
+            f"Missing R packages: {', '.join(missing_r_packages)}"
+        )
+    top_terms_df = select_top_terms(enrich_df, top_terms=args.top_terms)
+    group_summary_df = _build_group_summary(enrich_df, fdr_threshold=0.05)
+    _render_figures(
+        output_dir,
+        enrich_df=enrich_df,
+        top_terms_df=top_terms_df,
+        group_summary_df=group_summary_df,
+        method=method,
+        ranking_by_group=ranking_by_group,
+        ranking_df=ranking_df,
+        gene_sets=gene_sets,
+    )
+
+    running_tables: dict[tuple[str, str], pd.DataFrame] | None = None
+    if method == "gsea" and ranking_by_group:
+        running_tables = {}
+        for _, row in top_terms_df.head(4).iterrows():
+            group = str(row.get("group", ""))
+            term = str(row.get("term", ""))
+            ranking = ranking_by_group.get(group)
+            genes = gene_sets.get(term)
+            if ranking is None or not genes:
+                continue
+            running_tables[(group, term)] = compute_running_score_curve(ranking, genes, weight=args.gsea_weight)
+
+    figure_data_files = _write_tables(
+        output_dir,
+        enrich_df=enrich_df,
+        group_summary_df=group_summary_df,
+        ranking_df=ranking_df,
+        top_terms_df=top_terms_df,
+        gsea_running_tables=running_tables,
+    )
+
+    source_matrix_contract = get_matrix_contract(adata)
+    input_contract, matrix_contract = propagate_singlecell_contracts(
+        adata,
+        adata,
+        producer_skill=SKILL_NAME,
+        x_kind=source_matrix_contract.get("X") or infer_x_matrix_kind(adata),
+        raw_kind=source_matrix_contract.get("raw"),
+        primary_cluster_key=source_matrix_contract.get("primary_cluster_key") or source_meta.get("groupby"),
+    )
+    store_analysis_metadata(adata, SKILL_NAME, method, params)
+    output_h5ad = output_dir / "processed.h5ad"
+    save_h5ad(adata, output_h5ad)
+
+    engines = sorted(set(enrich_df["engine"].dropna().astype(str).tolist())) if not enrich_df.empty and "engine" in enrich_df.columns else []
+    summary = {
+        "method": method,
+        "ranking_source": source_meta.get("ranking_source"),
+        "upstream_skill": source_meta.get("upstream_skill"),
+        "groupby": source_meta.get("groupby"),
+        "n_groups": int(ranking_df["group"].astype(str).nunique()) if "group" in ranking_df.columns else 0,
+        "n_gene_sets_available": int(len(gene_sets)),
+        "n_terms_tested": int(len(enrich_df)),
+        "n_significant_terms": int(pd.to_numeric(enrich_df.get("pvalue_adj"), errors="coerce").fillna(1.0).le(0.05).sum()) if not enrich_df.empty else 0,
+        "engine_summary": ", ".join(engines) if engines else "none",
+        "requested_engine": args.engine,
+        "resolved_engine": resolved_engine,
+        "requested_source": gene_set_meta["requested_source"],
+        "resolved_source": gene_set_meta["resolved_source"],
+        "library_mode": gene_set_meta["library_mode"],
+        "warnings": list(method_meta.get("warnings", [])),
+        "fdr_threshold": 0.05,
+    }
+    _write_report(output_dir, summary=summary, params=params, input_file=input_file, group_summary_df=group_summary_df)
+    _write_reproducibility(output_dir, params=params, input_file=input_file, demo=args.demo)
+
+    checksum = sha256_file(input_file) if input_file and Path(input_file).exists() else ""
+    result_data = {
+        "params": params,
+        "input_contract": input_contract,
+        "matrix_contract": matrix_contract,
+        "requested_source": gene_set_meta["requested_source"],
+        "resolved_source": gene_set_meta["resolved_source"],
+        "library_mode": gene_set_meta["library_mode"],
+        "visualization": {"available_figure_data": figure_data_files},
+        "ranking_source": source_meta,
+    }
+    write_result_json(output_dir, SKILL_NAME, SKILL_VERSION, summary, result_data, checksum)
+    result_payload = load_result_json(output_dir) or {"skill": SKILL_NAME, "summary": summary, "data": result_data}
+    write_standard_run_artifacts(output_dir, result_payload, summary)
+
+    print(f"Success: {SKILL_NAME}")
+    print(f"  Output: {output_dir}")
+    print(f"Statistical enrichment complete: method={method}, groups={summary['n_groups']}, significant_terms={summary['n_significant_terms']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment.py
+++ b/skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment.py
@@ -1,0 +1,157 @@
+"""Tests for the sc-enrichment skill."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import anndata as ad
+import pytest
+
+SKILL_SCRIPT = Path(__file__).resolve().parent.parent / "sc_enrichment.py"
+MARKERS_SCRIPT = Path(__file__).resolve().parents[2] / "sc-markers" / "sc_markers.py"
+
+
+@pytest.fixture
+def tmp_output(tmp_path):
+    return tmp_path / "sc_enrichment_out"
+
+
+def _write_test_gmt(path: Path) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "PBMC_T\tna\tIL7R\tLTB\tIL32\tLDHB",
+                "PBMC_NK\tna\tNKG7\tGNLY\tPRF1\tGZMB",
+                "PBMC_B\tna\tMS4A1\tCD79A\tCD79B\tCD74",
+                "PBMC_MONO\tna\tLST1\tFCER1G\tTYROBP\tS100A8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_demo_ora_runs(tmp_output):
+    result = subprocess.run(
+        [sys.executable, str(SKILL_SCRIPT), "--demo", "--method", "ora", "--output", str(tmp_output)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert (tmp_output / "processed.h5ad").exists()
+    assert (tmp_output / "tables" / "enrichment_results.csv").exists()
+    assert (tmp_output / "figure_data" / "manifest.json").exists()
+
+
+def test_demo_gsea_runs(tmp_output):
+    result = subprocess.run(
+        [sys.executable, str(SKILL_SCRIPT), "--demo", "--method", "gsea", "--output", str(tmp_output)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert (tmp_output / "figures" / "gsea_running_scores.png").exists()
+    assert (tmp_output / "tables" / "top_terms.csv").exists()
+
+
+def test_processed_output_carries_contract_and_metadata(tmp_output):
+    subprocess.run(
+        [sys.executable, str(SKILL_SCRIPT), "--demo", "--method", "ora", "--output", str(tmp_output)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(SKILL_SCRIPT.parent),
+        check=True,
+    )
+    adata = ad.read_h5ad(tmp_output / "processed.h5ad")
+    assert "omicsclaw_matrix_contract" in adata.uns
+    assert "omicsclaw_input_contract" in adata.uns
+    assert "omicsclaw_sc-enrichment" in adata.uns
+
+
+def test_markers_output_dir_input_runs(tmp_path):
+    markers_out = tmp_path / "markers"
+    enrich_out = tmp_path / "enrichment"
+    gmt_path = _write_test_gmt(tmp_path / "custom_sets.gmt")
+
+    markers_result = subprocess.run(
+        [sys.executable, str(MARKERS_SCRIPT), "--demo", "--output", str(markers_out)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(MARKERS_SCRIPT.parent),
+    )
+    assert markers_result.returncode == 0, f"stderr: {markers_result.stderr}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SKILL_SCRIPT),
+            "--input",
+            str(markers_out),
+            "--method",
+            "ora",
+            "--gene-sets",
+            str(gmt_path),
+            "--output",
+            str(enrich_out),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    data = json.loads((enrich_out / "result.json").read_text())
+    assert data["skill"] == "sc-enrichment"
+    assert data["summary"]["ranking_source"] in {"markers_table", "auto_cluster_ranking"}
+
+
+def test_gene_set_from_markers_with_group_and_topn(tmp_path):
+    markers_out = tmp_path / "markers_src"
+    enrich_out = tmp_path / "enrichment_from_marker_sets"
+
+    markers_result = subprocess.run(
+        [sys.executable, str(MARKERS_SCRIPT), "--demo", "--output", str(markers_out)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(MARKERS_SCRIPT.parent),
+    )
+    assert markers_result.returncode == 0, f"stderr: {markers_result.stderr}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SKILL_SCRIPT),
+            "--input",
+            str(markers_out),
+            "--method",
+            "ora",
+            "--gene-set-from-markers",
+            str(markers_out),
+            "--marker-group",
+            "CD4 T cells",
+            "--marker-top-n",
+            "3",
+            "--output",
+            str(enrich_out),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(SKILL_SCRIPT.parent),
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    data = json.loads((enrich_out / "result.json").read_text())
+    assert data["data"]["params"]["gene_set_from_markers"] == str(markers_out)
+    assert data["data"]["params"]["marker_group"] == "CD4 T cells"
+    assert data["data"]["params"]["marker_top_n"] == "3"

--- a/skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment_methods.py
+++ b/skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment_methods.py
@@ -1,0 +1,22 @@
+"""Static method-contract tests for sc-enrichment."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SKILL_SCRIPT = Path(__file__).resolve().parent.parent / "sc_enrichment.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sc_enrichment", SKILL_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_methods_are_registered():
+    module = _load_module()
+    assert set(module.METHOD_REGISTRY) == {"ora", "gsea"}


### PR DESCRIPTION
## Summary
- add a new `sc-enrichment` skill for statistical enrichment on single-cell marker/DE rankings
- keep `sc-pathway-scoring` separate for per-cell signature activity scoring
- support `ora` and preranked `gsea` with `engine=auto|python|r`
- add marker-derived gene-set input (`--gene-set-from-markers`, `--marker-group`, `--marker-top-n`)
- add enrichment visualizations including top-term bar, group-term dotplot, group summary, enrichmap, ridgeplot, and GSEA running-score panels
- wire the skill into registry, catalog, orchestrator keyword routing, guides, guardrails, and quickstart
- refine singlecell enrichment dependency guidance and R tiering

## Validation
- `python -m pytest -q skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment.py skills/singlecell/scrna/sc-enrichment/tests/test_sc_enrichment_methods.py tests/test_sc_preflight.py -k 'sc_enrichment or enrichment or pathway'`
- result: `9 passed`
- smoke outputs generated under:
  - `output/review_sc_enrichment_demo_ora`
  - `output/review_sc_enrichment_demo_gsea`
  - `output/review_sc_enrichment_from_markers`
  - `output/review_sc_enrichment_from_de`
  - `output/review_sc_enrichment_hallmark_r`
  - `output/review_sc_enrichment_go_bp_r`
  - `output/review_sc_enrichment_kegg_r`
  - `output/review_sc_enrichment_marker_gene_set_single`

## Notes
- `engine=auto` now prefers the R `clusterProfiler/enrichplot` stack when available and falls back to Python otherwise.
- `sc-enrichment` is intentionally statistical term enrichment; per-cell pathway activity stays in `sc-pathway-scoring`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `sc-enrichment` skill for statistical pathway and gene-set enrichment analysis on marker or differential-expression rankings
  * Support for ORA and preranked GSEA enrichment methods
  * Multiple gene-set sources: built-in databases (GO, KEGG, Hallmark, Reactome) and custom GMT/JSON files
  * Rich enrichment visualizations including term rankings, group summaries, network maps, and GSEA diagnostics
  * Flexible execution engines (Python and R backends)

* **Documentation**
  * New enrichment workflow guides clarifying distinction between statistical enrichment and per-cell pathway scoring
  * Updated downstream analysis recommendations across single-cell guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->