### PR TITLE
feat(bot): add replot_skill for R Enhanced re-rendering in bot/oc-chat

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -2536,6 +2536,128 @@ async def execute_omicsclaw(args: dict, session_id: str = None, chat_id: int | s
 
 
 # ---------------------------------------------------------------------------
+# execute_replot_skill
+# ---------------------------------------------------------------------------
+
+
+async def execute_replot_skill(args: dict, session_id: str = None, chat_id: int | str = 0) -> str:
+    """Re-render R Enhanced plots from an existing skill output directory."""
+    skill_key = args.get("skill", "")
+    output_path_arg = args.get("output_path", "")
+    renderer = args.get("renderer", "")
+    return_media = str(args.get("return_media", "all")).strip().lower()
+
+    if not skill_key:
+        return "Error: 'skill' is required (e.g. 'sc-qc', 'sc-de')."
+    if not output_path_arg:
+        return "Error: 'output_path' is required — provide the output directory from the previous skill run."
+
+    # Resolve output directory
+    out_dir = Path(output_path_arg).resolve()
+    if not out_dir.exists():
+        # Try searching inside OUTPUT_DIR
+        candidate = OUTPUT_DIR / output_path_arg
+        if candidate.exists():
+            out_dir = candidate.resolve()
+        else:
+            return (
+                f"Output directory not found: '{output_path_arg}'\n\n"
+                f"Provide the full path returned by the previous {skill_key} run."
+            )
+
+    figure_data_dir = out_dir / "figure_data"
+    if not figure_data_dir.exists():
+        return (
+            f"figure_data/ not found in {out_dir}\n\n"
+            f"Re-run {skill_key} first to generate the figure data needed for R Enhanced plots."
+        )
+
+    # Build command
+    cmd = [get_skill_runner_python(), str(OMICSCLAW_PY), "replot", skill_key, "--output", str(out_dir)]
+    if renderer:
+        cmd.extend(["--renderer", renderer])
+
+    # Pass optional plot params
+    plot_param_map = {
+        "top_n": "--top-n",
+        "font_size": "--font-size",
+        "width": "--width",
+        "height": "--height",
+        "palette": "--palette",
+        "dpi": "--dpi",
+        "title": "--title",
+    }
+    for key, flag in plot_param_map.items():
+        val = args.get(key)
+        if val is not None:
+            cmd.extend([flag, str(val)])
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout_str = stdout_bytes.decode(errors="replace")
+        stderr_str = stderr_bytes.decode(errors="replace")
+    except Exception:
+        import traceback as _tb
+        return f"replot crashed:\n{_tb.format_exc()[-1500:]}"
+
+    if proc.returncode != 0:
+        err = stderr_str[-1500:] if stderr_str else stdout_str[-1500:] if stdout_str else "unknown error"
+        return f"replot {skill_key} failed (exit {proc.returncode}):\n{err}"
+
+    # Collect generated R Enhanced figures
+    r_enhanced_dir = out_dir / "figures" / "r_enhanced"
+    figure_names = []
+    media_items = []
+    if r_enhanced_dir.exists():
+        for f in sorted(r_enhanced_dir.rglob("*.png")):
+            media_items.append({"type": "photo", "path": str(f)})
+            figure_names.append(f.name)
+
+    if not figure_names:
+        return (
+            f"replot {skill_key} completed but no R Enhanced figures were generated.\n"
+            f"Output: {out_dir}\n\n"
+            f"The skill may not have R Enhanced renderers, or figure_data may be incomplete."
+        )
+
+    # Queue figures for delivery
+    if return_media and media_items and session_id:
+        if return_media == "all":
+            filtered = media_items
+        else:
+            keywords = [k.strip() for k in return_media.split(",") if k.strip()]
+            filtered = [
+                item for item in media_items
+                if any(kw in Path(item["path"]).stem.lower() for kw in keywords)
+            ]
+        if filtered:
+            pending_media[session_id] = pending_media.get(session_id, []) + filtered
+            sent_names = [Path(item["path"]).name for item in filtered]
+            result = (
+                f"R Enhanced re-render complete for **{skill_key}**.\n\n"
+                f"{len(sent_names)} figure(s) generated: {', '.join(sent_names)}\n"
+                f"Figures saved to: {r_enhanced_dir}"
+            )
+            result += (
+                f"\n\n---\n[MEDIA DELIVERY: {len(sent_names)} R Enhanced figure(s) queued: "
+                f"{', '.join(sent_names)}. They will be delivered automatically.]"
+            )
+            return result
+
+    # No session — return paths for inline rendering
+    hints = "\n".join(f"- `{r_enhanced_dir / n}`" for n in figure_names)
+    return (
+        f"R Enhanced re-render complete for **{skill_key}**.\n\n"
+        f"{len(figure_names)} figure(s) generated:\n{hints}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # execute_save_file
 # ---------------------------------------------------------------------------
 
@@ -3715,6 +3837,7 @@ async def execute_custom_analysis_execute(args: dict, **kwargs) -> str:
 def _available_tool_executors() -> dict[str, object]:
     executors = {
         "omicsclaw": execute_omicsclaw,
+        "replot_skill": execute_replot_skill,
         "save_file": execute_save_file,
         "write_file": execute_write_file,
         "generate_audio": execute_generate_audio,

--- a/omicsclaw/runtime/bot_tools.py
+++ b/omicsclaw/runtime/bot_tools.py
@@ -139,6 +139,56 @@ def build_bot_tool_specs(context: BotToolContext) -> list[ToolSpec]:
             policy_tags=("analysis", "workflow"),
         ),
         ToolSpec(
+            name="replot_skill",
+            description=(
+                "Re-render R Enhanced (ggplot2) plots from an existing skill output directory. "
+                "Use this ONLY when the user explicitly asks to 're-draw with R', 'use R Enhanced', "
+                "'make it prettier', or 'replot'. "
+                "The skill must have been run first (via the omicsclaw tool). "
+                "R Enhanced is currently supported for single-cell scRNA skills only "
+                "(sc-qc, sc-de, sc-markers, sc-preprocessing, sc-clustering, etc.). "
+                "By default returns all generated R Enhanced figures."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "skill": {
+                        "type": "string",
+                        "description": "Skill alias to replot (e.g. 'sc-qc', 'sc-de', 'sc-markers').",
+                    },
+                    "output_path": {
+                        "type": "string",
+                        "description": "Full path to the output directory from the previous skill run.",
+                    },
+                    "renderer": {
+                        "type": "string",
+                        "description": "Optional: run only a specific renderer (e.g. 'plot_feature_violin'). Omit to run all renderers.",
+                    },
+                    "return_media": {
+                        "type": "string",
+                        "description": "Filter for which R Enhanced figures to send. Default: 'all'. Use a keyword to filter (e.g. 'violin').",
+                    },
+                    "top_n": {"type": "integer", "description": "Number of top items to label/show."},
+                    "font_size": {"type": "integer", "description": "Base font size in points."},
+                    "width": {"type": "integer", "description": "Figure width in inches."},
+                    "height": {"type": "integer", "description": "Figure height in inches."},
+                    "dpi": {"type": "integer", "description": "Output resolution (default 300)."},
+                    "palette": {"type": "string", "description": "Color palette name."},
+                    "title": {"type": "string", "description": "Custom plot title."},
+                },
+                "required": ["skill", "output_path"],
+            },
+            surfaces=("bot",),
+            context_params=("session_id", "chat_id"),
+            read_only=False,
+            concurrency_safe=False,
+            result_policy=RESULT_POLICY_SUMMARY_OR_MEDIA,
+            progress_policy=PROGRESS_POLICY_ANALYSIS,
+            risk_level=RISK_LEVEL_MEDIUM,
+            writes_workspace=True,
+            policy_tags=("analysis", "workflow"),
+        ),
+        ToolSpec(
             name="save_file",
             description="Save a file that was sent via messaging to a specific folder. Default: OmicsClaw data/ directory.",
             parameters={


### PR DESCRIPTION
## Summary

- Add `replot_skill` ToolSpec in `omicsclaw/runtime/bot_tools.py` — exposes `skill`, `output_path`, `renderer` (optional), `return_media` (default `all`), and full plot-param suite (`top_n`, `font_size`, `dpi`, `palette`, `title`, `width`, `height`)
- Add `execute_replot_skill` async executor in `bot/core.py` — validates `output_path` / `figure_data/` existence, builds the `omicsclaw.py replot` subprocess, collects figures from `figures/r_enhanced/`, queues them in `pending_media` for delivery
- Register `replot_skill` in `_available_tool_executors()`

## Behaviour

| Turn | User says | Bot calls |
|------|-----------|-----------|
| 1 | "run sc-qc on my file" | `omicsclaw(skill='sc-qc', ...)` → Python figures |
| 2 | "re-draw with R" | `replot_skill(skill='sc-qc', output_path='...')` → R Enhanced figures delivered |

Only scRNA skills have `R_ENHANCED_PLOTS`; other domains return a friendly "not supported" message — zero impact on existing skill runs or first-round Python plots.

## Test plan

- [ ] Run `sc-qc --demo`, then ask bot "用R重画" — verify `r_qc_violin.png` delivered
- [ ] Ask bot to replot a spatial skill — verify friendly "not supported" message returned
- [ ] Pass `--renderer plot_feature_violin` via `extra_args` — verify only that renderer runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replot_skill tool for re-rendering previously generated plots from skill runs.
  * Supports customization options: font size, dimensions (width/height), color palette, DPI, title, and figure filtering.
  * Includes optional renderer selection for flexible output rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->