### PR TITLE
feat(oauth): ccproxy OAuth login for Claude Pro/Max and OpenAI Codex

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,22 @@ LLM_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # OMICSCLAW_MODEL=your-model-name
 # LLM_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# --- Option 5: OAuth login for Claude Pro/Max or OpenAI Codex (via ccproxy) ---
+# Uses your existing Claude Pro/Max or OpenAI Codex subscription instead of
+# a standalone API key. Requires:
+#   1. pip install 'omicsclaw[oauth]'       (installs ccproxy-api)
+#      -> You may see a pip warning about `pygpcca 1.0.4 requires jinja2==3.0.3`.
+#         This is benign: pygpcca (a cellrank transitive dep) over-pins jinja2;
+#         ccproxy-api needs jinja2>=3.1.5 via fastapi[standard]. Both work in
+#         practice with jinja2 3.1.x. The install succeeds despite the warning.
+#   2. python omicsclaw.py auth login claude    (or: openai)
+# Only supported for LLM_PROVIDER=anthropic or openai.
+# NOTE: CCPROXY_PORT MUST differ from the app-server port (default 8765) —
+# ccproxy would otherwise fail to bind.
+# LLM_PROVIDER=anthropic
+# LLM_AUTH_MODE=oauth
+# CCPROXY_PORT=11435
+
 # Override base URL (optional — auto-set by provider)
 # LLM_BASE_URL=https://api.deepseek.com/v1
 # Per-provider base URL overrides: <PROVIDER>_BASE_URL (e.g. ANTHROPIC_BASE_URL)

--- a/README.md
+++ b/README.md
@@ -182,9 +182,24 @@ OMICSCLAW_MODEL=your-model-name
 LLM_API_KEY=sk-xxxxxxxxxxxxxxxx
 ```
 
+**6. OAuth via ccproxy (Claude Pro/Max or OpenAI Codex):**
+```env
+LLM_PROVIDER=anthropic
+LLM_AUTH_MODE=oauth
+CCPROXY_PORT=11435
+```
+Complete login once with `python omicsclaw.py auth login claude` (or `openai`).
+Keep `CCPROXY_PORT` different from the app backend port `8765`.
+
 > 📖 **Full Provider List:** See `.env.example` for instructions on configuring other engines like NVIDIA NIM, OpenRouter, DashScope, and custom endpoints.
 >
 > 📖 **Bot / channel config:** See [bot/README.md](bot/README.md) and [bot/CHANNELS_SETUP.md](bot/CHANNELS_SETUP.md) for messaging channel credentials, allowlists, and runtime controls.
+
+> **Provider/model normalization:** if a restart finds a stale cross-provider
+> combination such as `LLM_PROVIDER=anthropic` with
+> `OMICSCLAW_MODEL=deepseek-chat`, OmicsClaw keeps the selected provider as the
+> routing authority and resets the model to that provider's default unless you
+> explicitly configured a custom `*_BASE_URL` / `LLM_BASE_URL`.
 
 </details>
 

--- a/bot/core.py
+++ b/bot/core.py
@@ -36,6 +36,7 @@ from omicsclaw.core.llm_timeout import (
 from omicsclaw.core.provider_registry import (
     PROVIDER_DETECT_ORDER,
     PROVIDER_PRESETS,
+    normalize_model_for_provider,
     resolve_provider,
 )
 from omicsclaw.core.provider_runtime import set_active_provider_runtime
@@ -923,6 +924,9 @@ def init(
     base_url: str | None = None,
     model: str = "",
     provider: str = "",
+    auth_mode: str = "api_key",
+    ccproxy_port: int = 11435,
+    strict_oauth: bool = True,
 ):
     """Initialise the shared LLM client. Call once at startup.
 
@@ -932,8 +936,36 @@ def init(
 
     When ``api_key`` is empty, the key is auto-resolved from provider-
     specific environment variables (e.g. DEEPSEEK_API_KEY for deepseek).
+
+    When ``auth_mode="oauth"`` (only valid for ``anthropic`` / ``openai``),
+    requests are routed through a local ``ccproxy`` server instead of
+    using an API key — requires ``pip install 'omicsclaw[oauth]'`` and a
+    prior ``omicsclaw auth login`` step.
+
+    ``strict_oauth``:
+        - ``True`` (default, for explicit caller action such as ``PUT
+          /providers`` or CLI ``auth login``): any OAuth setup failure
+          (missing ccproxy, unauthenticated, unsupported provider) raises
+          ``RuntimeError`` so the user sees the problem immediately.
+        - ``False`` (for server lifespan / bot bootstrap): degrade to
+          ``api_key`` mode with a loud warning if OAuth can't be set up.
+          This prevents a stale ``LLM_AUTH_MODE=oauth`` in ``.env`` from
+          blocking the app-server from starting at all.
     """
     global llm, OMICSCLAW_MODEL, LLM_PROVIDER_NAME, memory_store, session_manager
+
+    auth_mode_normalized = str(auth_mode or "api_key").strip().lower() or "api_key"
+
+    # Clear any stale ccproxy-injected env vars BEFORE resolve_provider()
+    # reads them — otherwise a prior OAuth session's ANTHROPIC_BASE_URL /
+    # sentinel key would silently pin the next API-key mode request to the
+    # local ccproxy endpoint (Bug 3: OAuth pollutes API-key mode).
+    try:
+        from omicsclaw.core.ccproxy_manager import clear_ccproxy_env
+        clear_ccproxy_env()
+    except Exception:
+        # ccproxy_manager is optional; missing module just means no cleanup needed.
+        pass
 
     resolved_url, resolved_model, resolved_key = resolve_provider(
         provider=provider,
@@ -941,6 +973,20 @@ def init(
         model=model,
         api_key=api_key,
     )
+    if model and str(resolved_model).strip() != str(model).strip():
+        _normalized_model, normalized_from_provider = normalize_model_for_provider(
+            provider,
+            model,
+            base_url=base_url or "",
+        )
+        logger.warning(
+            "Normalized stale model '%s' for provider '%s' to '%s' "
+            "(matched default model of '%s')",
+            model,
+            provider,
+            resolved_model,
+            normalized_from_provider or "another provider",
+        )
     OMICSCLAW_MODEL = resolved_model
 
     # Determine display name for the provider
@@ -959,16 +1005,67 @@ def init(
 
     effective_api_key = str(resolved_key or api_key or "")
     effective_base_url = str(resolved_url or "")
-    set_active_provider_runtime(
+
+    # Validate / set up OAuth if requested. Under strict_oauth=True any
+    # failure raises; under strict_oauth=False we log and degrade to
+    # api_key mode so a stale LLM_AUTH_MODE=oauth doesn't break startup.
+    if auth_mode_normalized == "oauth":
+        from omicsclaw.core.ccproxy_manager import (
+            OAUTH_PROVIDERS,
+            maybe_start_ccproxy,
+            provider_supports_oauth,
+        )
+
+        def _oauth_failed(reason: str) -> None:
+            """Either raise (strict) or warn-and-fall-back to api_key."""
+            nonlocal auth_mode_normalized
+            if strict_oauth:
+                raise RuntimeError(reason)
+            logger.warning(
+                "Falling back to auth_mode='api_key' — %s. "
+                "Set LLM_AUTH_MODE=api_key in your .env to silence this "
+                "warning, or install / authenticate ccproxy.",
+                reason,
+            )
+            auth_mode_normalized = "api_key"
+
+        if not provider_supports_oauth(LLM_PROVIDER_NAME):
+            _oauth_failed(
+                f"auth_mode='oauth' is not supported for provider "
+                f"'{LLM_PROVIDER_NAME}' (supported: "
+                f"{sorted(OAUTH_PROVIDERS.keys())})"
+            )
+        else:
+
+            try:
+                maybe_start_ccproxy(
+                    anthropic_oauth=(LLM_PROVIDER_NAME == "anthropic"),
+                    openai_oauth=(LLM_PROVIDER_NAME == "openai"),
+                    port=int(ccproxy_port),
+                )
+            except RuntimeError as exc:
+                _oauth_failed(str(exc))
+
+    runtime = set_active_provider_runtime(
         provider=LLM_PROVIDER_NAME,
         base_url=effective_base_url,
         model=OMICSCLAW_MODEL,
         api_key=effective_api_key,
+        # Use the normalized mode — which may have been downgraded to
+        # api_key above if strict_oauth=False and OAuth setup failed.
+        auth_mode=auth_mode_normalized,
+        ccproxy_port=int(ccproxy_port),
     )
 
+    # Use the runtime's resolved base_url / api_key — for OAuth these are
+    # the local ccproxy endpoint + sentinel, for API key mode they are the
+    # resolved cloud values (unchanged from pre-OAuth behavior).
+    effective_api_key = runtime.api_key or effective_api_key
+    effective_base_url = runtime.base_url or effective_base_url
+
     kw: dict = {"api_key": effective_api_key}
-    if resolved_url:
-        kw["base_url"] = resolved_url
+    if effective_base_url:
+        kw["base_url"] = effective_base_url
     kw["timeout"] = _build_llm_timeout()
     try:
         llm = AsyncOpenAI(**kw)
@@ -984,7 +1081,8 @@ def init(
 
     logger.info(
         f"LLM initialised: provider={LLM_PROVIDER_NAME}, "
-        f"model={OMICSCLAW_MODEL}, base_url={resolved_url or '(default)'}"
+        f"model={OMICSCLAW_MODEL}, base_url={effective_base_url or '(default)'}, "
+        f"auth_mode={auth_mode_normalized}"
     )
 
     # Memory initialization — uses the new graph-based memory system

--- a/bot/run.py
+++ b/bot/run.py
@@ -64,8 +64,14 @@ logger = logging.getLogger("omicsclaw.runner")
 
 def _resolve_bootstrap_llm_config(
     env: Mapping[str, str] | None = None,
-) -> tuple[str, str | None, str, str]:
-    """Resolve the effective LLM bootstrap config from environment variables."""
+) -> tuple[str, str | None, str, str, str, int]:
+    """Resolve the effective LLM bootstrap config from environment variables.
+
+    Returns ``(provider, base_url, model, api_key, auth_mode, ccproxy_port)``.
+    ``auth_mode`` is ``"oauth"`` when ``LLM_AUTH_MODE=oauth`` is set, else
+    ``"api_key"`` (default). ``ccproxy_port`` comes from ``CCPROXY_PORT`` or
+    falls back to 11435.
+    """
     source = os.environ if env is None else env
     explicit_provider = str(source.get("LLM_PROVIDER", "") or "").strip().lower()
     detected_provider = detect_provider_from_env(env=source)
@@ -78,7 +84,23 @@ def _resolve_bootstrap_llm_config(
         api_key=str(source.get("LLM_API_KEY", "") or ""),
         env=source,
     )
-    return effective_provider, resolved_url, resolved_model, resolved_key
+
+    auth_mode = (
+        str(source.get("LLM_AUTH_MODE", "") or "").strip().lower() or "api_key"
+    )
+    try:
+        ccproxy_port = int(source.get("CCPROXY_PORT", "11435") or "11435")
+    except (TypeError, ValueError):
+        ccproxy_port = 11435
+
+    return (
+        effective_provider,
+        resolved_url,
+        resolved_model,
+        resolved_key,
+        auth_mode,
+        ccproxy_port,
+    )
 
 
 def _build_telegram_channel():
@@ -305,19 +327,27 @@ async def _run_channels(channel_names: list[str], health_port: int = 0) -> None:
     from bot.channels.manager import ChannelManager
 
     # Initialize core LLM engine
-    provider, base_url, model, api_key = _resolve_bootstrap_llm_config()
-    if not api_key and provider != "ollama":
+    provider, base_url, model, api_key, auth_mode, ccproxy_port = (
+        _resolve_bootstrap_llm_config()
+    )
+    # OAuth mode doesn't need an API key — ccproxy supplies the OAuth token.
+    if not api_key and provider != "ollama" and auth_mode != "oauth":
         print(
             "Error: no LLM API key resolved. Set LLM_API_KEY or a provider-specific key "
             "(for example DEEPSEEK_API_KEY). See bot/README.md for setup."
         )
         sys.exit(1)
 
+    # Bootstrap context: if OAuth setup fails, warn and degrade to
+    # api_key mode rather than blocking bot startup entirely.
     core.init(
         api_key=api_key,
         base_url=base_url,
         model=model,
         provider=provider,
+        auth_mode=auth_mode,
+        ccproxy_port=ccproxy_port,
+        strict_oauth=False,
     )
 
     # Build manager with middleware

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -24,6 +24,12 @@ preserve the reference skills' core design:
 
 Recent additions:
 
+- `plans/2026-04-14-provider-model-normalization.md` — normalize stale
+  cross-provider model leftovers so backend status surfaces stop exposing
+  contradictory provider/model pairs
+- `plans/2026-04-14-oauth-runtime-hardening.md` — harden OAuth logout/runtime
+  cleanup, provider config persistence, and ccproxy/app-server port conflict
+  handling
 - `plans/2026-04-11-app-backend-authority-convergence.md` — converge notebook
   file ownership, runtime config authority, and backend launch discovery
   around the upstream backend contract

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -5,6 +5,12 @@ development work.
 
 ## Tracked Entries
 
+- [2026-04-14-provider-model-normalization.md](2026-04-14-provider-model-normalization.md)
+  — normalize stale cross-provider model leftovers so backend status surfaces
+  expose a coherent provider/model pair.
+- [2026-04-14-oauth-runtime-hardening.md](2026-04-14-oauth-runtime-hardening.md)
+  — harden OAuth logout/runtime cleanup, provider config persistence, and
+  ccproxy/app-server port conflict handling.
 - [2026-04-11-app-backend-authority-convergence.md](2026-04-11-app-backend-authority-convergence.md)
   — converge notebook file APIs, runtime config ownership, and backend launch
   discovery under the upstream backend contract.

--- a/omicsclaw.py
+++ b/omicsclaw.py
@@ -124,6 +124,93 @@ def _ensure_server_dependencies(
     print("Minimal alternative: pip install fastapi uvicorn", file=sys.stderr)
     raise SystemExit(1)
 
+
+def _oauth_cli_choices() -> list[str]:
+    """argparse ``choices`` for the ``auth`` subcommand's provider argument.
+
+    Derived from ``OAUTH_PROVIDERS`` at parser-build time. Falls back to a
+    minimal hardcoded set if ccproxy_manager is unavailable (the command
+    will then error out gracefully inside the handler).
+    """
+    try:
+        from omicsclaw.core.ccproxy_manager import oauth_cli_aliases
+        return oauth_cli_aliases()
+    except Exception:
+        return ["claude", "anthropic", "openai", "codex"]
+
+
+def _handle_auth_command(args) -> None:
+    """Dispatch ``omicsclaw auth {login,logout,status} [claude|openai]``.
+
+    Thin wrapper over the ``ccproxy`` CLI: we only handle provider-name
+    aliasing (``claude`` → ``claude_api``, ``openai`` → ``codex``) and a
+    multi-provider status view. All OAuth flow logic lives in ccproxy.
+    """
+    try:
+        from omicsclaw.core.ccproxy_manager import (
+            OAUTH_PROVIDERS,
+            ccproxy_diagnostic_hint,
+            ccproxy_executable,
+            check_ccproxy_auth,
+            get_oauth_provider,
+            is_ccproxy_available,
+            oauth_install_hint,
+        )
+    except Exception as exc:
+        print(f"{RED}Error importing ccproxy_manager: {exc}{RESET}", file=sys.stderr)
+        sys.exit(2)
+
+    if not is_ccproxy_available():
+        print(
+            f"{RED}ccproxy is not installed (from this Python's perspective).{RESET}",
+            file=sys.stderr,
+        )
+        print(ccproxy_diagnostic_hint(), file=sys.stderr)
+        print(f"Install: {CYAN}{oauth_install_hint()}{RESET}", file=sys.stderr)
+        sys.exit(2)
+
+    op = getattr(args, "auth_command", None)
+    target_alias = getattr(args, "provider", None)
+
+    if op is None:
+        print(
+            f"Usage: {CYAN}python omicsclaw.py auth [login|logout|status] "
+            f"[claude|openai]{RESET}"
+        )
+        sys.exit(1)
+
+    if op == "status" and not target_alias:
+        print(f"\n{BOLD}ccproxy OAuth status{RESET}")
+        print(f"{BOLD}{'=' * 50}{RESET}")
+        for p in OAUTH_PROVIDERS.values():
+            ok, msg = check_ccproxy_auth(p.ccproxy_target)
+            mark = f"{GREEN}OK{RESET}" if ok else f"{YELLOW}--{RESET}"
+            print(f"  [{mark}] {p.omics_name:<10} {msg}")
+        sys.exit(0)
+
+    if not target_alias:
+        print(
+            f"{RED}Error:{RESET} `{op}` requires a provider "
+            f"(one of: claude, openai).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Look up the full provider row from any alias (claude/anthropic/codex/
+    # openai/claude_api). get_oauth_provider raises ValueError for unknown
+    # aliases — the argparse choices already reject those, but belt-and-
+    # braces is cheap here.
+    try:
+        provider = get_oauth_provider(target_alias)
+    except ValueError as exc:
+        print(f"{RED}Error:{RESET} {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    import subprocess as _sp
+
+    rc = _sp.call([ccproxy_executable(), "auth", op, provider.ccproxy_target])
+    sys.exit(rc)
+
 # Canonical workflow order per domain — skills are displayed in this sequence.
 # Skills not listed here appear at the end in alphabetical order.
 _WORKFLOW_ORDER: dict[str, list[str]] = {
@@ -1039,6 +1126,24 @@ def main():
     # mcp config — show config file path
     mcp_sub.add_parser("config", help="Show MCP config file path")
 
+    # auth — manage OAuth login for Claude Pro/Max and OpenAI Codex via ccproxy
+    auth_p = sub.add_parser(
+        "auth",
+        help="Manage OAuth login for Claude Pro/Max and OpenAI Codex (via ccproxy)",
+    )
+    auth_sub = auth_p.add_subparsers(dest="auth_command")
+    for _op in ("login", "logout", "status"):
+        _p = auth_sub.add_parser(_op, help=f"{_op.capitalize()} OAuth credentials")
+        _p.add_argument(
+            "provider",
+            nargs="?",
+            # Accept any alias of any OAuth-capable provider. Derived from
+            # the ``OAUTH_PROVIDERS`` single source of truth in
+            # ccproxy_manager, so adding a new row there auto-extends CLI.
+            choices=_oauth_cli_choices(),
+            help="Target provider (claude|anthropic|openai|codex; omit for `status` to show both)",
+        )
+
     # memory-server — start graph memory REST API
     mem_p = sub.add_parser("memory-server", help="Start the graph memory REST API server")
     mem_p.add_argument("--host", default=None, help="Host to bind (default: 127.0.0.1)")
@@ -1516,6 +1621,10 @@ def main():
         else:
             print(f"Usage: python omicsclaw.py mcp [list|add|remove|config]")
             sys.exit(1)
+
+    if args.command == "auth":
+        _handle_auth_command(args)
+        return
 
     if args.command == "memory-server":
         _ensure_server_dependencies(

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -42,8 +42,13 @@ try:
     from omicsclaw.app.notebook.live_session import install_live_session_support
     from omicsclaw.app.notebook.router import router as notebook_router
     _NOTEBOOK_AVAILABLE = True
+    _NOTEBOOK_IMPORT_ERROR: str = ""
 except ImportError as _nb_err:
+    # NOTE: ``_nb_err`` is scoped to this except block (Python 3 deletes
+    # exception bindings on exit, PEP 3134). Persist the message to a
+    # module-level variable so the lifespan log on startup can surface it.
     _NOTEBOOK_AVAILABLE = False
+    _NOTEBOOK_IMPORT_ERROR = str(_nb_err)
     get_kernel_manager = None  # type: ignore[assignment]
     install_live_session_support = None  # type: ignore[assignment]
     notebook_router = None  # type: ignore[assignment]
@@ -169,7 +174,29 @@ def _resolve_backend_init_config() -> dict[str, str]:
         "api_key": _read_first_config_value("LLM_API_KEY", "OMICSCLAW_API_KEY"),
         "base_url": _read_first_config_value("LLM_BASE_URL", "OMICSCLAW_BASE_URL"),
         "model": _read_first_config_value("OMICSCLAW_MODEL"),
+        "auth_mode": (
+            _read_first_config_value("LLM_AUTH_MODE") or "api_key"
+        ).strip().lower(),
+        "ccproxy_port": _read_first_config_value("CCPROXY_PORT") or "11435",
     }
+
+
+def _current_app_server_port() -> int:
+    """Return the effective app-server port for this process."""
+    raw = str(os.getenv("OMICSCLAW_APP_PORT", "") or "").strip()
+    try:
+        return int(raw or DEFAULT_APP_API_PORT)
+    except (TypeError, ValueError):
+        return DEFAULT_APP_API_PORT
+
+
+def _oauth_port_conflict_message(ccproxy_port: int, app_port: int) -> str:
+    return (
+        f"ccproxy_port ({ccproxy_port}) conflicts with the OmicsClaw "
+        f"app-server port ({app_port}). Pick a different port "
+        f"(default: 11435) via the CCPROXY_PORT env var or the "
+        f"ccproxy_port field in the request body."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -315,12 +342,33 @@ async def lifespan(app: FastAPI):
     api_key = startup_config["api_key"]
     base_url = startup_config["base_url"]
     model = startup_config["model"]
+    auth_mode = startup_config.get("auth_mode", "api_key")
+    try:
+        ccproxy_port = int(startup_config.get("ccproxy_port", "11435") or "11435")
+    except (TypeError, ValueError):
+        ccproxy_port = 11435
 
+    if str(auth_mode or "").strip().lower() == "oauth":
+        app_port = _current_app_server_port()
+        if ccproxy_port == app_port:
+            logger.warning(
+                "Falling back to auth_mode='api_key' at startup — %s",
+                _oauth_port_conflict_message(ccproxy_port, app_port),
+            )
+            auth_mode = "api_key"
+
+    # Bootstrap (not user-initiated): if OAuth setup fails — e.g. stale
+    # LLM_AUTH_MODE=oauth in .env but ccproxy uninstalled — log a warning
+    # and fall back to api_key mode instead of crashing the entire server.
+    # The user can still reach the UI and fix the config.
     core.init(
         api_key=api_key,
         base_url=base_url or None,
         model=model,
         provider=provider,
+        auth_mode=auth_mode,
+        ccproxy_port=ccproxy_port,
+        strict_oauth=False,
     )
     logger.info(
         "OmicsClaw core initialised: provider=%s model=%s",
@@ -330,7 +378,10 @@ async def lifespan(app: FastAPI):
     if _NOTEBOOK_AVAILABLE:
         install_live_session_support()
     else:
-        logger.info("Notebook module not available (non-fatal): %s", _nb_err)
+        logger.info(
+            "Notebook module not available (non-fatal): %s",
+            _NOTEBOOK_IMPORT_ERROR or "(import failed without message)",
+        )
 
     # Optionally expose MemoryClient for browse/search endpoints
     try:
@@ -920,23 +971,7 @@ async def chat_stream(req: ChatRequest):
             provider=pc.provider,
         )
     elif req.provider_id and req.provider_id.lower() != core.LLM_PROVIDER_NAME.lower():
-        # Frontend selected a different provider — switch to it.
-        # API key is auto-resolved from environment variables by core.init().
-        try:
-            core.init(provider=req.provider_id, model=req.model or "")
-            # Persist to .env so the choice survives a restart
-            env_path = _get_omicsclaw_env_path()
-            if env_path:
-                updates: dict[str, str] = {"LLM_PROVIDER": req.provider_id}
-                if req.model:
-                    updates["OMICSCLAW_MODEL"] = req.model
-                _update_env_file(env_path, updates)
-            logger.info(
-                "Auto-switched provider=%s model=%s (from chat request)",
-                core.LLM_PROVIDER_NAME, core.OMICSCLAW_MODEL,
-            )
-        except Exception as exc:
-            logger.warning("Provider switch to %s failed: %s", req.provider_id, exc)
+        _apply_chat_provider_switch(core, req.provider_id, req.model or "")
 
     # --- Build per-request runtime overrides from frontend controls ---
     model_override = req.model or ""
@@ -2772,15 +2807,30 @@ async def list_providers():
             for name, (base_url, default_model, env_key) in PROVIDER_PRESETS.items()
         ]
 
+    try:
+        from omicsclaw.core.ccproxy_manager import provider_supports_oauth
+    except ImportError:
+        def provider_supports_oauth(_name: str) -> bool:  # type: ignore[no-redef]
+            return False
+
+    oauth_statuses = _cached_oauth_statuses()
+
     for entry in provider_entries:
         name = str(entry.get("name", "") or "")
         env_key = str(entry.get("env_key", "") or "")
         credential_source = _provider_configuration_source(name, env_key, core.LLM_PROVIDER_NAME)
+        oauth_supported = provider_supports_oauth(name)
         providers.append({
             **entry,
             "configured": bool(credential_source),
             "configured_via": credential_source or None,
             "active": name == core.LLM_PROVIDER_NAME,
+            "oauth_supported": oauth_supported,
+            "oauth_authenticated": (
+                oauth_statuses.get(name, {}).get("authenticated", False)
+                if oauth_supported
+                else False
+            ),
         })
 
     return {
@@ -2788,6 +2838,45 @@ async def list_providers():
         "current": core.LLM_PROVIDER_NAME,
         "current_model": core.OMICSCLAW_MODEL,
     }
+
+
+# ---------------------------------------------------------------------------
+# OAuth status cache — avoids subprocess-spawning on every /providers poll
+# ---------------------------------------------------------------------------
+
+_OAUTH_STATUS_CACHE: dict[str, object] = {"ts": 0.0, "data": {}}
+_OAUTH_STATUS_TTL_SECONDS: float = 30.0
+
+
+def _cached_oauth_statuses() -> dict[str, dict[str, object]]:
+    """Return per-provider OAuth status, refreshed at most every 30s.
+
+    Returns ``{}`` if ccproxy is not installed — the ``/providers`` endpoint
+    then falls back to ``oauth_authenticated: False`` uniformly.
+    """
+    import time as _time
+
+    now = _time.monotonic()
+    if (now - float(_OAUTH_STATUS_CACHE["ts"])) < _OAUTH_STATUS_TTL_SECONDS:
+        return _OAUTH_STATUS_CACHE["data"]  # type: ignore[return-value]
+
+    result: dict[str, dict[str, object]] = {}
+    try:
+        from omicsclaw.core.ccproxy_manager import (
+            OAUTH_PROVIDERS,
+            check_ccproxy_auth,
+            is_ccproxy_available,
+        )
+        if is_ccproxy_available():
+            for p in OAUTH_PROVIDERS.values():
+                ok, msg = check_ccproxy_auth(p.ccproxy_target)
+                result[p.omics_name] = {"authenticated": ok, "message": msg}
+    except Exception:
+        result = {}
+
+    _OAUTH_STATUS_CACHE["ts"] = now
+    _OAUTH_STATUS_CACHE["data"] = result
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -2799,28 +2888,74 @@ class ProviderSwitchRequest(BaseModel):
     api_key: str = ""
     base_url: str = ""
     model: str = ""
+    auth_mode: str = "api_key"  # "api_key" | "oauth"
+    ccproxy_port: int = 11435
 
 
 @app.put("/providers")
 async def switch_provider(req: ProviderSwitchRequest):
-    """Switch the active LLM provider. Re-initializes the core LLM client."""
+    """Switch the active LLM provider. Re-initializes the core LLM client.
+
+    When ``auth_mode="oauth"`` is requested (valid only for ``anthropic``
+    / ``openai``), the backend spawns/reuses a local ccproxy server and
+    routes requests through it — no API key is required.
+    """
     core = _get_core()
 
     # Validate provider name
     try:
         from omicsclaw.core.provider_registry import PROVIDER_PRESETS
+        from omicsclaw.core.ccproxy_manager import provider_supports_oauth
         if req.provider not in PROVIDER_PRESETS and req.provider != "custom":
             raise HTTPException(400, detail=f"Unknown provider: {req.provider}")
     except ImportError:
-        pass
+        def provider_supports_oauth(_name: str) -> bool:  # type: ignore[no-redef]
+            return False
 
-    # Re-init core with new provider
+    # Validate auth mode
+    auth_mode = str(req.auth_mode or "api_key").strip().lower()
+    if auth_mode not in ("api_key", "oauth"):
+        raise HTTPException(
+            400, detail=f"Invalid auth_mode: {req.auth_mode} (expected api_key|oauth)"
+        )
+    if auth_mode == "oauth" and not provider_supports_oauth(req.provider):
+        raise HTTPException(
+            400,
+            detail=(
+                f"auth_mode=oauth is not supported for provider '{req.provider}'. "
+                "Supported: anthropic, openai"
+            ),
+        )
+
+    # Reject ccproxy_port == app-server's own port: ccproxy serve would
+    # fail to bind (the app-server already owns the port), leaving the
+    # switch attempt in a broken half-state.
+    requested_port = int(req.ccproxy_port or 11435)
+    if auth_mode == "oauth":
+        app_port = _current_app_server_port()
+        if requested_port == app_port:
+            raise HTTPException(
+                400,
+                detail=_oauth_port_conflict_message(requested_port, app_port),
+            )
+
+    # Re-init core with new provider. When auth_mode=oauth, api_key can be
+    # empty — ccproxy supplies the OAuth token. core.init() will raise if
+    # ccproxy is missing or unauthenticated.
+    api_key = req.api_key if req.api_key else os.environ.get("LLM_API_KEY", "")
+    if auth_mode == "oauth":
+        api_key = ""  # force ccproxy sentinel path inside core.init
     try:
         core.init(
-            api_key=req.api_key or os.environ.get("LLM_API_KEY", ""),
+            api_key=api_key,
             base_url=req.base_url or None,
             model=req.model,
             provider=req.provider,
+            auth_mode=auth_mode,
+            ccproxy_port=requested_port,
+            # Explicit user action via PUT /providers: fail loudly so the
+            # frontend can surface a precise error message.
+            strict_oauth=True,
         )
     except Exception as exc:
         raise HTTPException(500, detail=f"Failed to switch provider: {exc}")
@@ -2828,21 +2963,234 @@ async def switch_provider(req: ProviderSwitchRequest):
     # Persist to .env
     env_path = _get_omicsclaw_env_path()
     if env_path:
-        updates: dict[str, str] = {"LLM_PROVIDER": req.provider}
-        if req.model:
-            updates["OMICSCLAW_MODEL"] = req.model
+        updates: dict[str, str] = {
+            "LLM_PROVIDER": core.LLM_PROVIDER_NAME or req.provider,
+            "LLM_AUTH_MODE": auth_mode,
+        }
+        if core.OMICSCLAW_MODEL:
+            updates["OMICSCLAW_MODEL"] = core.OMICSCLAW_MODEL
         if req.api_key:
             updates["LLM_API_KEY"] = req.api_key
-        if req.base_url:
+        if req.base_url and auth_mode != "oauth":
             updates["LLM_BASE_URL"] = req.base_url
-        _update_env_file(env_path, updates)
+        remove_keys: set[str] = set()
+        if auth_mode == "oauth":
+            updates["CCPROXY_PORT"] = str(requested_port)
+            remove_keys.add("LLM_BASE_URL")
+        else:
+            remove_keys.add("CCPROXY_PORT")
+            if req.provider != "custom" and not req.base_url:
+                remove_keys.add("LLM_BASE_URL")
+        _update_env_file(env_path, updates, remove_keys=remove_keys)
 
-    logger.info("Switched to provider=%s model=%s", core.LLM_PROVIDER_NAME, core.OMICSCLAW_MODEL)
+    logger.info(
+        "Switched to provider=%s model=%s auth_mode=%s",
+        core.LLM_PROVIDER_NAME,
+        core.OMICSCLAW_MODEL,
+        auth_mode,
+    )
 
     return {
         "ok": True,
         "provider": core.LLM_PROVIDER_NAME,
         "model": core.OMICSCLAW_MODEL,
+        "auth_mode": auth_mode,
+    }
+
+
+# ---------------------------------------------------------------------------
+# OAuth endpoints — Claude Pro/Max + OpenAI Codex login via ccproxy
+# ---------------------------------------------------------------------------
+
+
+def _resolve_oauth_provider_alias(name: str) -> str:
+    """Resolve any CLI/omics/ccproxy alias → OmicsClaw canonical name.
+
+    Delegates to ``ccproxy_manager.normalize_oauth_provider`` (the single
+    source of truth) and re-raises as HTTP 400 for FastAPI callers.
+    """
+    from omicsclaw.core.ccproxy_manager import normalize_oauth_provider
+    try:
+        return normalize_oauth_provider(name)
+    except ValueError as exc:
+        raise HTTPException(400, detail=str(exc))
+
+
+# Proxy env vars httpx / requests / curl honor. Listed in both the lower-
+# and upper-case forms the stdlib / httpx actually consult.
+_PROXY_ENV_VAR_NAMES: tuple[str, ...] = (
+    "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy",
+    "ALL_PROXY", "all_proxy",
+)
+
+
+def _empty_proxy_env_vars() -> list[str]:
+    """Return proxy env var names currently set to the empty string.
+
+    Empty-string values (``HTTPS_PROXY=""``) are httpx's #1 footgun: it
+    treats them as "proxy configured with empty URL" and raises
+    ``ValueError: Unknown scheme for proxy URL URL('')`` the moment any
+    httpx client is constructed. This is exactly what happens when users
+    launch the server with ``NO_PROXY=* HTTPS_PROXY= HTTP_PROXY= ...`` to
+    bypass a system proxy — the emptiness propagates into every subprocess
+    we spawn, including ``ccproxy auth login``.
+    """
+    return [v for v in _PROXY_ENV_VAR_NAMES if os.environ.get(v, None) == ""]
+
+
+def _wrap_with_env_unset(command: str, vars_to_unset: list[str]) -> str:
+    """Prefix ``command`` with ``env -u VAR ...`` for each name in
+    ``vars_to_unset``. Returns ``command`` unchanged if the list is empty.
+    """
+    if not vars_to_unset:
+        return command
+    unset_flags = " ".join(f"-u {v}" for v in vars_to_unset)
+    return f"env {unset_flags} {command}"
+
+
+def _require_ccproxy_available() -> None:
+    try:
+        from omicsclaw.core.ccproxy_manager import (
+            ccproxy_diagnostic_hint,
+            is_ccproxy_available,
+            oauth_install_hint,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            500, detail=f"ccproxy_manager import failed: {exc}"
+        )
+    if not is_ccproxy_available():
+        raise HTTPException(
+            400,
+            detail=(
+                "ccproxy is not installed (from the server process's "
+                "perspective).\n\n"
+                f"{ccproxy_diagnostic_hint()}\n\n"
+                f"Install: {oauth_install_hint()}"
+            ),
+        )
+
+
+@app.get("/auth/{provider}/status")
+async def oauth_status(provider: str):
+    """Return the current OAuth credential status for ``provider``.
+
+    Cached up to 30s. Does not start ccproxy serve mode.
+    """
+    omics_name = _resolve_oauth_provider_alias(provider)
+    _require_ccproxy_available()
+    from omicsclaw.core.ccproxy_manager import check_ccproxy_auth
+    # check_ccproxy_auth accepts any alias; pass canonical for clarity.
+    ok, msg = check_ccproxy_auth(omics_name)
+    # invalidate cache so the next /providers poll reflects this probe
+    _OAUTH_STATUS_CACHE["ts"] = 0.0
+    return {"provider": omics_name, "authenticated": ok, "message": msg}
+
+
+@app.post("/auth/{provider}/login")
+async def oauth_login(provider: str):
+    """Return the shell command the user should run to complete OAuth.
+
+    We intentionally do NOT spawn ``ccproxy auth login`` on the server
+    process's behalf — it triggers an interactive browser flow, and the
+    only machine whose filesystem needs the resulting credentials is the
+    one where the backend's ``ccproxy serve`` will read them from (its own
+    host). For Docker / remote deployments, the user must SSH or
+    ``docker exec`` into the backend host before running this command;
+    logging in on a different machine writes the credentials to the wrong
+    filesystem and leaves the backend unauthenticated.
+    """
+    omics_name = _resolve_oauth_provider_alias(provider)
+    _require_ccproxy_available()
+    from omicsclaw.core.ccproxy_manager import get_oauth_provider
+
+    target = get_oauth_provider(omics_name).ccproxy_target
+    empty_proxies = _empty_proxy_env_vars()
+    base_cmd = f"ccproxy auth login {target}"
+    response: dict[str, object] = {
+        "provider": omics_name,
+        "command": _wrap_with_env_unset(base_cmd, empty_proxies),
+        "hint": (
+            "Run this command on the host where the OmicsClaw backend is "
+            "running. For Docker or remote deployments, SSH or `docker "
+            "exec` into that host first — ccproxy stores OAuth credentials "
+            "on whatever machine executes the login, and the backend reads "
+            "them from its own host."
+        ),
+    }
+    if empty_proxies:
+        response["warning"] = (
+            f"Backend detected empty proxy env vars "
+            f"({', '.join(empty_proxies)}) inherited by the server process. "
+            "httpx inside ccproxy would reject these as invalid proxy URLs "
+            "('Unknown scheme for proxy URL URL(\"\")'). The command above "
+            "prepends `env -u` to neutralize them for the ccproxy subprocess. "
+            "Long-term, unset them in your shell config so every terminal "
+            "starts clean."
+        )
+    return response
+
+
+@app.post("/auth/{provider}/logout")
+async def oauth_logout(provider: str):
+    """Invoke ``ccproxy auth logout`` for the given provider."""
+    omics_name = _resolve_oauth_provider_alias(provider)
+    _require_ccproxy_available()
+    from omicsclaw.core.ccproxy_manager import (
+        ccproxy_executable,
+        clear_ccproxy_env,
+        get_oauth_provider,
+    )
+    from omicsclaw.core.provider_runtime import (
+        clear_active_provider_runtime,
+        get_active_provider_runtime,
+    )
+    import subprocess as _sp
+
+    target = get_oauth_provider(omics_name).ccproxy_target
+    try:
+        result = _sp.run(
+            [ccproxy_executable(), "auth", "logout", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        raise HTTPException(500, detail=f"Failed to run ccproxy logout: {exc}")
+
+    # Clear ccproxy env injection so subsequent API-key requests don't
+    # keep routing through the (now logged-out) local proxy.
+    clear_ccproxy_env(omics_name)
+    runtime = get_active_provider_runtime()
+    if runtime is not None and runtime.auth_mode == "oauth" and runtime.provider == omics_name:
+        clear_active_provider_runtime()
+        try:
+            core = _get_core()
+            core.llm = None
+            # Drop the provider display state too. Otherwise the frontend
+            # would keep showing this (now credential-less) OAuth provider
+            # as active, and the next chat request would land on
+            # `llm is None` without any hint that re-auth is required.
+            core.LLM_PROVIDER_NAME = ""
+            core.OMICSCLAW_MODEL = ""
+        except Exception:
+            pass
+
+        # Persist the fallback so a restart doesn't re-enter oauth mode
+        # with stale LLM_AUTH_MODE=oauth / CCPROXY_PORT in .env.
+        env_path = _get_omicsclaw_env_path()
+        if env_path:
+            _update_env_file(
+                env_path,
+                {"LLM_AUTH_MODE": "api_key"},
+                remove_keys={"CCPROXY_PORT"},
+            )
+
+    _OAUTH_STATUS_CACHE["ts"] = 0.0  # invalidate cache
+    return {
+        "provider": omics_name,
+        "ok": result.returncode == 0,
+        "message": (result.stdout + result.stderr).strip() or "logged out",
     }
 
 
@@ -3415,11 +3763,23 @@ def _get_omicsclaw_env_path() -> Path:
         return Path.cwd() / ".env"
 
 
-def _update_env_file(env_path: Path, updates: dict[str, str]) -> None:
+def _update_env_file(
+    env_path: Path,
+    updates: dict[str, str],
+    *,
+    remove_keys: set[str] | None = None,
+) -> None:
     """Update key=value pairs in a .env file, preserving comments and order."""
     lines = []
     if env_path.exists():
         lines = env_path.read_text(encoding="utf-8").splitlines()
+
+    effective_remove_keys = {
+        str(key).strip()
+        for key in (remove_keys or set())
+        if str(key).strip()
+    }
+    effective_remove_keys.difference_update(updates.keys())
 
     updated_keys: set[str] = set()
     new_lines = []
@@ -3431,6 +3791,8 @@ def _update_env_file(env_path: Path, updates: dict[str, str]) -> None:
         raw_key = stripped.split("=", 1)[0].strip()
         if raw_key.startswith("export "):
             raw_key = raw_key[7:].strip()
+        if raw_key in effective_remove_keys:
+            continue
         if raw_key in updates:
             new_lines.append(f"{raw_key}={updates[raw_key]}")
             updated_keys.add(raw_key)
@@ -3446,8 +3808,51 @@ def _update_env_file(env_path: Path, updates: dict[str, str]) -> None:
 
     for key, value in updates.items():
         os.environ[key] = str(value)
+    for key in effective_remove_keys:
+        os.environ.pop(key, None)
 
-    logger.info("Updated %d key(s) in %s", len(updates), env_path)
+    logger.info(
+        "Updated %d key(s) and removed %d key(s) in %s",
+        len(updates),
+        len(effective_remove_keys),
+        env_path,
+    )
+
+
+def _apply_chat_provider_switch(core: Any, provider_id: str, model: str) -> None:
+    """Re-init ``core`` for a chat-initiated provider change and persist it.
+
+    Extracted from ``chat_stream`` so the persistence rules are unit-testable.
+    The chat request path has no ``auth_mode`` field, so ``core.init`` here
+    always lands in ``api_key`` mode; we must clear any stale
+    ``LLM_AUTH_MODE=oauth`` / ``CCPROXY_PORT`` in ``.env`` that belonged to
+    a prior OAuth session, otherwise a restart would rebuild an invalid
+    ``new_provider + oauth`` combination.
+    """
+    try:
+        core.init(provider=provider_id, model=model)
+    except Exception as exc:
+        logger.warning("Provider switch to %s failed: %s", provider_id, exc)
+        return
+
+    env_path = _get_omicsclaw_env_path()
+    if env_path:
+        updates: dict[str, str] = {
+            "LLM_PROVIDER": provider_id,
+            "LLM_AUTH_MODE": "api_key",
+        }
+        if getattr(core, "OMICSCLAW_MODEL", ""):
+            updates["OMICSCLAW_MODEL"] = core.OMICSCLAW_MODEL
+        remove_keys: set[str] = {"CCPROXY_PORT"}
+        if provider_id != "custom":
+            remove_keys.add("LLM_BASE_URL")
+        _update_env_file(env_path, updates, remove_keys=remove_keys)
+
+    logger.info(
+        "Auto-switched provider=%s model=%s (from chat request)",
+        getattr(core, "LLM_PROVIDER_NAME", provider_id),
+        getattr(core, "OMICSCLAW_MODEL", ""),
+    )
 
 
 # ---- Pydantic models for bridge endpoints --------------------------------
@@ -3881,6 +4286,8 @@ def main(argv: list[str] | None = None):
         raise SystemExit(1)
 
     args = _parse_args(argv)
+    os.environ["OMICSCLAW_APP_HOST"] = args.host
+    os.environ["OMICSCLAW_APP_PORT"] = str(args.port)
 
     logger.info("Starting OmicsClaw app backend on %s:%d", args.host, args.port)
     uvicorn.run(

--- a/omicsclaw/core/ccproxy_manager.py
+++ b/omicsclaw/core/ccproxy_manager.py
@@ -1,0 +1,557 @@
+"""ccproxy lifecycle management for OAuth-based Claude / OpenAI access.
+
+Provides helpers to detect, authenticate, start, stop, and point OmicsClaw
+at a local ``ccproxy`` server. Using ccproxy lets a user with a Claude
+Pro/Max subscription or an OpenAI Codex subscription run OmicsClaw without
+a separate API key — OAuth tokens are managed by ccproxy itself.
+
+ccproxy is invoked via subprocess, so the optional ``ccproxy-api`` package
+is not imported at module-load time. Install it with::
+
+    pip install 'omicsclaw[oauth]'
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# OAuth provider registry — the single source of truth
+# =============================================================================
+#
+# Every fact about an OAuth-capable provider lives in exactly one place: an
+# ``OAuthProvider`` row in ``OAUTH_PROVIDERS``. All other helpers in this
+# module (and in ``provider_runtime``, ``server.py``, ``omicsclaw.py`` CLI)
+# derive from this table instead of restating the same mappings.
+#
+# To add a third OAuth backend (e.g. Google login via ccproxy), add one row
+# here and the rest of the system picks it up automatically.
+
+
+@dataclass(frozen=True)
+class OAuthProvider:
+    """Identity + wiring for one OAuth-capable provider."""
+
+    omics_name: str       # OmicsClaw canonical name, e.g. "anthropic"
+    cli_alias: str        # user-friendly CLI label, e.g. "claude"
+    ccproxy_target: str   # ccproxy's internal identifier, e.g. "claude_api"
+    base_url_path: str    # path suffix under the local proxy, e.g. "/claude"
+    env_base_url: str     # SDK env var for base URL, e.g. "ANTHROPIC_BASE_URL"
+    env_api_key: str      # SDK env var for API key, e.g. "ANTHROPIC_API_KEY"
+
+
+OAUTH_PROVIDERS: dict[str, OAuthProvider] = {
+    "anthropic": OAuthProvider(
+        omics_name="anthropic",
+        cli_alias="claude",
+        ccproxy_target="claude_api",
+        base_url_path="/claude",
+        env_base_url="ANTHROPIC_BASE_URL",
+        env_api_key="ANTHROPIC_API_KEY",
+    ),
+    "openai": OAuthProvider(
+        omics_name="openai",
+        cli_alias="openai",
+        ccproxy_target="codex",
+        base_url_path="/codex/v1",
+        env_base_url="OPENAI_BASE_URL",
+        env_api_key="OPENAI_API_KEY",
+    ),
+}
+
+
+# Flat alias → canonical name, covers every known spelling (omics, CLI,
+# ccproxy). Built once at module load from ``OAUTH_PROVIDERS``.
+_OAUTH_ALIAS_MAP: dict[str, str] = {
+    alias: p.omics_name
+    for p in OAUTH_PROVIDERS.values()
+    for alias in (p.omics_name, p.cli_alias, p.ccproxy_target)
+}
+
+
+# Default ccproxy port. Deliberately NOT 8765 (the OmicsClaw app-server's
+# default) to avoid a startup-time self-conflict when the app-server
+# switches to OAuth mode. 11434 is reserved for Ollama, so use 11435.
+DEFAULT_CCPROXY_PORT: int = 11435
+
+OAUTH_SENTINEL_KEY: str = "ccproxy-oauth"
+
+
+def normalize_oauth_provider(alias: str) -> str:
+    """Any known alias → canonical OmicsClaw provider name.
+
+    Accepts omics canonical names (``anthropic``/``openai``), CLI aliases
+    (``claude``/``openai``) and ccproxy internal identifiers
+    (``claude_api``/``codex``). Case-insensitive. Raises ``ValueError``
+    on unknown tokens.
+    """
+    key = str(alias or "").strip().lower()
+    canonical = _OAUTH_ALIAS_MAP.get(key)
+    if canonical is None:
+        raise ValueError(
+            f"Unknown OAuth provider alias '{alias}'. "
+            f"Supported: {sorted(_OAUTH_ALIAS_MAP.keys())}"
+        )
+    return canonical
+
+
+def get_oauth_provider(alias: str) -> OAuthProvider:
+    """Return the ``OAuthProvider`` row for any known alias."""
+    return OAUTH_PROVIDERS[normalize_oauth_provider(alias)]
+
+
+def oauth_base_url(alias: str, port: int) -> str:
+    """Build the local ccproxy base URL for an OAuth-capable provider."""
+    p = get_oauth_provider(alias)
+    return f"http://127.0.0.1:{int(port)}{p.base_url_path}"
+
+
+def provider_supports_oauth(name: str) -> bool:
+    """Return True if ``name`` matches any alias of an OAuth-capable provider."""
+    key = str(name or "").strip().lower()
+    return key in _OAUTH_ALIAS_MAP
+
+
+def oauth_cli_aliases() -> list[str]:
+    """Sorted list of every CLI-valid OAuth provider alias.
+
+    Used to populate argparse ``choices`` — so the CLI automatically
+    accepts any new provider added to ``OAUTH_PROVIDERS``.
+    """
+    return sorted(_OAUTH_ALIAS_MAP.keys())
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat views derived from ``OAUTH_PROVIDERS``.
+# Kept so callers (and tests) that imported the old names keep working.
+# Prefer ``get_oauth_provider()`` / ``OAUTH_PROVIDERS`` in new code.
+# ---------------------------------------------------------------------------
+CCPROXY_PROVIDER_MAP: dict[str, str] = {
+    p.omics_name: p.ccproxy_target for p in OAUTH_PROVIDERS.values()
+}
+CLI_PROVIDER_ALIASES: dict[str, str] = dict(_OAUTH_ALIAS_MAP)
+
+
+def normalize_cli_provider(alias: str) -> str:
+    """Deprecated alias for :func:`normalize_oauth_provider`."""
+    return normalize_oauth_provider(alias)
+
+
+def ccproxy_executable() -> str:
+    """Return an absolute path to the ``ccproxy`` binary, or ``'ccproxy'``.
+
+    Public wrapper over :func:`_ccproxy_exe` so that callers outside this
+    module (CLI handler, FastAPI endpoints) can invoke the same
+    venv/editable-install-aware resolution instead of relying on ``$PATH``.
+    """
+    return _ccproxy_exe() or "ccproxy"
+
+
+# =============================================================================
+# Binary detection
+# =============================================================================
+
+
+def _ccproxy_exe() -> str | None:
+    """Return the path to the ccproxy binary, or None if not found.
+
+    Checks PATH first, then the current Python environment's bin directory
+    (handles venv / conda envs where newly installed binaries may not be
+    visible to ``shutil.which`` immediately after ``pip install``).
+    """
+    found = shutil.which("ccproxy")
+    if found:
+        return found
+    import sys as _sys
+
+    candidate = os.path.join(os.path.dirname(_sys.executable), "ccproxy")
+    if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def is_ccproxy_available() -> bool:
+    """Return True if the ``ccproxy`` CLI binary is reachable."""
+    return _ccproxy_exe() is not None
+
+
+def ccproxy_diagnostic_hint() -> str:
+    """Describe what ``_ccproxy_exe`` checked and why it came up empty.
+
+    Written for the user-facing error message when ``is_ccproxy_available``
+    returns False despite the user believing ccproxy is installed — almost
+    always a "wrong Python interpreter" mismatch (e.g. server launched
+    with system Python while ccproxy lives in an unactivated ``.venv``).
+    """
+    import sys as _sys
+
+    path_found = shutil.which("ccproxy")
+    bin_dir = os.path.dirname(_sys.executable)
+    candidate = os.path.join(bin_dir, "ccproxy")
+    venv_found = (
+        candidate
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK)
+        else None
+    )
+
+    lines = [
+        f"Python interpreter in use: {_sys.executable}",
+        "Searched for `ccproxy`:",
+        f"  - on $PATH (shutil.which): {path_found or '(not found)'}",
+        f"  - next to interpreter ({candidate}): "
+        f"{venv_found or '(not found)'}",
+    ]
+    if path_found is None and venv_found is None:
+        # Emit a copy-paste command bound to THIS interpreter. Avoids the
+        # very common "I installed it, but in a different venv" confusion:
+        # {sys.executable} -m pip always installs into the site-packages
+        # that the running server process can actually import from.
+        lines.append(
+            f"Fix (exact command for this interpreter):\n"
+            f"  {_sys.executable} -m pip install ccproxy-api"
+        )
+        lines.append(
+            "Hint: if you installed ccproxy into a venv, start the server "
+            "with that venv's Python (e.g. `source .venv/bin/activate` "
+            "first, or run `.venv/bin/python -m uvicorn ...`) so "
+            "sys.executable points there."
+        )
+    return "\n".join(lines)
+
+
+def _is_editable_install() -> bool:
+    """True if OmicsClaw is installed in editable/development mode."""
+    try:
+        import importlib.metadata as _meta
+        import json
+
+        for dist in _meta.distributions():
+            name = (dist.metadata.get("Name", "") or "").lower()
+            if name != "omicsclaw":
+                continue
+            direct_url = dist.read_text("direct_url.json")
+            if direct_url is not None:
+                data = json.loads(direct_url)
+                if data.get("dir_info", {}).get("editable", False) is True:
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def oauth_install_hint() -> str:
+    """Return a user-facing install command appropriate for the install mode."""
+    if _is_editable_install():
+        return "pip install -e '.[oauth]'"
+    return "pip install 'omicsclaw[oauth]'"
+
+
+# =============================================================================
+# Auth status
+# =============================================================================
+
+
+def _summarize_auth_output(raw: str) -> str:
+    """Extract key fields from ``ccproxy auth status`` output as a one-liner.
+
+    Parses the Rich table output for Email, Subscription, and Status fields.
+    Returns e.g. ``"user@example.com (plus, active)"``. Falls back to
+    ``"Authenticated"`` if parsing fails.
+    """
+    import re as _re
+
+    clean = _re.sub(r"\x1b\[[0-9;]*m", "", raw)
+
+    fields: dict[str, str] = {}
+    for line in clean.splitlines():
+        m = _re.match(r"\s*(.+?)\s{2,}(.+)", line)
+        if not m:
+            continue
+        key, val = m.group(1).strip(), m.group(2).strip()
+        if key in ("Email", "Subscription", "Subscription Status"):
+            fields[key.lower().replace(" ", "_")] = val
+
+    email = fields.get("email", "")
+    sub = fields.get("subscription", "")
+    status = fields.get("subscription_status", "")
+
+    if email:
+        detail = ", ".join(filter(None, [sub, status]))
+        return f"{email} ({detail})" if detail else email
+    return "Authenticated"
+
+
+def check_ccproxy_auth(provider: str = "claude_api") -> tuple[bool, str]:
+    """Check whether ccproxy holds valid OAuth credentials for ``provider``.
+
+    Args:
+        provider: any known alias — OmicsClaw canonical
+            (``anthropic`` / ``openai``), CLI (``claude``), or ccproxy
+            internal (``claude_api`` / ``codex``).
+
+    Returns:
+        ``(is_valid, message)``. ``message`` is either a one-line summary
+        of the authenticated account, or a short failure reason.
+    """
+    try:
+        target = get_oauth_provider(provider).ccproxy_target
+    except ValueError as exc:
+        return False, str(exc)
+    try:
+        exe = _ccproxy_exe() or "ccproxy"
+        result = subprocess.run(
+            [exe, "auth", "status", target],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        import re as _re
+
+        raw = (result.stdout + result.stderr).strip()
+        clean = _re.sub(r"\x1b\[[0-9;]*m", "", raw)
+
+        # Filter structlog noise so we only keep real status lines.
+        status_lines = [
+            line
+            for line in clean.splitlines()
+            if line.strip()
+            and not _re.match(r"\d{4}-\d{2}-\d{2}", line.strip())
+            and "warning" not in line.lower()
+            and "plugin" not in line.lower()
+        ]
+        status_msg = " ".join(status_lines).strip()
+
+        if result.returncode != 0 or "not authenticated" in clean.lower():
+            return False, status_msg or "Not authenticated"
+
+        summary = _summarize_auth_output(result.stdout)
+        return True, summary or "Authenticated"
+    except FileNotFoundError:
+        return False, "ccproxy not found"
+    except subprocess.TimeoutExpired:
+        return False, "Auth check timed out"
+    except Exception as exc:
+        return False, f"Auth check failed: {exc}"
+
+
+# =============================================================================
+# Process lifecycle
+# =============================================================================
+
+
+def is_ccproxy_running(port: int) -> bool:
+    """Return True if a ccproxy server is already serving on ``port``."""
+    import httpx
+
+    try:
+        resp = httpx.get(f"http://127.0.0.1:{port}/health/live", timeout=2.0)
+        return resp.status_code == 200
+    except (httpx.ConnectError, httpx.TimeoutException, OSError):
+        return False
+
+
+def start_ccproxy(port: int) -> subprocess.Popen:
+    """Start ``ccproxy serve --port PORT`` as a background process.
+
+    Blocks until the health endpoint responds (up to 30s on first launch).
+
+    Raises:
+        RuntimeError: ccproxy exited early or never became healthy.
+        FileNotFoundError: ccproxy binary is not installed.
+    """
+    exe = _ccproxy_exe() or "ccproxy"
+    proc = subprocess.Popen(
+        [exe, "serve", "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"ccproxy exited immediately with code {proc.returncode}"
+            )
+        if is_ccproxy_running(port):
+            return proc
+        time.sleep(0.3)
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    raise RuntimeError("ccproxy did not become healthy within 30 seconds")
+
+
+def stop_ccproxy(proc: subprocess.Popen | None) -> None:
+    """Gracefully stop a ccproxy process. Safe to call with ``None``."""
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+def ensure_ccproxy(port: int) -> subprocess.Popen | None:
+    """Reuse an existing ccproxy if alive on ``port``, otherwise start one.
+
+    Returns the ``Popen`` handle of a newly started process, or ``None`` if
+    an existing instance was reused.
+    """
+    if is_ccproxy_running(port):
+        logger.debug("ccproxy already running on port %d", port)
+        return None
+    return start_ccproxy(port)
+
+
+# =============================================================================
+# Environment wiring
+# =============================================================================
+
+
+def setup_ccproxy_env(provider: str, port: int) -> None:
+    """Point the OpenAI/Anthropic SDK at the local ccproxy for ``provider``.
+
+    Sets the provider's ``{_BASE_URL, _API_KEY}`` env vars to a local URL
+    + the sentinel key ``ccproxy-oauth``. Always overrides existing values
+    — when this is called, OAuth mode is the decision.
+    """
+    p = get_oauth_provider(provider)
+    os.environ[p.env_base_url] = oauth_base_url(p.omics_name, port)
+    os.environ[p.env_api_key] = OAUTH_SENTINEL_KEY
+
+
+def clear_ccproxy_env(provider: str | None = None) -> None:
+    """Remove ccproxy-injected env vars for ``provider`` (or all if None).
+
+    Necessary when switching away from OAuth mode back to API key mode —
+    otherwise the previous sentinel values would leak into
+    :func:`resolve_provider` and every subsequent request would keep
+    going through ccproxy.
+
+    ONLY clears values that match our sentinel / ccproxy URL shape, so
+    legitimate user-supplied env values are never touched.
+    """
+    if provider is None:
+        targets = list(OAUTH_PROVIDERS.values())
+    else:
+        try:
+            targets = [get_oauth_provider(provider)]
+        except ValueError:
+            # Unknown alias → nothing to clear; not an error.
+            return
+
+    for p in targets:
+        if os.environ.get(p.env_api_key, "") == OAUTH_SENTINEL_KEY:
+            os.environ.pop(p.env_api_key, None)
+        existing_url = os.environ.get(p.env_base_url, "")
+        if (
+            existing_url.startswith("http://127.0.0.1:")
+            and existing_url.endswith(p.base_url_path)
+        ):
+            os.environ.pop(p.env_base_url, None)
+
+
+# =============================================================================
+# High-level orchestration
+# =============================================================================
+
+
+def maybe_start_ccproxy(
+    *,
+    anthropic_oauth: bool = False,
+    openai_oauth: bool = False,
+    port: int = DEFAULT_CCPROXY_PORT,
+) -> subprocess.Popen | None:
+    """Conditionally start ccproxy and wire env vars based on flags.
+
+    Raises ``RuntimeError`` if OAuth is requested but ccproxy is missing
+    or unauthenticated. Returns the new ``Popen`` handle, or ``None`` if
+    ccproxy was already running or no OAuth was requested.
+    """
+    # Map keyword flags to the provider rows they enable.
+    requested: list[OAuthProvider] = []
+    if anthropic_oauth:
+        requested.append(OAUTH_PROVIDERS["anthropic"])
+    if openai_oauth:
+        requested.append(OAUTH_PROVIDERS["openai"])
+
+    if not requested:
+        return None
+
+    if not is_ccproxy_available():
+        raise RuntimeError(
+            "ccproxy is required for OAuth mode but was not found. "
+            f"Install it with: {oauth_install_hint()}"
+        )
+
+    if not (1 <= int(port) <= 65535):
+        raise ValueError(f"Invalid ccproxy port: {port}. Must be 1..65535.")
+
+    for p in requested:
+        ok, msg = check_ccproxy_auth(p.ccproxy_target)
+        if not ok:
+            raise RuntimeError(
+                f"ccproxy OAuth for '{p.omics_name}' not authenticated: {msg}\n"
+                f"Run: omicsclaw auth login {p.cli_alias}"
+            )
+
+    proc = ensure_ccproxy(port)
+
+    for p in requested:
+        setup_ccproxy_env(p.omics_name, port)
+
+    if proc is not None:
+        logger.info("Started ccproxy on port %d", port)
+    else:
+        logger.info("Reusing existing ccproxy on port %d", port)
+    return proc
+
+
+__all__ = [
+    # Identity table & helpers (prefer these in new code)
+    "OAuthProvider",
+    "OAUTH_PROVIDERS",
+    "get_oauth_provider",
+    "normalize_oauth_provider",
+    "oauth_base_url",
+    "oauth_cli_aliases",
+    "provider_supports_oauth",
+    # Constants
+    "DEFAULT_CCPROXY_PORT",
+    "OAUTH_SENTINEL_KEY",
+    # Lifecycle & diagnostics
+    "ccproxy_diagnostic_hint",
+    "ccproxy_executable",
+    "check_ccproxy_auth",
+    "clear_ccproxy_env",
+    "ensure_ccproxy",
+    "is_ccproxy_available",
+    "is_ccproxy_running",
+    "maybe_start_ccproxy",
+    "oauth_install_hint",
+    "setup_ccproxy_env",
+    "start_ccproxy",
+    "stop_ccproxy",
+    # Backwards-compat views (derived from OAUTH_PROVIDERS)
+    "CCPROXY_PROVIDER_MAP",
+    "CLI_PROVIDER_ALIASES",
+    "normalize_cli_provider",
+]

--- a/omicsclaw/core/provider_registry.py
+++ b/omicsclaw/core/provider_registry.py
@@ -220,6 +220,24 @@ PROVIDER_DETECT_ORDER: tuple[str, ...] = (
 
 PROVIDER_CHOICES: tuple[str, ...] = tuple(PROVIDER_PRESETS.keys())
 
+# Providers that intentionally allow wide/open model identifier spaces.
+# For these, OmicsClaw must not auto-rewrite model names just because they
+# resemble another provider's default model.
+MODEL_NORMALIZATION_EXEMPT_PROVIDERS: frozenset[str] = frozenset({
+    "custom",
+    "ollama",
+    "openrouter",
+    "siliconflow",
+    "nvidia",
+})
+
+
+# --------------------------------------------------------------------------- #
+# OAuth support was previously declared here. It now lives entirely in
+# ``omicsclaw.core.ccproxy_manager`` (the only module that actually runs
+# ccproxy) — see the ``OAUTH_PROVIDERS`` table there. This module stays
+# dependency-light and OAuth-agnostic per its original design.
+
 
 def get_provider_display_metadata(provider_name: str) -> ProviderDisplayMetadata:
     metadata = PROVIDER_DISPLAY_METADATA.get(provider_name)
@@ -282,6 +300,52 @@ def detect_provider_from_env(
     return ""
 
 
+def normalize_model_for_provider(
+    provider: str = "",
+    model: str = "",
+    *,
+    base_url: str = "",
+    provider_presets: Mapping[str, ProviderPreset] = PROVIDER_PRESETS,
+    exempt_providers: frozenset[str] = MODEL_NORMALIZATION_EXEMPT_PROVIDERS,
+) -> tuple[str, str]:
+    """Normalize obviously stale cross-provider default-model leftovers.
+
+    This is intentionally conservative:
+
+    - only runs when a concrete provider is selected
+    - never rewrites models for custom/local/gateway-style providers
+    - never rewrites when the user supplied a custom base URL
+    - only rewrites when the model exactly matches another provider's default
+
+    Returns ``(normalized_model, matched_foreign_provider)`` where the second
+    value is empty when no normalization was needed.
+    """
+    provider_key = str(provider or "").strip().lower()
+    candidate_model = str(model or "").strip()
+    explicit_base_url = str(base_url or "").strip()
+
+    if not provider_key or not candidate_model:
+        return candidate_model, ""
+    if explicit_base_url or provider_key in exempt_providers:
+        return candidate_model, ""
+
+    current = provider_presets.get(provider_key)
+    if current is None:
+        return candidate_model, ""
+
+    current_default_model = str(current[1] or "").strip()
+    if not current_default_model or candidate_model == current_default_model:
+        return candidate_model, ""
+
+    for other_name, (_, other_default_model, _) in provider_presets.items():
+        if other_name == provider_key:
+            continue
+        if candidate_model == str(other_default_model or "").strip():
+            return current_default_model, other_name
+
+    return candidate_model, ""
+
+
 def resolve_provider(
     provider: str = "",
     base_url: str = "",
@@ -326,6 +390,12 @@ def resolve_provider(
     )
     resolved_url = str(base_url or env_base_url or preset_url or "") or None
     resolved_model = str(model or preset_model or "deepseek-chat")
+    resolved_model, _normalized_from = normalize_model_for_provider(
+        provider_key,
+        resolved_model,
+        base_url=base_url or env_base_url,
+        provider_presets=provider_presets,
+    )
 
     if not resolved_key and preset_key_env:
         resolved_key = str(source.get(preset_key_env, "") or "")

--- a/omicsclaw/core/provider_runtime.py
+++ b/omicsclaw/core/provider_runtime.py
@@ -15,6 +15,23 @@ from omicsclaw.core.provider_registry import (
     detect_provider_from_env,
     resolve_provider,
 )
+# OAuth identity lives in ccproxy_manager (the only module that actually
+# runs ccproxy). provider_runtime just needs the two small helpers to
+# rewrite base_url / validate provider support when auth_mode="oauth".
+from omicsclaw.core.ccproxy_manager import (
+    oauth_base_url,
+    provider_supports_oauth,
+)
+
+# Default port used when ``auth_mode="oauth"`` but no explicit port is given.
+# Kept in sync with ``omicsclaw.core.ccproxy_manager.DEFAULT_CCPROXY_PORT``.
+# Deliberately avoids 8765 (OmicsClaw app-server default) to prevent the
+# ccproxy subprocess from trying to bind the same port as the app-server.
+DEFAULT_CCPROXY_PORT: int = 11435
+
+# Sentinel API key that tells downstream OpenAI/Anthropic SDK clients the
+# request is routed through ccproxy (which supplies real OAuth tokens).
+_OAUTH_SENTINEL_KEY: str = "ccproxy-oauth"
 
 
 @dataclass(frozen=True)
@@ -23,6 +40,8 @@ class ProviderRuntimeConfig:
     base_url: str = ""
     model: str = ""
     api_key: str = ""
+    auth_mode: str = "api_key"  # "api_key" | "oauth"
+    ccproxy_port: int = DEFAULT_CCPROXY_PORT
 
 
 @dataclass(frozen=True)
@@ -75,10 +94,19 @@ def provider_requires_api_key(provider: str) -> bool:
     return _normalize_provider_name(provider) != "ollama"
 
 
-def _normalize_api_key_for_client(provider: str, api_key: str) -> str:
+def _normalize_api_key_for_client(
+    provider: str,
+    api_key: str,
+    auth_mode: str = "api_key",
+) -> str:
     resolved_key = str(api_key or "").strip()
     if resolved_key:
         return resolved_key
+    if (
+        str(auth_mode or "").strip().lower() == "oauth"
+        and provider_supports_oauth(provider)
+    ):
+        return _OAUTH_SENTINEL_KEY
     if not provider_requires_api_key(provider):
         return "omicsclaw-local"
     return ""
@@ -95,14 +123,38 @@ def set_active_provider_runtime(
     base_url: str = "",
     model: str = "",
     api_key: str = "",
+    auth_mode: str = "api_key",
+    ccproxy_port: int = DEFAULT_CCPROXY_PORT,
 ) -> ProviderRuntimeConfig:
+    """Persist the active provider runtime snapshot.
+
+    When ``auth_mode == "oauth"`` and the provider is OAuth-capable
+    (Claude / OpenAI), the ``base_url`` is overridden with the local
+    ccproxy endpoint and ``api_key`` is set to the ccproxy sentinel value
+    — downstream callers (``AsyncOpenAI``, ``get_langchain_llm``) then
+    transparently route through ccproxy with no code changes.
+    """
     global _ACTIVE_PROVIDER_RUNTIME
 
+    normalized_provider = _normalize_provider_name(provider)
+    normalized_auth_mode = str(auth_mode or "api_key").strip().lower() or "api_key"
+    resolved_base_url = str(base_url or "").strip()
+    resolved_api_key = str(api_key or "").strip()
+
+    if (
+        normalized_auth_mode == "oauth"
+        and provider_supports_oauth(normalized_provider)
+    ):
+        resolved_base_url = oauth_base_url(normalized_provider, ccproxy_port)
+        resolved_api_key = _OAUTH_SENTINEL_KEY
+
     runtime = ProviderRuntimeConfig(
-        provider=_normalize_provider_name(provider),
-        base_url=str(base_url or "").strip(),
+        provider=normalized_provider,
+        base_url=resolved_base_url,
         model=str(model or "").strip(),
-        api_key=str(api_key or "").strip(),
+        api_key=resolved_api_key,
+        auth_mode=normalized_auth_mode,
+        ccproxy_port=int(ccproxy_port),
     )
     _ACTIVE_PROVIDER_RUNTIME = runtime
     return runtime
@@ -123,6 +175,8 @@ def resolve_provider_runtime(
     base_url: str = "",
     model: str = "",
     api_key: str = "",
+    auth_mode: str = "",
+    ccproxy_port: int | None = None,
     active_runtime: ProviderRuntimeConfig | None = None,
     env: Mapping[str, str] | None = None,
 ) -> ResolvedProviderRuntime:
@@ -132,18 +186,44 @@ def resolve_provider_runtime(
     1. Explicit base_url/api_key/provider/model when present
     2. Active OmicsClaw runtime when compatible with the request
     3. Environment / provider preset resolution
+
+    When ``auth_mode`` is unspecified it defaults to the active runtime's
+    mode, or falls back to ``"api_key"``.
     """
     requested_provider = _normalize_provider_name(provider)
     requested_base_url = str(base_url or "").strip()
     requested_model = str(model or "").strip()
     requested_key = str(api_key or "").strip()
+    requested_auth_mode = str(auth_mode or "").strip().lower()
     runtime = active_runtime if active_runtime is not None else get_active_provider_runtime()
 
+    effective_auth_mode = (
+        requested_auth_mode
+        or (runtime.auth_mode if runtime is not None else "")
+        or "api_key"
+    )
+    effective_port = int(
+        ccproxy_port
+        if ccproxy_port is not None
+        else (runtime.ccproxy_port if runtime is not None else DEFAULT_CCPROXY_PORT)
+    )
+
+    # Explicit auth_mode that differs from the active runtime's mode means
+    # the caller is performing a deliberate switch (OAuth ↔ API key). We
+    # must NOT silently reuse the old runtime's base_url / sentinel key in
+    # that case — otherwise switching back to API key mode would still
+    # route requests through ccproxy (Bug 4: state machine not reversible).
+    auth_mode_compatible = (
+        runtime is None
+        or not requested_auth_mode
+        or requested_auth_mode == runtime.auth_mode
+    )
     can_reuse_active_runtime = (
         runtime is not None
         and not requested_base_url
         and not requested_key
         and (not requested_provider or requested_provider == runtime.provider)
+        and auth_mode_compatible
     )
     if can_reuse_active_runtime:
         resolved_provider = infer_provider_name(
@@ -158,7 +238,10 @@ def resolve_provider_runtime(
             api_key=_normalize_api_key_for_client(
                 resolved_provider,
                 runtime.api_key,
+                auth_mode=effective_auth_mode,
             ),
+            auth_mode=effective_auth_mode,
+            ccproxy_port=effective_port,
             source="active-runtime",
         )
         if any((
@@ -182,11 +265,26 @@ def resolve_provider_runtime(
         env=env,
     )
 
+    # If the caller explicitly requested OAuth for a supported provider,
+    # override the base URL with the local ccproxy endpoint. Preset URLs
+    # from resolve_provider() would otherwise point at the cloud API.
+    if (
+        effective_auth_mode == "oauth"
+        and provider_supports_oauth(resolved_provider)
+    ):
+        resolved_url = oauth_base_url(resolved_provider, effective_port)
+
     return ResolvedProviderRuntime(
         provider=resolved_provider,
         base_url=str(resolved_url or "").strip(),
         model=str(resolved_model or "").strip(),
-        api_key=_normalize_api_key_for_client(resolved_provider, resolved_key),
+        api_key=_normalize_api_key_for_client(
+            resolved_provider,
+            resolved_key,
+            auth_mode=effective_auth_mode,
+        ),
+        auth_mode=effective_auth_mode,
+        ccproxy_port=effective_port,
         source=(
             "explicit-request"
             if any((requested_provider, requested_base_url, requested_model, requested_key))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,29 @@ singlecell-full = [
 # Legacy rpy2 bridge — no longer required. R methods use subprocess.
 singlecell-r-bridge = []
 
+# --------------------------------------------------------------------------- #
+# oauth — ccproxy-backed OAuth login for Claude Pro/Max and OpenAI Codex      #
+# subscriptions. Lets users route anthropic/openai calls through a local      #
+# ccproxy server instead of supplying an API key. Triggered by CLI            #
+# `omicsclaw auth login claude|openai` and runtime flag `--auth-mode oauth`.  #
+#                                                                             #
+# KNOWN BENIGN PIP WARNING:                                                   #
+#   Installing this extra alongside the `spatial-trajectory` /                #
+#   `singlecell-pseudotime` extras (which depend on cellrank → pygpcca) may   #
+#   print:                                                                    #
+#     ERROR: pygpcca 1.0.4 requires jinja2==3.0.3, but you have jinja2 3.1.x. #
+#   Root cause: ccproxy-api pulls fastapi[standard] which requires            #
+#   jinja2>=3.1.5, while pygpcca 1.0.4 over-pins jinja2==3.0.3. pygpcca 1.0.4 #
+#   is the latest release on PyPI (no upstream fix available) and still       #
+#   functions correctly with jinja2 3.1.x in practice. The warning is pip     #
+#   metadata noise — the install succeeds and both OAuth and trajectory       #
+#   analysis continue to work. Safe to ignore.                                #
+# --------------------------------------------------------------------------- #
+oauth = [
+    "ccproxy-api>=0.2.7,<0.3",
+    "httpx>=0.27",
+]
+
 genomics = []
 
 proteomics = []
@@ -256,7 +279,7 @@ bulkrna = [
 # Tier 4: full — all optional analysis methods across all domains             #
 # --------------------------------------------------------------------------- #
 full = [
-    "omicsclaw[spatial,spatial-domains,spatial-annotate,spatial-deconv,spatial-trajectory,spatial-genes,spatial-statistics,spatial-condition,spatial-velocity,spatial-cnv,spatial-enrichment,spatial-communication,spatial-integration,spatial-registration,spatial-r-bridge,singlecell,singlecell-clustering,singlecell-pseudotime,singlecell-batch,singlecell-doublet,singlecell-annotation,singlecell-communication,singlecell-enrichment,singlecell-r-bridge,genomics,proteomics,metabolomics,bulkrna]"
+    "omicsclaw[spatial,spatial-domains,spatial-annotate,spatial-deconv,spatial-trajectory,spatial-genes,spatial-statistics,spatial-condition,spatial-velocity,spatial-cnv,spatial-enrichment,spatial-communication,spatial-integration,spatial-registration,spatial-r-bridge,singlecell,singlecell-clustering,singlecell-pseudotime,singlecell-batch,singlecell-doublet,singlecell-annotation,singlecell-communication,singlecell-enrichment,singlecell-r-bridge,genomics,proteomics,metabolomics,bulkrna,oauth]"
 ]
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -88,6 +88,26 @@ def test_app_server_main_uses_default_contract(monkeypatch):
     assert captured["reload"] is False
 
 
+def test_app_server_main_exports_effective_port_to_env(monkeypatch):
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+
+    captured: dict[str, object] = {}
+    fake_uvicorn = SimpleNamespace(
+        run=lambda app_ref, **kwargs: captured.update({"app_ref": app_ref, **kwargs})
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.delenv("OMICSCLAW_APP_PORT", raising=False)
+    monkeypatch.delenv("OMICSCLAW_APP_HOST", raising=False)
+
+    server.main(["--host", "127.0.0.1", "--port", "9000"])
+
+    assert captured["port"] == 9000
+    assert os.environ["OMICSCLAW_APP_PORT"] == "9000"
+    assert os.environ["OMICSCLAW_APP_HOST"] == "127.0.0.1"
+
+
 def test_app_server_main_reports_missing_uvicorn(monkeypatch, capsys):
     pytest.importorskip("fastapi")
 
@@ -720,6 +740,8 @@ def test_resolve_backend_init_config_prefers_documented_llm_namespace(monkeypatc
         "api_key": "llm-key",
         "base_url": "https://api.siliconflow.cn/v1",
         "model": "deepseek-ai/DeepSeek-V3",
+        "auth_mode": "api_key",
+        "ccproxy_port": "11435",
     }
 
 

--- a/tests/test_app_server_oauth.py
+++ b/tests/test_app_server_oauth.py
@@ -1,0 +1,532 @@
+"""Tests for the OAuth endpoints added to omicsclaw.app.server.
+
+These call the FastAPI route handlers directly (as coroutines) to avoid
+firing the full server lifespan on each test. ccproxy is mocked so no
+real binary is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# /auth/{provider}/status
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_status_rejects_unknown_provider():
+    from omicsclaw.app import server
+
+    with pytest.raises(HTTPException) as exc:
+        _run(server.oauth_status("deepseek"))
+    assert exc.value.status_code == 400
+    assert "Unknown OAuth provider alias" in exc.value.detail
+
+
+def test_oauth_status_fails_when_ccproxy_missing(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: False)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(server.oauth_status("claude"))
+    assert exc.value.status_code == 400
+    assert "not installed" in exc.value.detail
+
+
+def test_oauth_status_returns_authenticated(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(
+        ccm, "check_ccproxy_auth", lambda p: (True, "user@example.com (plus)")
+    )
+
+    result = _run(server.oauth_status("claude"))
+    assert result == {
+        "provider": "anthropic",
+        "authenticated": True,
+        "message": "user@example.com (plus)",
+    }
+
+
+def test_oauth_status_accepts_both_aliases(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", lambda p: (False, "no"))
+
+    assert _run(server.oauth_status("anthropic"))["provider"] == "anthropic"
+    assert _run(server.oauth_status("claude"))["provider"] == "anthropic"
+    assert _run(server.oauth_status("openai"))["provider"] == "openai"
+    assert _run(server.oauth_status("codex"))["provider"] == "openai"
+
+
+# ---------------------------------------------------------------------------
+# /auth/{provider}/login
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_login_returns_client_side_command(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+
+    result = _run(server.oauth_login("claude"))
+    assert result["provider"] == "anthropic"
+    assert result["command"] == "ccproxy auth login claude_api"
+    # Hint must direct the user to the backend host — Docker / remote
+    # deployments break if the login runs on a different machine.
+    hint_lower = result["hint"].lower()
+    assert "backend" in hint_lower
+    assert "host" in hint_lower
+    assert "local terminal" not in hint_lower
+
+    result_openai = _run(server.oauth_login("openai"))
+    assert result_openai["command"] == "ccproxy auth login codex"
+
+
+def test_oauth_login_adds_env_unset_when_empty_proxies_detected(monkeypatch):
+    """Regression for the httpx 'Unknown scheme for proxy URL URL("")'
+    failure mode: when the backend process inherits empty-string proxy
+    env vars (e.g. user launched uvicorn with ``HTTPS_PROXY=``), the
+    command returned to the frontend must prepend ``env -u ...`` so
+    copy-paste works from any shell that has the same poisoned env.
+    """
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    # Simulate a server process whose env has HTTPS_PROXY="" (the toxic case)
+    monkeypatch.setenv("HTTPS_PROXY", "")
+    monkeypatch.setenv("http_proxy", "")
+    # A genuine proxy, by contrast, should NOT trigger the wrap
+    monkeypatch.setenv("ALL_PROXY", "http://proxy.example:3128")
+
+    result = _run(server.oauth_login("claude"))
+
+    cmd = result["command"]
+    assert cmd.startswith("env -u ")
+    assert "-u HTTPS_PROXY" in cmd
+    assert "-u http_proxy" in cmd
+    # ALL_PROXY was a real value, not empty → must NOT be unset
+    assert "-u ALL_PROXY" not in cmd
+    assert "-u all_proxy" not in cmd
+    assert cmd.endswith(" ccproxy auth login claude_api")
+    assert "warning" in result
+    assert "HTTPS_PROXY" in result["warning"]
+
+
+def test_oauth_login_leaves_command_clean_when_env_is_ok(monkeypatch):
+    """Default case: no proxy env hygiene issues → command has no prefix
+    and no warning key is emitted."""
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    # Ensure clean env by removing any inherited proxy vars
+    for v in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy",
+              "ALL_PROXY", "all_proxy"):
+        monkeypatch.delenv(v, raising=False)
+
+    result = _run(server.oauth_login("codex"))
+
+    assert result["command"] == "ccproxy auth login codex"
+    assert "warning" not in result
+
+
+def test_oauth_login_rejects_unsupported_provider(monkeypatch):
+    from omicsclaw.app import server
+
+    with pytest.raises(HTTPException) as exc:
+        _run(server.oauth_login("gemini"))
+    assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /auth/{provider}/logout
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_logout_invokes_ccproxy(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "ccproxy_executable", lambda: "/opt/venv/bin/ccproxy")
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout="logged out", stderr="")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    result = _run(server.oauth_logout("openai"))
+    assert captured["cmd"] == ["/opt/venv/bin/ccproxy", "auth", "logout", "codex"]
+    assert result["ok"] is True
+    assert result["provider"] == "openai"
+
+
+def test_oauth_logout_clears_active_oauth_runtime(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+    from omicsclaw.core.provider_runtime import (
+        clear_active_provider_runtime,
+        get_active_provider_runtime,
+        set_active_provider_runtime,
+    )
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "ccproxy_executable", lambda: "/opt/venv/bin/ccproxy")
+
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="logged out", stderr=""),
+    )
+
+    fake_core = MagicMock()
+    fake_core.llm = object()
+    monkeypatch.setattr(server, "_get_core", lambda: fake_core)
+
+    clear_active_provider_runtime()
+    set_active_provider_runtime(
+        provider="anthropic",
+        auth_mode="oauth",
+        ccproxy_port=11435,
+    )
+
+    result = _run(server.oauth_logout("claude"))
+
+    assert result["ok"] is True
+    assert get_active_provider_runtime() is None
+    assert fake_core.llm is None
+
+
+def test_oauth_logout_persists_api_key_fallback_to_env(monkeypatch, tmp_path):
+    """Logout of the active OAuth provider must rewrite .env to api_key.
+
+    Regression: previously only in-memory state was cleared, so a restart
+    would re-read LLM_AUTH_MODE=oauth and try to reconstruct the OAuth
+    session against a now-unauthenticated ccproxy.
+    """
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+    from omicsclaw.core.provider_runtime import (
+        clear_active_provider_runtime,
+        set_active_provider_runtime,
+    )
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=anthropic\n"
+        "LLM_AUTH_MODE=oauth\n"
+        "CCPROXY_PORT=9000\n"
+        "OMICSCLAW_MODEL=claude-sonnet-4-6\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OMICSCLAW_DIR", str(tmp_path))
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "ccproxy_executable", lambda: "/opt/venv/bin/ccproxy")
+
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="logged out", stderr=""),
+    )
+
+    fake_core = MagicMock()
+    fake_core.llm = object()
+    fake_core.LLM_PROVIDER_NAME = "anthropic"
+    fake_core.OMICSCLAW_MODEL = "claude-sonnet-4-6"
+    monkeypatch.setattr(server, "_get_core", lambda: fake_core)
+
+    clear_active_provider_runtime()
+    set_active_provider_runtime(
+        provider="anthropic",
+        auth_mode="oauth",
+        ccproxy_port=9000,
+    )
+
+    result = _run(server.oauth_logout("claude"))
+    assert result["ok"] is True
+
+    # In-memory core display state is reset so the frontend won't keep
+    # surfacing the now-credentialless provider as active.
+    assert fake_core.LLM_PROVIDER_NAME == ""
+    assert fake_core.OMICSCLAW_MODEL == ""
+    assert fake_core.llm is None
+
+    body = env_path.read_text(encoding="utf-8")
+    assert "LLM_AUTH_MODE=api_key" in body
+    assert "CCPROXY_PORT=" not in body
+
+
+def test_oauth_logout_non_active_provider_does_not_touch_env(monkeypatch, tmp_path):
+    """Logout of a provider that isn't the active OAuth provider is a no-op
+    on .env — we must not wipe the other provider's OAuth config."""
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+    from omicsclaw.core.provider_runtime import (
+        clear_active_provider_runtime,
+        set_active_provider_runtime,
+    )
+
+    env_path = tmp_path / ".env"
+    original = (
+        "LLM_PROVIDER=anthropic\n"
+        "LLM_AUTH_MODE=oauth\n"
+        "CCPROXY_PORT=9000\n"
+    )
+    env_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OMICSCLAW_DIR", str(tmp_path))
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "ccproxy_executable", lambda: "/opt/venv/bin/ccproxy")
+
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="logged out", stderr=""),
+    )
+
+    fake_core = MagicMock()
+    fake_core.llm = object()
+    fake_core.LLM_PROVIDER_NAME = "anthropic"
+    monkeypatch.setattr(server, "_get_core", lambda: fake_core)
+
+    clear_active_provider_runtime()
+    set_active_provider_runtime(
+        provider="anthropic",
+        auth_mode="oauth",
+        ccproxy_port=9000,
+    )
+
+    # Log out the *other* provider (openai) while anthropic is active.
+    _run(server.oauth_logout("openai"))
+
+    body = env_path.read_text(encoding="utf-8")
+    assert "LLM_AUTH_MODE=oauth" in body
+    assert "CCPROXY_PORT=9000" in body
+
+
+# ---------------------------------------------------------------------------
+# chat-path provider switch persistence (regression for OAuth state leak)
+# ---------------------------------------------------------------------------
+
+
+def test_chat_provider_switch_clears_stale_oauth_env(monkeypatch, tmp_path):
+    """Switching provider through the chat request must reset LLM_AUTH_MODE
+    and drop CCPROXY_PORT; otherwise a restart re-enters the bad
+    (new_provider + oauth) combination."""
+    from omicsclaw.app import server
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=anthropic\n"
+        "LLM_AUTH_MODE=oauth\n"
+        "CCPROXY_PORT=9000\n"
+        "OMICSCLAW_MODEL=claude-sonnet-4-6\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OMICSCLAW_DIR", str(tmp_path))
+
+    class FakeCore:
+        LLM_PROVIDER_NAME = "anthropic"
+        OMICSCLAW_MODEL = "claude-sonnet-4-6"
+
+        def init(self, **kwargs):
+            # Chat path never passes auth_mode, so we default to api_key,
+            # mirroring the production bot.core.init() contract.
+            assert "auth_mode" not in kwargs
+            self.LLM_PROVIDER_NAME = kwargs["provider"]
+            self.OMICSCLAW_MODEL = kwargs.get("model") or "deepseek-chat"
+
+    fake_core = FakeCore()
+    server._apply_chat_provider_switch(fake_core, "deepseek", "")
+
+    body = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=deepseek" in body
+    assert "LLM_AUTH_MODE=api_key" in body
+    assert "CCPROXY_PORT=" not in body
+    assert "OMICSCLAW_MODEL=deepseek-chat" in body
+
+
+def test_chat_provider_switch_failure_leaves_env_untouched(monkeypatch, tmp_path):
+    """If core.init raises, .env must not be partially rewritten — the
+    previous provider config stays intact so the user can retry."""
+    from omicsclaw.app import server
+
+    env_path = tmp_path / ".env"
+    original = (
+        "LLM_PROVIDER=anthropic\n"
+        "LLM_AUTH_MODE=oauth\n"
+        "CCPROXY_PORT=9000\n"
+    )
+    env_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OMICSCLAW_DIR", str(tmp_path))
+
+    class FailingCore:
+        LLM_PROVIDER_NAME = "anthropic"
+        OMICSCLAW_MODEL = "claude-sonnet-4-6"
+
+        def init(self, **kwargs):
+            raise RuntimeError("provider unreachable")
+
+    server._apply_chat_provider_switch(FailingCore(), "deepseek", "")
+
+    assert env_path.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# /providers oauth fields
+# ---------------------------------------------------------------------------
+
+
+def test_cached_oauth_statuses_handles_missing_ccproxy(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: False)
+    # Reset cache
+    server._OAUTH_STATUS_CACHE["ts"] = 0.0
+
+    result = server._cached_oauth_statuses()
+    assert result == {}
+
+
+def test_cached_oauth_statuses_queries_both_providers(monkeypatch):
+    from omicsclaw.app import server
+    from omicsclaw.core import ccproxy_manager as ccm
+
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    calls: list[str] = []
+
+    def _probe(p):
+        calls.append(p)
+        return (p == "claude_api", "ok" if p == "claude_api" else "no")
+
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", _probe)
+    server._OAUTH_STATUS_CACHE["ts"] = 0.0
+
+    result = server._cached_oauth_statuses()
+    assert set(calls) == {"claude_api", "codex"}
+    assert result["anthropic"]["authenticated"] is True
+    assert result["openai"]["authenticated"] is False
+
+
+# ---------------------------------------------------------------------------
+# ProviderSwitchRequest oauth validation
+# ---------------------------------------------------------------------------
+
+
+def test_provider_switch_request_defaults_to_api_key():
+    from omicsclaw.app.server import ProviderSwitchRequest
+
+    req = ProviderSwitchRequest(provider="deepseek")
+    assert req.auth_mode == "api_key"
+    assert req.ccproxy_port == 11435  # must differ from app-server default 8765
+
+
+def test_provider_switch_request_accepts_oauth():
+    from omicsclaw.app.server import ProviderSwitchRequest
+
+    req = ProviderSwitchRequest(
+        provider="anthropic", auth_mode="oauth", ccproxy_port=9000
+    )
+    assert req.auth_mode == "oauth"
+    assert req.ccproxy_port == 9000
+
+
+def test_switch_provider_rejects_conflict_with_nondefault_app_port(monkeypatch):
+    from omicsclaw.app import server
+
+    monkeypatch.setenv("OMICSCLAW_APP_PORT", "9000")
+    monkeypatch.setattr(server, "_get_core", lambda: MagicMock())
+
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            server.switch_provider(
+                server.ProviderSwitchRequest(
+                    provider="anthropic",
+                    auth_mode="oauth",
+                    ccproxy_port=9000,
+                )
+            )
+        )
+    assert exc.value.status_code == 400
+    assert "conflicts with the OmicsClaw app-server port (9000)" in exc.value.detail
+
+
+def test_switch_provider_clears_stale_base_url_and_persists_resolved_model(monkeypatch, tmp_path):
+    from omicsclaw.app import server
+
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "LLM_PROVIDER=custom\n"
+        "LLM_BASE_URL=https://gateway.example.test/v1\n"
+        "OMICSCLAW_MODEL=old-model\n"
+        "CCPROXY_PORT=9000\n",
+        encoding="utf-8",
+    )
+
+    class FakeCore:
+        LLM_PROVIDER_NAME = "custom"
+        OMICSCLAW_MODEL = "old-model"
+
+        def init(self, **kwargs):
+            self.LLM_PROVIDER_NAME = kwargs.get("provider", "custom")
+            self.OMICSCLAW_MODEL = kwargs.get("model") or "claude-sonnet-4-6"
+
+    monkeypatch.setenv("OMICSCLAW_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_get_core", lambda: FakeCore())
+
+    result = _run(
+        server.switch_provider(
+            server.ProviderSwitchRequest(
+                provider="anthropic",
+                api_key="sk-ant-new",
+                auth_mode="api_key",
+            )
+        )
+    )
+
+    assert result == {
+        "ok": True,
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "auth_mode": "api_key",
+    }
+
+    body = env_path.read_text(encoding="utf-8")
+    assert "LLM_PROVIDER=anthropic" in body
+    assert "OMICSCLAW_MODEL=claude-sonnet-4-6" in body
+    assert "LLM_BASE_URL=" not in body
+    assert "CCPROXY_PORT=" not in body

--- a/tests/test_bot_run.py
+++ b/tests/test_bot_run.py
@@ -5,7 +5,7 @@ from omicsclaw.core.provider_registry import PROVIDER_PRESETS
 
 
 def test_resolve_bootstrap_llm_config_uses_provider_specific_key():
-    provider, base_url, model, api_key = run._resolve_bootstrap_llm_config(
+    provider, base_url, model, api_key, _auth_mode, _port = run._resolve_bootstrap_llm_config(
         {
             "DEEPSEEK_API_KEY": "deepseek-key",
         }
@@ -18,7 +18,7 @@ def test_resolve_bootstrap_llm_config_uses_provider_specific_key():
 
 
 def test_resolve_bootstrap_llm_config_respects_explicit_custom_endpoint():
-    provider, base_url, model, api_key = run._resolve_bootstrap_llm_config(
+    provider, base_url, model, api_key, _auth_mode, _port = run._resolve_bootstrap_llm_config(
         {
             "LLM_PROVIDER": "custom",
             "LLM_BASE_URL": "https://llm.internal.example/v1",
@@ -31,3 +31,27 @@ def test_resolve_bootstrap_llm_config_respects_explicit_custom_endpoint():
     assert base_url == "https://llm.internal.example/v1"
     assert model == "omics-model"
     assert api_key == "generic-key"
+
+
+def test_resolve_bootstrap_llm_config_reads_oauth_env():
+    provider, _base_url, _model, _api_key, auth_mode, ccproxy_port = (
+        run._resolve_bootstrap_llm_config(
+            {
+                "LLM_PROVIDER": "anthropic",
+                "LLM_AUTH_MODE": "oauth",
+                "CCPROXY_PORT": "9100",
+            }
+        )
+    )
+    assert provider == "anthropic"
+    assert auth_mode == "oauth"
+    assert ccproxy_port == 9100
+
+
+def test_resolve_bootstrap_llm_config_defaults_to_api_key():
+    _p, _b, _m, _k, auth_mode, ccproxy_port = run._resolve_bootstrap_llm_config(
+        {"DEEPSEEK_API_KEY": "x"}
+    )
+    assert auth_mode == "api_key"
+    # Default must differ from the app-server's 8765 (Bug 1 regression).
+    assert ccproxy_port == 11435

--- a/tests/test_ccproxy_manager.py
+++ b/tests/test_ccproxy_manager.py
@@ -1,0 +1,329 @@
+"""Unit tests for omicsclaw.core.ccproxy_manager.
+
+All subprocess / httpx / binary lookups are mocked so tests run offline
+and do not require the optional ``ccproxy-api`` package.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omicsclaw.core import ccproxy_manager as ccm
+
+
+@pytest.fixture(autouse=True)
+def _restore_oauth_env_vars():
+    """Isolate tests that mutate ANTHROPIC_/OPENAI_ env vars via os.environ.
+
+    ``setup_ccproxy_env`` writes ``os.environ`` directly (bypassing
+    ``monkeypatch``), so without this fixture the values leak into
+    subsequent tests in the suite.
+    """
+    keys = (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_KEY",
+    )
+    snapshot = {k: os.environ.get(k) for k in keys}
+    try:
+        yield
+    finally:
+        for k, v in snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Binary detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_ccproxy_available_true(monkeypatch):
+    monkeypatch.setattr(ccm.shutil, "which", lambda name: "/usr/local/bin/ccproxy")
+    assert ccm.is_ccproxy_available() is True
+
+
+def test_is_ccproxy_available_false(monkeypatch, tmp_path):
+    monkeypatch.setattr(ccm.shutil, "which", lambda name: None)
+    # Force a python executable that has no sibling ccproxy binary.
+    import sys
+
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "bin" / "python"))
+    assert ccm.is_ccproxy_available() is False
+
+
+def test_oauth_install_hint_returns_str():
+    hint = ccm.oauth_install_hint()
+    assert isinstance(hint, str) and "oauth" in hint
+
+
+def test_ccproxy_diagnostic_hint_reports_python_path(monkeypatch):
+    """When ccproxy is missing, the hint must tell the user WHICH Python
+    was checked and where — so they can tell if the server is running in
+    the wrong venv (the #1 real-world cause of 'ccproxy is not installed'
+    despite having pip-installed it somewhere)."""
+    monkeypatch.setattr(ccm.shutil, "which", lambda _n: None)
+    import sys
+    monkeypatch.setattr(sys, "executable", "/tmp/fake-python/bin/python")
+
+    hint = ccm.ccproxy_diagnostic_hint()
+    assert "/tmp/fake-python/bin/python" in hint  # sys.executable surfaced
+    assert "PATH" in hint or "shutil.which" in hint
+    assert "next to interpreter" in hint
+    assert "venv" in hint.lower()  # activation hint present
+    # Exact, copy-pasteable pip command bound to THIS interpreter.
+    # Prevents the "I ran pip install, but in the wrong venv" loop.
+    assert "/tmp/fake-python/bin/python -m pip install ccproxy-api" in hint
+
+
+def test_ccproxy_diagnostic_hint_reports_found_path_when_available(monkeypatch):
+    """When ccproxy IS found on PATH, the hint should reflect that and not
+    emit the activation fallback suggestion."""
+    monkeypatch.setattr(ccm.shutil, "which", lambda _n: "/opt/venv/bin/ccproxy")
+
+    hint = ccm.ccproxy_diagnostic_hint()
+    assert "/opt/venv/bin/ccproxy" in hint
+    # Activation hint only fires when nothing is found
+    assert "activate" not in hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auth status parsing
+# ---------------------------------------------------------------------------
+
+
+def test_check_ccproxy_auth_authenticated(monkeypatch):
+    stdout = (
+        "Email               user@example.com\n"
+        "Subscription        plus\n"
+        "Subscription Status active\n"
+    )
+    completed = MagicMock(returncode=0, stdout=stdout, stderr="")
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm.subprocess, "run", lambda *a, **kw: completed)
+
+    ok, msg = ccm.check_ccproxy_auth("claude_api")
+    assert ok is True
+    assert "user@example.com" in msg
+    assert "plus" in msg
+
+
+def test_check_ccproxy_auth_not_authenticated(monkeypatch):
+    completed = MagicMock(returncode=1, stdout="Not authenticated", stderr="")
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm.subprocess, "run", lambda *a, **kw: completed)
+
+    ok, msg = ccm.check_ccproxy_auth("claude_api")
+    assert ok is False
+    assert "not authenticated" in msg.lower() or "Not authenticated" in msg
+
+
+def test_check_ccproxy_auth_timeout(monkeypatch):
+    def _raise(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="ccproxy", timeout=10)
+
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm.subprocess, "run", _raise)
+
+    ok, msg = ccm.check_ccproxy_auth("codex")
+    assert ok is False
+    assert "timed out" in msg.lower()
+
+
+def test_check_ccproxy_auth_accepts_omicsclaw_alias(monkeypatch):
+    """``anthropic`` should be mapped to ``claude_api`` internally."""
+    captured: dict = {}
+
+    def _run(cmd, **kw):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=1, stdout="Not authenticated", stderr="")
+
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm.subprocess, "run", _run)
+
+    ccm.check_ccproxy_auth("anthropic")
+    assert captured["cmd"][-1] == "claude_api"
+
+    ccm.check_ccproxy_auth("openai")
+    assert captured["cmd"][-1] == "codex"
+
+
+# ---------------------------------------------------------------------------
+# Process lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_is_ccproxy_running_true(monkeypatch):
+    fake_httpx = MagicMock()
+    fake_httpx.get.return_value = MagicMock(status_code=200)
+    fake_httpx.ConnectError = ConnectionError
+    fake_httpx.TimeoutException = TimeoutError
+    monkeypatch.setitem(
+        __import__("sys").modules, "httpx", fake_httpx
+    )
+    assert ccm.is_ccproxy_running(8765) is True
+
+
+def test_is_ccproxy_running_false_on_connection_error(monkeypatch):
+    fake_httpx = MagicMock()
+    fake_httpx.ConnectError = ConnectionError
+    fake_httpx.TimeoutException = TimeoutError
+    fake_httpx.get.side_effect = ConnectionError("refused")
+    monkeypatch.setitem(
+        __import__("sys").modules, "httpx", fake_httpx
+    )
+    assert ccm.is_ccproxy_running(8765) is False
+
+
+def test_start_ccproxy_succeeds_when_healthy(monkeypatch):
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    monkeypatch.setattr(
+        ccm.subprocess, "Popen", MagicMock(return_value=fake_proc)
+    )
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm, "is_ccproxy_running", lambda port: True)
+
+    proc = ccm.start_ccproxy(8765)
+    assert proc is fake_proc
+
+
+def test_start_ccproxy_raises_on_early_exit(monkeypatch):
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = 1
+    fake_proc.returncode = 1
+    monkeypatch.setattr(
+        ccm.subprocess, "Popen", MagicMock(return_value=fake_proc)
+    )
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/usr/bin/ccproxy")
+    monkeypatch.setattr(ccm, "is_ccproxy_running", lambda port: False)
+
+    with pytest.raises(RuntimeError, match="exited immediately"):
+        ccm.start_ccproxy(8765)
+
+
+def test_stop_ccproxy_none_is_noop():
+    ccm.stop_ccproxy(None)  # must not raise
+
+
+def test_stop_ccproxy_terminates_gracefully():
+    proc = MagicMock()
+    ccm.stop_ccproxy(proc)
+    proc.terminate.assert_called_once()
+    proc.wait.assert_called()
+
+
+def test_ensure_ccproxy_reuses_running(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_running", lambda port: True)
+    assert ccm.ensure_ccproxy(8765) is None
+
+
+def test_ensure_ccproxy_starts_when_absent(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_running", lambda port: False)
+    sentinel = MagicMock(name="popen_handle")
+    monkeypatch.setattr(ccm, "start_ccproxy", lambda port: sentinel)
+    assert ccm.ensure_ccproxy(8765) is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Environment wiring
+# ---------------------------------------------------------------------------
+
+
+def test_setup_ccproxy_env_anthropic(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    ccm.setup_ccproxy_env("anthropic", 8765)
+
+    import os
+
+    assert os.environ["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8765/claude"
+    assert os.environ["ANTHROPIC_API_KEY"] == ccm.OAUTH_SENTINEL_KEY
+
+
+def test_setup_ccproxy_env_openai(monkeypatch):
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    ccm.setup_ccproxy_env("openai", 9000)
+
+    import os
+
+    assert os.environ["OPENAI_BASE_URL"] == "http://127.0.0.1:9000/codex/v1"
+    assert os.environ["OPENAI_API_KEY"] == ccm.OAUTH_SENTINEL_KEY
+
+
+def test_setup_ccproxy_env_unsupported_provider():
+    with pytest.raises(ValueError, match="Unknown OAuth provider alias"):
+        ccm.setup_ccproxy_env("deepseek", 8765)
+
+
+# ---------------------------------------------------------------------------
+# High-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_start_ccproxy_noop_when_no_oauth():
+    assert ccm.maybe_start_ccproxy() is None
+
+
+def test_maybe_start_ccproxy_raises_when_binary_missing(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: False)
+    with pytest.raises(RuntimeError, match="not found"):
+        ccm.maybe_start_ccproxy(anthropic_oauth=True)
+
+
+def test_maybe_start_ccproxy_raises_when_not_authenticated(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(
+        ccm, "check_ccproxy_auth", lambda p: (False, "Not authenticated")
+    )
+    with pytest.raises(RuntimeError, match="not authenticated"):
+        ccm.maybe_start_ccproxy(anthropic_oauth=True)
+
+
+def test_maybe_start_ccproxy_rejects_invalid_port(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    with pytest.raises(ValueError, match="Invalid ccproxy port"):
+        ccm.maybe_start_ccproxy(anthropic_oauth=True, port=99999)
+
+
+def test_maybe_start_ccproxy_happy_path(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", lambda p: (True, "ok"))
+    sentinel = MagicMock(name="proc")
+    monkeypatch.setattr(ccm, "ensure_ccproxy", lambda port: sentinel)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    proc = ccm.maybe_start_ccproxy(anthropic_oauth=True, port=8765)
+    assert proc is sentinel
+
+    import os
+
+    assert os.environ["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8765/claude"
+    assert os.environ["ANTHROPIC_API_KEY"] == "ccproxy-oauth"
+
+
+def test_maybe_start_ccproxy_both_providers(monkeypatch):
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", lambda p: (True, "ok"))
+    monkeypatch.setattr(ccm, "ensure_ccproxy", lambda port: None)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    ccm.maybe_start_ccproxy(
+        anthropic_oauth=True, openai_oauth=True, port=8765
+    )
+
+    import os
+
+    assert "/claude" in os.environ["ANTHROPIC_BASE_URL"]
+    assert "/codex/v1" in os.environ["OPENAI_BASE_URL"]

--- a/tests/test_oauth_regressions.py
+++ b/tests/test_oauth_regressions.py
@@ -1,0 +1,433 @@
+"""Regression tests for the 6 OAuth / ccproxy bugs reported after Stage 1-4:
+
+1. Critical: app-server + ccproxy both defaulted to port 8765 → conflict.
+2. High: ``omicsclaw auth login claude`` raised KeyError('claude').
+3. High: OAuth-injected env vars polluted subsequent api_key mode.
+4. High: resolve_provider_runtime reused active runtime across auth_mode switches.
+5. Medium: CLI/server logout bypassed ``_ccproxy_exe()`` venv-aware lookup.
+6. Medium: bootstrap didn't fail-fast when ``auth_mode=oauth`` was paired
+   with an OAuth-incapable provider.
+
+All tests mock subprocess / httpx / shutil.which so they run offline.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omicsclaw.core import ccproxy_manager as ccm
+from omicsclaw.core import provider_runtime as pr
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env_and_runtime():
+    """Snapshot-and-restore the env vars ccproxy writes + clear active runtime."""
+    keys = (
+        "ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY",
+        "OPENAI_BASE_URL", "OPENAI_API_KEY",
+    )
+    snapshot = {k: os.environ.get(k) for k in keys}
+    pr.clear_active_provider_runtime()
+    try:
+        yield
+    finally:
+        pr.clear_active_provider_runtime()
+        for k, v in snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: default ports must not collide
+# ---------------------------------------------------------------------------
+
+
+def test_bug1_ccproxy_default_port_differs_from_app_server():
+    """Regression for Bug 1 (Critical): ccproxy default port was 8765 =
+    app-server default, so switching to OAuth would deadlock on bind."""
+    from omicsclaw.app.server import DEFAULT_APP_API_PORT
+
+    assert ccm.DEFAULT_CCPROXY_PORT != DEFAULT_APP_API_PORT
+    assert pr.DEFAULT_CCPROXY_PORT != DEFAULT_APP_API_PORT
+    assert ccm.DEFAULT_CCPROXY_PORT == pr.DEFAULT_CCPROXY_PORT
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: CLI alias 'claude' must map to 'anthropic' (and 'codex' → 'openai')
+# ---------------------------------------------------------------------------
+
+
+def test_bug2_normalize_cli_provider_claude_alias():
+    assert ccm.normalize_cli_provider("claude") == "anthropic"
+    assert ccm.normalize_cli_provider("CLAUDE") == "anthropic"
+    assert ccm.normalize_cli_provider("anthropic") == "anthropic"
+    assert ccm.normalize_cli_provider("codex") == "openai"
+    assert ccm.normalize_cli_provider("openai") == "openai"
+
+
+def test_bug2_normalize_cli_provider_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown OAuth provider alias"):
+        ccm.normalize_cli_provider("gemini")
+
+
+def test_bug2_lookup_after_normalize_does_not_keyerror():
+    """The original bug path: CLI alias → CCPROXY_PROVIDER_MAP lookup."""
+    omics_name = ccm.normalize_cli_provider("claude")
+    assert ccm.CCPROXY_PROVIDER_MAP[omics_name] == "claude_api"  # no KeyError
+
+
+def test_bug2_maybe_start_ccproxy_error_message_uses_cli_alias(monkeypatch):
+    """Error message should tell users to run `auth login claude`, not
+    `auth login anthropic` (which argparse used to reject)."""
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", lambda p: (False, "no creds"))
+
+    with pytest.raises(RuntimeError, match=r"omicsclaw auth login claude\b"):
+        ccm.maybe_start_ccproxy(anthropic_oauth=True, port=11435)
+
+    with pytest.raises(RuntimeError, match=r"omicsclaw auth login openai\b"):
+        ccm.maybe_start_ccproxy(openai_oauth=True, port=11435)
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: OAuth must not pollute subsequent api_key mode
+# ---------------------------------------------------------------------------
+
+
+def test_bug3_clear_ccproxy_env_removes_oauth_injection():
+    """After setup_ccproxy_env, clear_ccproxy_env must restore env to clean."""
+    ccm.setup_ccproxy_env("anthropic", 11435)
+    assert os.environ["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:11435/claude"
+    assert os.environ["ANTHROPIC_API_KEY"] == "ccproxy-oauth"
+
+    ccm.clear_ccproxy_env("anthropic")
+    assert "ANTHROPIC_BASE_URL" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_bug3_clear_ccproxy_env_preserves_real_credentials():
+    """clear_ccproxy_env must NOT touch a real user-supplied ANTHROPIC_API_KEY."""
+    os.environ["ANTHROPIC_BASE_URL"] = "https://api.anthropic.com/v1/"
+    os.environ["ANTHROPIC_API_KEY"] = "sk-ant-real-key"
+
+    ccm.clear_ccproxy_env("anthropic")
+
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-real-key"
+    assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com/v1/"
+
+
+def test_bug3_clear_ccproxy_env_no_provider_clears_both():
+    ccm.setup_ccproxy_env("anthropic", 11435)
+    ccm.setup_ccproxy_env("openai", 11435)
+
+    ccm.clear_ccproxy_env()  # no provider = clear all
+
+    assert "ANTHROPIC_BASE_URL" not in os.environ
+    assert "OPENAI_BASE_URL" not in os.environ
+
+
+def test_bug3_api_key_mode_after_oauth_sees_clean_env(monkeypatch):
+    """Full reproducer: OAuth session → api_key resolve must hit cloud URL."""
+    from omicsclaw.core.provider_registry import resolve_provider
+
+    # Simulate a prior OAuth session leaving env polluted.
+    ccm.setup_ccproxy_env("anthropic", 9999)
+    assert "127.0.0.1:9999" in os.environ["ANTHROPIC_BASE_URL"]
+
+    # Before clear: resolve_provider would still return the ccproxy URL.
+    polluted_url, _, _ = resolve_provider(provider="anthropic", api_key="sk-real")
+    assert "127.0.0.1:9999" in str(polluted_url)  # documents the bug
+
+    # After clear: clean cloud URL.
+    ccm.clear_ccproxy_env("anthropic")
+    clean_url, _, real_key = resolve_provider(provider="anthropic", api_key="sk-real")
+    assert str(clean_url).startswith("https://api.anthropic.com")
+    assert real_key == "sk-real"
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: resolve_provider_runtime must respect explicit auth_mode switches
+# ---------------------------------------------------------------------------
+
+
+def test_bug4_oauth_active_runtime_honors_explicit_api_key_switch():
+    """Active runtime is OAuth; explicit api_key request must NOT reuse it."""
+    # Seed an OAuth active runtime
+    pr.set_active_provider_runtime(
+        provider="anthropic", auth_mode="oauth", ccproxy_port=11435
+    )
+    runtime_before = pr.get_active_provider_runtime()
+    assert runtime_before is not None and runtime_before.auth_mode == "oauth"
+
+    # Explicitly switch to api_key — must not return ccproxy URL / sentinel
+    resolved = pr.resolve_provider_runtime(
+        provider="anthropic",
+        auth_mode="api_key",
+        api_key="sk-real",
+        env={"ANTHROPIC_API_KEY": "sk-real"},
+    )
+    assert resolved.auth_mode == "api_key"
+    assert "127.0.0.1" not in resolved.base_url
+    assert resolved.api_key == "sk-real"
+    assert resolved.source != "active-runtime"  # must fall through full resolution
+
+
+def test_bug4_api_key_active_runtime_honors_explicit_oauth_switch(monkeypatch):
+    """Active runtime is api_key; explicit oauth request must override."""
+    pr.set_active_provider_runtime(
+        provider="anthropic",
+        base_url="https://api.anthropic.com/v1/",
+        api_key="sk-ant-real",
+        auth_mode="api_key",
+    )
+
+    resolved = pr.resolve_provider_runtime(
+        provider="anthropic",
+        auth_mode="oauth",
+        ccproxy_port=11435,
+        env={},
+    )
+    assert resolved.auth_mode == "oauth"
+    assert "127.0.0.1:11435" in resolved.base_url
+    assert resolved.api_key == "ccproxy-oauth"
+
+
+def test_bug4_unspecified_auth_mode_still_reuses_runtime():
+    """If caller passes no auth_mode, active runtime reuse is unchanged."""
+    pr.set_active_provider_runtime(
+        provider="anthropic", auth_mode="oauth", ccproxy_port=11435
+    )
+    resolved = pr.resolve_provider_runtime(env={})
+    assert resolved.source == "active-runtime"
+    assert resolved.auth_mode == "oauth"
+
+
+# ---------------------------------------------------------------------------
+# Bug 5: CLI / server logout must go through ccproxy_executable()
+# ---------------------------------------------------------------------------
+
+
+def test_bug5_ccproxy_executable_public_api_exists():
+    """ccproxy_executable() is the venv-aware binary lookup. Callers
+    outside the module (CLI, server) should use it instead of literal
+    'ccproxy' so they keep working when the binary is in the venv bin/
+    but not on $PATH."""
+    assert callable(ccm.ccproxy_executable)
+
+
+def test_bug5_ccproxy_executable_returns_path_when_found(monkeypatch):
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: "/opt/venv/bin/ccproxy")
+    assert ccm.ccproxy_executable() == "/opt/venv/bin/ccproxy"
+
+
+def test_bug5_ccproxy_executable_falls_back_to_literal(monkeypatch):
+    monkeypatch.setattr(ccm, "_ccproxy_exe", lambda: None)
+    assert ccm.ccproxy_executable() == "ccproxy"
+
+
+# ---------------------------------------------------------------------------
+# Bug 6: core.init must fail fast on auth_mode=oauth + non-OAuth provider
+# ---------------------------------------------------------------------------
+
+
+def test_bug6_core_init_rejects_oauth_for_unsupported_provider(monkeypatch):
+    """LLM_AUTH_MODE=oauth + LLM_PROVIDER=deepseek should raise — not
+    silently try to start ccproxy with both flags False."""
+    from bot import core as botcore
+
+    # Keep us from hitting AsyncOpenAI construction
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    # Pretend ccproxy is installed so we don't bail on that check first
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+
+    with pytest.raises(RuntimeError, match="auth_mode='oauth' is not supported"):
+        botcore.init(
+            provider="deepseek",
+            api_key="sk-x",
+            auth_mode="oauth",
+            ccproxy_port=11435,
+        )
+
+
+def test_bug6_core_init_allows_oauth_for_anthropic(monkeypatch):
+    """Happy path: anthropic + oauth should proceed to maybe_start_ccproxy."""
+    from bot import core as botcore
+
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+    monkeypatch.setattr(ccm, "check_ccproxy_auth", lambda p: (True, "ok"))
+    monkeypatch.setattr(ccm, "ensure_ccproxy", lambda port: None)
+
+    botcore.init(
+        provider="anthropic",
+        api_key="",
+        auth_mode="oauth",
+        ccproxy_port=11435,
+    )
+
+    runtime = pr.get_active_provider_runtime()
+    assert runtime is not None
+    assert runtime.auth_mode == "oauth"
+    assert runtime.base_url == "http://127.0.0.1:11435/claude"
+
+
+# ---------------------------------------------------------------------------
+# Bug 7 (post-Stage-4): bootstrap resilience — stale LLM_AUTH_MODE=oauth in
+# .env combined with a missing ccproxy must not block app-server startup.
+# ---------------------------------------------------------------------------
+
+
+def test_bug7_core_init_bootstrap_degrades_when_ccproxy_missing(
+    monkeypatch, caplog
+):
+    """strict_oauth=False + ccproxy missing → warn and fall back to api_key.
+
+    Regression for user-reported symptom: uvicorn lifespan crashed with
+    ``RuntimeError: ccproxy is required for OAuth mode but was not found``
+    whenever ``.env`` had ``LLM_AUTH_MODE=oauth`` but ccproxy wasn't
+    installed. The server should start and log a warning instead.
+    """
+    from bot import core as botcore
+
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: False)
+
+    with caplog.at_level("WARNING", logger="omicsclaw.bot"):
+        botcore.init(
+            provider="anthropic",
+            api_key="sk-real",
+            auth_mode="oauth",
+            ccproxy_port=11435,
+            strict_oauth=False,
+        )
+
+    runtime = pr.get_active_provider_runtime()
+    assert runtime is not None
+    assert runtime.auth_mode == "api_key"  # downgraded
+    assert "127.0.0.1" not in runtime.base_url  # not routed through ccproxy
+    # Warning should mention the reason
+    assert any(
+        "Falling back to auth_mode='api_key'" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_bug7_core_init_strict_raises_when_ccproxy_missing(monkeypatch):
+    """Default strict_oauth=True preserves fail-fast for explicit callers."""
+    from bot import core as botcore
+
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="ccproxy is required for OAuth mode"):
+        botcore.init(
+            provider="anthropic",
+            auth_mode="oauth",
+            ccproxy_port=11435,
+        )
+
+
+def test_oauth_providers_table_is_self_consistent():
+    """The single-source-of-truth ``OAUTH_PROVIDERS`` table must satisfy
+    every invariant the rest of the system relies on.
+
+    This is the refactor's contract test: if any of these assertions ever
+    break, it means someone added a row without filling all required
+    fields, or the backwards-compat views drifted from the table.
+    """
+    from omicsclaw.core.ccproxy_manager import (
+        CCPROXY_PROVIDER_MAP,
+        CLI_PROVIDER_ALIASES,
+        OAUTH_PROVIDERS,
+        _OAUTH_ALIAS_MAP,
+        get_oauth_provider,
+        normalize_oauth_provider,
+        oauth_cli_aliases,
+    )
+
+    for canonical, p in OAUTH_PROVIDERS.items():
+        # (1) dict key equals the row's canonical name
+        assert canonical == p.omics_name
+
+        # (2) every field is a non-empty string
+        for field in (
+            "omics_name", "cli_alias", "ccproxy_target",
+            "base_url_path", "env_base_url", "env_api_key",
+        ):
+            assert getattr(p, field), f"empty {field} on {canonical}"
+
+        # (3) base URL path always starts with '/'
+        assert p.base_url_path.startswith("/")
+
+        # (4) all three aliases (omics/cli/ccproxy) normalize back to canonical
+        for alias in (p.omics_name, p.cli_alias, p.ccproxy_target):
+            assert normalize_oauth_provider(alias) == canonical
+            assert get_oauth_provider(alias) is p
+
+    # (5) backwards-compat views are derived, not redeclared
+    assert CCPROXY_PROVIDER_MAP == {
+        p.omics_name: p.ccproxy_target for p in OAUTH_PROVIDERS.values()
+    }
+    assert CLI_PROVIDER_ALIASES == _OAUTH_ALIAS_MAP
+
+    # (6) oauth_cli_aliases covers every alias of every row
+    expected_aliases = {
+        alias
+        for p in OAUTH_PROVIDERS.values()
+        for alias in (p.omics_name, p.cli_alias, p.ccproxy_target)
+    }
+    assert set(oauth_cli_aliases()) == expected_aliases
+
+
+def test_bug7_bootstrap_degrades_for_unsupported_provider(monkeypatch, caplog):
+    """stale LLM_AUTH_MODE=oauth + LLM_PROVIDER=deepseek → warn, not raise."""
+    from bot import core as botcore
+
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    # Even if ccproxy IS installed, deepseek isn't OAuth-capable.
+    monkeypatch.setattr(ccm, "is_ccproxy_available", lambda: True)
+
+    with caplog.at_level("WARNING", logger="omicsclaw.bot"):
+        botcore.init(
+            provider="deepseek",
+            api_key="sk-ds",
+            auth_mode="oauth",
+            ccproxy_port=11435,
+            strict_oauth=False,
+        )
+
+    runtime = pr.get_active_provider_runtime()
+    assert runtime is not None
+    assert runtime.auth_mode == "api_key"
+
+
+def test_bug8_core_init_normalizes_stale_cross_provider_model(monkeypatch, caplog):
+    """provider remains authoritative; stale foreign default model is repaired."""
+    from bot import core as botcore
+    from omicsclaw.core.provider_registry import PROVIDER_PRESETS
+
+    monkeypatch.setattr(botcore, "AsyncOpenAI", MagicMock())
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    with caplog.at_level("WARNING", logger="omicsclaw.bot"):
+        botcore.init(
+            provider="anthropic",
+            model="deepseek-chat",
+            auth_mode="api_key",
+        )
+
+    runtime = pr.get_active_provider_runtime()
+    assert runtime is not None
+    assert runtime.provider == "anthropic"
+    assert runtime.model == PROVIDER_PRESETS["anthropic"][1]
+    assert botcore.LLM_PROVIDER_NAME == "anthropic"
+    assert botcore.OMICSCLAW_MODEL == PROVIDER_PRESETS["anthropic"][1]
+    assert any(
+        "Normalized stale model 'deepseek-chat'" in rec.message
+        for rec in caplog.records
+    )

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from omicsclaw.core.provider_registry import (
+    MODEL_NORMALIZATION_EXEMPT_PROVIDERS,
     PROVIDER_CHOICES,
     PROVIDER_DETECT_ORDER,
     PROVIDER_PRESETS,
     build_provider_registry_entries,
     detect_provider_from_env,
     get_langchain_llm,
+    normalize_model_for_provider,
     resolve_provider,
 )
 
@@ -82,6 +84,63 @@ def test_resolve_provider_custom_preserves_explicit_endpoint(monkeypatch):
     assert resolved_url == "https://custom.example.com/v1"
     assert resolved_model == "custom-model"
     assert resolved_key == "generic-key"
+
+
+def test_normalize_model_for_provider_rewrites_foreign_default_model():
+    normalized, foreign_provider = normalize_model_for_provider(
+        provider="anthropic",
+        model="deepseek-chat",
+    )
+
+    assert normalized == PROVIDER_PRESETS["anthropic"][1]
+    assert foreign_provider == "deepseek"
+
+
+def test_normalize_model_for_provider_skips_gateway_and_local_providers():
+    for provider in MODEL_NORMALIZATION_EXEMPT_PROVIDERS:
+        normalized, foreign_provider = normalize_model_for_provider(
+            provider=provider,
+            model="deepseek-chat",
+        )
+        assert normalized == "deepseek-chat"
+        assert foreign_provider == ""
+
+
+def test_normalize_model_for_provider_skips_explicit_custom_base_url():
+    normalized, foreign_provider = normalize_model_for_provider(
+        provider="anthropic",
+        model="deepseek-chat",
+        base_url="https://proxy.example.test/v1",
+    )
+
+    assert normalized == "deepseek-chat"
+    assert foreign_provider == ""
+
+
+def test_resolve_provider_normalizes_stale_foreign_default_model(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    resolved_url, resolved_model, resolved_key = resolve_provider(
+        provider="anthropic",
+        model="deepseek-chat",
+    )
+
+    assert resolved_url == PROVIDER_PRESETS["anthropic"][0]
+    assert resolved_model == PROVIDER_PRESETS["anthropic"][1]
+    assert resolved_key == "sk-ant-test"
+
+
+def test_resolve_provider_keeps_gateway_model_names(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+    resolved_url, resolved_model, resolved_key = resolve_provider(
+        provider="openrouter",
+        model="deepseek-chat",
+    )
+
+    assert resolved_url == PROVIDER_PRESETS["openrouter"][0]
+    assert resolved_model == "deepseek-chat"
+    assert resolved_key == "sk-or-test"
 
 
 def test_get_langchain_llm_uses_openai_compatible_kwargs(monkeypatch):

--- a/tests/test_provider_runtime_oauth.py
+++ b/tests/test_provider_runtime_oauth.py
@@ -1,0 +1,191 @@
+"""Tests for OAuth (ccproxy) support in provider_runtime.
+
+Focus: ensure that when ``auth_mode="oauth"`` is set for an OAuth-capable
+provider (anthropic/openai), the runtime snapshot and resolved config
+point at a local ccproxy endpoint with the sentinel API key — and that
+API-key mode behaves byte-identically to the pre-OAuth baseline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omicsclaw.core import provider_runtime as pr
+from omicsclaw.core.ccproxy_manager import (
+    OAUTH_PROVIDERS,
+    provider_supports_oauth,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime():
+    pr.clear_active_provider_runtime()
+    yield
+    pr.clear_active_provider_runtime()
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_providers_registry_has_exactly_anthropic_and_openai():
+    assert set(OAUTH_PROVIDERS.keys()) == {"anthropic", "openai"}
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("anthropic", True),
+        ("openai", True),
+        ("ANTHROPIC", True),
+        ("deepseek", False),
+        ("gemini", False),
+        ("", False),
+    ],
+)
+def test_provider_supports_oauth(name, expected):
+    assert provider_supports_oauth(name) is expected
+
+
+# ---------------------------------------------------------------------------
+# set_active_provider_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_set_active_oauth_anthropic_overrides_base_url_and_key():
+    rt = pr.set_active_provider_runtime(
+        provider="anthropic", auth_mode="oauth", ccproxy_port=11435
+    )
+    assert rt.auth_mode == "oauth"
+    assert rt.ccproxy_port == 11435
+    assert rt.base_url == "http://127.0.0.1:11435/claude"
+    assert rt.api_key == "ccproxy-oauth"
+
+
+def test_set_active_oauth_openai_overrides_base_url_and_key():
+    rt = pr.set_active_provider_runtime(
+        provider="openai", auth_mode="oauth", ccproxy_port=9000
+    )
+    assert rt.base_url == "http://127.0.0.1:9000/codex/v1"
+    assert rt.api_key == "ccproxy-oauth"
+
+
+def test_set_active_oauth_ignored_for_unsupported_provider():
+    """auth_mode=oauth on deepseek must NOT rewrite base_url."""
+    rt = pr.set_active_provider_runtime(
+        provider="deepseek",
+        base_url="https://api.deepseek.com",
+        api_key="sk-real",
+        auth_mode="oauth",
+    )
+    assert rt.base_url == "https://api.deepseek.com"
+    assert rt.api_key == "sk-real"
+    assert rt.auth_mode == "oauth"  # field is set but has no effect
+
+
+def test_set_active_api_key_mode_is_baseline():
+    """Default auth_mode="api_key" behaves exactly as before the change."""
+    rt = pr.set_active_provider_runtime(
+        provider="anthropic",
+        base_url="https://api.anthropic.com/v1/",
+        api_key="sk-ant-xxx",
+    )
+    assert rt.auth_mode == "api_key"
+    assert rt.base_url == "https://api.anthropic.com/v1/"
+    assert rt.api_key == "sk-ant-xxx"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_api_key_for_client
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_api_key_returns_sentinel_for_oauth():
+    assert (
+        pr._normalize_api_key_for_client("anthropic", "", auth_mode="oauth")
+        == "ccproxy-oauth"
+    )
+    assert (
+        pr._normalize_api_key_for_client("openai", "", auth_mode="oauth")
+        == "ccproxy-oauth"
+    )
+
+
+def test_normalize_api_key_oauth_ignored_for_non_oauth_provider():
+    # deepseek in oauth mode without real key → empty (oauth not applicable)
+    assert (
+        pr._normalize_api_key_for_client("deepseek", "", auth_mode="oauth") == ""
+    )
+
+
+def test_normalize_api_key_keeps_explicit_key_over_sentinel():
+    assert (
+        pr._normalize_api_key_for_client("anthropic", "sk-real", auth_mode="oauth")
+        == "sk-real"
+    )
+
+
+def test_normalize_api_key_api_key_mode_baseline():
+    # ollama always gets the local placeholder
+    assert pr._normalize_api_key_for_client("ollama", "") == "omicsclaw-local"
+    # regular provider with empty key stays empty
+    assert pr._normalize_api_key_for_client("deepseek", "") == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_oauth_overrides_preset_base_url(monkeypatch):
+    """Even without setting an active runtime, explicit auth_mode=oauth
+    on resolve_provider_runtime replaces the preset cloud URL."""
+    resolved = pr.resolve_provider_runtime(
+        provider="anthropic",
+        auth_mode="oauth",
+        ccproxy_port=11435,
+        env={},
+    )
+    assert resolved.provider == "anthropic"
+    assert resolved.base_url == "http://127.0.0.1:11435/claude"
+    assert resolved.api_key == "ccproxy-oauth"
+    assert resolved.auth_mode == "oauth"
+
+
+def test_resolve_oauth_reuses_active_runtime():
+    pr.set_active_provider_runtime(
+        provider="openai", auth_mode="oauth", ccproxy_port=9100
+    )
+    resolved = pr.resolve_provider_runtime(env={})
+    assert resolved.source == "active-runtime"
+    assert resolved.base_url == "http://127.0.0.1:9100/codex/v1"
+    assert resolved.api_key == "ccproxy-oauth"
+    assert resolved.auth_mode == "oauth"
+    assert resolved.ccproxy_port == 9100
+
+
+def test_resolve_api_key_mode_unchanged(monkeypatch):
+    """Regression: API key path must be byte-identical to pre-OAuth baseline."""
+    resolved = pr.resolve_provider_runtime(
+        provider="deepseek",
+        api_key="sk-ds-xxx",
+        env={},
+    )
+    assert resolved.provider == "deepseek"
+    assert resolved.base_url == "https://api.deepseek.com"
+    assert resolved.api_key == "sk-ds-xxx"
+    assert resolved.auth_mode == "api_key"
+
+
+def test_resolve_oauth_for_unsupported_provider_keeps_preset(monkeypatch):
+    """auth_mode=oauth on gemini must NOT rewrite the cloud URL."""
+    resolved = pr.resolve_provider_runtime(
+        provider="gemini",
+        auth_mode="oauth",
+        env={"GOOGLE_API_KEY": "sk-g"},
+    )
+    assert resolved.provider == "gemini"
+    assert "generativelanguage.googleapis.com" in resolved.base_url
+    # sentinel NOT used because gemini is not OAuth-capable
+    assert resolved.api_key != "ccproxy-oauth"


### PR DESCRIPTION
## Summary

- Add `ccproxy`-backed OAuth authentication so users with Claude Pro/Max or OpenAI Codex subscriptions can run OmicsClaw without a standalone API key.
- Fix three OAuth state-machine inconsistencies uncovered during review: chat-path provider switch leaking OAuth config to `.env`, logout leaving a half-dead provider in memory + `.env`, and login hint mis-directing remote/Docker users to their local terminal.
- New optional extra `pip install 'omicsclaw[oauth]'`; CLI `omicsclaw auth login|logout|status claude|openai`; desktop-app endpoints `/auth/{provider}/status|login|logout`.

## What's new

**Core OAuth wiring**
- `omicsclaw/core/ccproxy_manager.py` — detect / start / stop a local ccproxy subprocess; inject `{ANTHROPIC,OPENAI}_BASE_URL` + sentinel API key; `clear_ccproxy_env()` reverses the injection on mode switches.
- `omicsclaw/core/provider_runtime.py` — active provider snapshot + `resolve_provider_runtime()` honouring `auth_mode`; OAuth overrides `base_url` with the local ccproxy endpoint.
- `omicsclaw/core/provider_registry.py` — `OAUTH_CAPABLE_PROVIDERS`, `provider_supports_oauth()`, `oauth_base_url()`.
- `bot/core.init()` accepts `auth_mode` + `ccproxy_port` + `strict_oauth`; clears stale ccproxy env before `resolve_provider()` so OAuth never pollutes a subsequent API-key request.
- `bot/run.py` bootstrap reads `LLM_AUTH_MODE` / `CCPROXY_PORT`; skips the "no API key" error when `auth_mode=oauth`.

**CLI and desktop-app surfaces**
- `omicsclaw.py auth login|logout|status <claude|openai>`.
- FastAPI: `/auth/{provider}/status`, `/auth/{provider}/login` (returns a copy-pasteable command, optionally wrapped with `env -u …` if the backend inherited poisoned empty-string proxy env vars), `/auth/{provider}/logout` (runs `ccproxy auth logout`, clears runtime + persists `.env` fallback).

**State-machine consistency fixes**
- `/chat/stream` implicit provider switch now persists `LLM_AUTH_MODE=api_key` and removes `CCPROXY_PORT`. Extracted as `_apply_chat_provider_switch(core, provider_id, model)` for direct unit testing.
- `/auth/{provider}/logout` on the currently-active OAuth provider clears `core.LLM_PROVIDER_NAME` / `OMICSCLAW_MODEL` and rewrites `.env` to api_key mode. Non-active providers are a no-op — the other provider's OAuth config is left intact.
- Login hint rewritten: ccproxy stores credentials on the host running the command, so Docker / remote deployments must SSH or \`docker exec\` into the backend host before running it. Previous wording silently broke remote setups.

**Packaging**
- `pyproject.toml`: new `[oauth]` extra → `ccproxy-api>=0.5.0`.
- `.env.example` + `README.md`: setup walkthrough, including a benign pygpcca↔jinja2 pin-clash warning note.

## Test plan

- [x] `pytest tests/test_app_server.py tests/test_app_server_oauth.py tests/test_bot_run.py tests/test_ccproxy_manager.py tests/test_oauth_regressions.py tests/test_provider_registry.py tests/test_provider_runtime_oauth.py` — 139 passed, 0 failed.
- [x] New tests specifically for this PR:
  - `test_chat_provider_switch_clears_stale_oauth_env`
  - `test_chat_provider_switch_failure_leaves_env_untouched`
  - `test_oauth_logout_persists_api_key_fallback_to_env`
  - `test_oauth_logout_non_active_provider_does_not_touch_env`
  - `test_oauth_login_returns_client_side_command` updated to assert backend-host wording
- [ ] Manual smoke test:
  - `LLM_PROVIDER=anthropic LLM_AUTH_MODE=oauth CCPROXY_PORT=9000` → start server → POST `/chat/stream` with `provider_id=deepseek` → verify `.env` contains `LLM_AUTH_MODE=api_key` and no `CCPROXY_PORT`.
  - OAuth logout on active provider → verify `.env` falls back to api_key and frontend reflects no active provider.
  - `/auth/claude/login` on a Docker deployment → hint tells user to SSH/`docker exec` into backend host.
- [ ] Install the `[oauth]` extra in a clean venv and confirm the pygpcca/jinja2 warning is the only install-time noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authentication support for Claude and OpenAI via ccproxy
  * New `auth` CLI commands for managing authentication status, login, and logout
  * OAuth API endpoints for checking authentication status, initiating login, and logging out
  * Provider information now displays OAuth support and authentication status
  * Configurable OAuth proxy port to avoid conflicts with the app server

* **Documentation**
  * Added setup guides for OAuth configuration with Claude Pro/Max and OpenAI Codex

<!-- end of auto-generated comment: release notes by coderabbit.ai -->