### PR TITLE
fix(scrna): harden console encoding output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - **🔒 Privacy-First** — All processing is local; memory stores metadata only (no raw data uploads).
 - **🎯 Smart Routing** — Natural language routed to the appropriate analysis automatically.
 - **🧬 Multi-Omics Coverage** — 72 predefined skills across spatial, single-cell, genomics, proteomics, metabolomics, bulk RNA-seq, literature and orchestration.
+- **🖨️ Console-Safe Output** — The CLI now escapes non-encodable terminal output, and the single-cell RNA terminal guidance stays ASCII-friendly so Windows GBK consoles fail soft instead of crashing.
 
 **What makes it different:**
 

--- a/omicsclaw.py
+++ b/omicsclaw.py
@@ -36,6 +36,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+
+def _configure_stdio_error_handling(*streams: Any) -> None:
+    """Avoid hard failures when a terminal cannot encode Unicode output."""
+    for stream in streams or (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(errors="backslashreplace")
+        except (OSError, ValueError):
+            continue
+
+
+_configure_stdio_error_handling()
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------

--- a/skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py
+++ b/skills/singlecell/scrna/sc-cell-annotation/sc_annotate.py
@@ -1732,26 +1732,26 @@ def main():
     print(f"  Cell types identified: {n_types}")
     if summary.get("used_fallback"):
         print(f"  NOTE: Requested '{summary.get('requested_method')}' but fell back to "
-              f"'{summary.get('actual_method')}' — {summary.get('fallback_reason', 'see log')}")
+              f"'{summary.get('actual_method')}' - {summary.get('fallback_reason', 'see log')}")
     if unk_count and unk_count == total_types:
         print()
-        print("  *** ALL cells were labeled 'Unknown' — annotation did not work for this dataset. ***")
+        print("  *** ALL cells were labeled 'Unknown' - annotation did not work for this dataset. ***")
         print("  This usually means the built-in marker genes don't match your tissue or organism.")
         print()
         print("  How to fix:")
-        print("    Option 1 — Provide your own markers (easiest):")
+        print("    Option 1 - Provide your own markers (easiest):")
         print('      Create a JSON file, e.g. my_markers.json:')
         print('        {"T cell": ["CD3D","CD3E"], "Epithelial": ["EPCAM","KRT18"]}')
         print("      Then rerun:")
         print(f"        python {SCRIPT_REL_PATH} --input <your.h5ad> --output {output_dir} --method markers --marker-file my_markers.json")
         print()
-        print("    Option 2 — Use CellTypist (100+ pretrained models, no reference needed):")
+        print("    Option 2 - Use CellTypist (100+ pretrained models, no reference needed):")
         print("      List available models:")
         print('        python -c "import celltypist; celltypist.models.models_description()"')
         print("      Pick a model for your tissue, then:")
         print(f"        python {SCRIPT_REL_PATH} --input <your.h5ad> --output {output_dir} --method celltypist --model Immune_All_Low.pkl")
         print()
-        print("    Option 3 — Use a labeled reference dataset:")
+        print("    Option 3 - Use a labeled reference dataset:")
         print("      Download a reference H5AD from https://cellxgene.cziscience.com/")
         print("      Then:")
         print(f"        python {SCRIPT_REL_PATH} --input <your.h5ad> --output {output_dir} --method knnpredict --reference ref.h5ad")
@@ -1762,8 +1762,8 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Next steps:")
-    print(f"  • sc-markers: python omicsclaw.py run sc-markers --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-de:      python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-markers: python omicsclaw.py run sc-markers --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-de:      python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-cell-communication/sc_cell_communication.py
+++ b/skills/singlecell/scrna/sc-cell-communication/sc_cell_communication.py
@@ -1414,16 +1414,16 @@ def main():
     _degenerate = _n_interactions == 0
     if _degenerate:
         print()
-        print("  *** NO interactions were detected — communication analysis produced empty results. ***")
+        print("  *** NO interactions were detected - communication analysis produced empty results. ***")
         print("  This usually means the gene names in your data do not overlap with the ligand-receptor database,")
         print("  or the cell type grouping has too few cells per group.")
         print()
         print("  How to fix:")
-        print(f"    Option 1 — Check that '--cell-type-key {args.cell_type_key}' has meaningful labels (not numeric IDs).")
+        print(f"    Option 1 - Check that '--cell-type-key {args.cell_type_key}' has meaningful labels (not numeric IDs).")
         print("      Example: python omicsclaw.py run sc-cell-annotation --input data.h5ad --output anno_out/")
-        print("    Option 2 — Use a richer method that queries a larger LR database:")
+        print("    Option 2 - Use a richer method that queries a larger LR database:")
         print("      Example: python omicsclaw.py run sc-cell-communication --method liana --input data.h5ad --output out/")
-        print("    Option 3 — Verify gene names are HGNC symbols (human) or standard gene symbols (mouse).")
+        print("    Option 3 - Verify gene names are HGNC symbols (human) or standard gene symbols (mouse).")
         print("      If Ensembl IDs, convert first: python omicsclaw.py run bulkrna-geneid-mapping --input data.h5ad --from ensembl --to symbol --output mapped/")
         print()
 
@@ -1584,7 +1584,7 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Analysis complete. Further exploration:")
-    print(f"  • sc-grn: python omicsclaw.py run sc-grn --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-grn: python omicsclaw.py run sc-grn --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-clustering/sc_cluster.py
+++ b/skills/singlecell/scrna/sc-clustering/sc_cluster.py
@@ -1021,9 +1021,9 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Next steps:")
-    print(f"  • sc-cell-annotation: python omicsclaw.py run sc-cell-annotation --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-markers:         python omicsclaw.py run sc-markers --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-pseudotime:      python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-cell-annotation: python omicsclaw.py run sc-cell-annotation --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-markers:         python omicsclaw.py run sc-markers --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-pseudotime:      python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-cytotrace/sc_cytotrace.py
+++ b/skills/singlecell/scrna/sc-cytotrace/sc_cytotrace.py
@@ -689,8 +689,8 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Analysis complete. Further exploration:")
-    print(f"  • sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-velocity:   python omicsclaw.py run sc-velocity --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-velocity:   python omicsclaw.py run sc-velocity --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-drug-response/sc_drug_response.py
+++ b/skills/singlecell/scrna/sc-drug-response/sc_drug_response.py
@@ -800,16 +800,16 @@ def main() -> None:
     degenerate = drug_scores.empty or drug_scores["Score"].isna().all()
     if degenerate:
         print()
-        print("  *** NO DRUGS WERE SCORED — drug response prediction did not produce results. ***")
+        print("  *** NO DRUGS WERE SCORED - drug response prediction did not produce results. ***")
         print("  This usually means none of the drug target genes were found in your expression data.")
         print()
         print("  How to fix:")
-        print("    Option 1 — Check gene names (Ensembl vs symbols):")
+        print("    Option 1 - Check gene names (Ensembl vs symbols):")
         print("      python omicsclaw.py run bulkrna-geneid-mapping --input data.h5ad --output mapped/")
-        print("    Option 2 — Use CaDRReS model-based prediction:")
+        print("    Option 2 - Use CaDRReS model-based prediction:")
         print(f"      python omicsclaw.py run sc-drug-response --input <data.h5ad> --output <dir> \\")
         print(f"        --method cadrres --model-dir ~/.cache/omicsclaw/drug_response/")
-        print("    Option 3 — Provide custom drug-target gene mapping (future feature)")
+        print("    Option 3 - Provide custom drug-target gene mapping (future feature)")
         print()
 
     # ── Store drug scores in adata.obs ──

--- a/skills/singlecell/scrna/sc-enrichment/sc_enrichment.py
+++ b/skills/singlecell/scrna/sc-enrichment/sc_enrichment.py
@@ -1538,8 +1538,8 @@ def main() -> None:
     # --- Next-step guidance ---
     print()
     print(">> Analysis complete. Further exploration:")
-    print(f"  • sc-cell-communication: python omicsclaw.py run sc-cell-communication --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-grn:                python omicsclaw.py run sc-grn --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-cell-communication: python omicsclaw.py run sc-cell-communication --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-grn:                python omicsclaw.py run sc-grn --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-gene-programs/sc_gene_programs.py
+++ b/skills/singlecell/scrna/sc-gene-programs/sc_gene_programs.py
@@ -613,8 +613,8 @@ def main() -> int:
 
     # --- Next-step guidance ---
     print(">> Next steps:")
-    print(f"  • sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
 
     return 0
 

--- a/skills/singlecell/scrna/sc-markers/sc_markers.py
+++ b/skills/singlecell/scrna/sc-markers/sc_markers.py
@@ -461,8 +461,8 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Next steps:")
-    print(f"  • sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == '__main__':

--- a/skills/singlecell/scrna/sc-metacell/sc_metacell.py
+++ b/skills/singlecell/scrna/sc-metacell/sc_metacell.py
@@ -532,8 +532,8 @@ def main() -> int:
     # --- Next-step guidance ---
     print()
     print(">> Next step: Use metacell AnnData for downstream analysis:")
-    print(f"  • sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
 
     return 0
 

--- a/skills/singlecell/scrna/sc-perturb-prep/sc_perturb_prep.py
+++ b/skills/singlecell/scrna/sc-perturb-prep/sc_perturb_prep.py
@@ -331,7 +331,7 @@ def main() -> int:
             "Verify the mapping file is not empty or malformed",
         ]
         print()
-        print("  *** ZERO cells were assigned after merging — no barcodes matched. ***")
+        print("  *** ZERO cells were assigned after merging - no barcodes matched. ***")
         print("  This usually means the barcode format in the mapping file does not match adata.obs_names.")
         print()
         print("  How to fix:")
@@ -345,7 +345,7 @@ def main() -> int:
             "Verify --control-patterns does not match all sgRNAs",
         ]
         print()
-        print(f"  *** Only {n_perts} perturbation label(s) found — expected at least 2 (control + target). ***")
+        print(f"  *** Only {n_perts} perturbation label(s) found - expected at least 2 (control + target). ***")
         print()
     elif prep_diagnostics["all_control"]:
         prep_diagnostics["suggested_actions"] = [
@@ -353,7 +353,7 @@ def main() -> int:
             "Check that target-gene column or sgRNA naming convention is correct",
         ]
         print()
-        print("  *** ALL cells were labeled as control — no perturbation targets detected. ***")
+        print("  *** ALL cells were labeled as control - no perturbation targets detected. ***")
         print()
 
     summary = {

--- a/skills/singlecell/scrna/sc-perturb/sc_perturb.py
+++ b/skills/singlecell/scrna/sc-perturb/sc_perturb.py
@@ -321,7 +321,7 @@ def main() -> int:
     diagnostics = _detect_degenerate_output(global_counts, class_counts)
     if diagnostics.get("all_non_perturbed"):
         print()
-        print("  *** ALL cells were classified as non-perturbed (NP) — Mixscape found no perturbation signal. ***")
+        print("  *** ALL cells were classified as non-perturbed (NP) - Mixscape found no perturbation signal. ***")
         print("  This usually means the perturbation effect is too weak for the current threshold,")
         print("  or the perturbation labels do not match real perturbation conditions.")
         print()
@@ -453,8 +453,8 @@ def main() -> int:
     # --- Next-step guidance ---
     print()
     print(">> Next steps:")
-    print(f"  • sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-de:         python omicsclaw.py run sc-de --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-enrichment: python omicsclaw.py run sc-enrichment --input {output_dir}/processed.h5ad --output <dir>")
 
     return 0
 

--- a/skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py
+++ b/skills/singlecell/scrna/sc-pseudotime/sc_pseudotime.py
@@ -1423,8 +1423,8 @@ def main() -> None:
     # --- Next-step guidance ---
     print()
     print(">> Next steps:")
-    print(f"  • sc-velocity:      python omicsclaw.py run sc-velocity --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-gene-programs: python omicsclaw.py run sc-gene-programs --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-velocity:      python omicsclaw.py run sc-velocity --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-gene-programs: python omicsclaw.py run sc-gene-programs --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/skills/singlecell/scrna/sc-velocity-prep/sc_velocity_prep.py
+++ b/skills/singlecell/scrna/sc-velocity-prep/sc_velocity_prep.py
@@ -569,16 +569,16 @@ def main() -> None:
         if not has_spliced or not has_unspliced:
             print("  Missing velocity layers: spliced=%s unspliced=%s" % (has_spliced, has_unspliced))
         elif unspliced_total == 0:
-            print("  Unspliced layer has zero molecules — downstream velocity estimation will fail.")
+            print("  Unspliced layer has zero molecules - downstream velocity estimation will fail.")
         else:
             print("  Both spliced and unspliced layers have zero total molecules.")
         print()
         print("  How to fix:")
-        print("    Option 1 — Re-run with a correct GTF that includes intron annotations:")
+        print("    Option 1 - Re-run with a correct GTF that includes intron annotations:")
         print("      oc run sc-velocity-prep --input <dir> --method velocyto --gtf <genes.gtf> --output <dir>")
-        print("    Option 2 — Use STARsolo with Velocyto feature:")
+        print("    Option 2 - Use STARsolo with Velocyto feature:")
         print("      oc run sc-velocity-prep --input <dir> --method starsolo --output <dir>")
-        print("    Option 3 — Use a pre-existing loom file with velocity layers:")
+        print("    Option 3 - Use a pre-existing loom file with velocity layers:")
         print("      oc run sc-velocity-prep --input <sample.loom> --method velocyto --output <dir>")
         print()
 

--- a/skills/singlecell/scrna/sc-velocity/sc_velocity.py
+++ b/skills/singlecell/scrna/sc-velocity/sc_velocity.py
@@ -776,18 +776,18 @@ def main():
             print()
             print("  *** WARNING: Velocity output appears degenerate. ***")
             if all_zero:
-                print("  All velocity vectors are zero — scVelo could not estimate meaningful velocity.")
+                print("  All velocity vectors are zero - scVelo could not estimate meaningful velocity.")
             if nan_frac > 0.5:
-                print(f"  {nan_frac*100:.0f}% of velocity values are NaN — fitting may have failed.")
+                print(f"  {nan_frac*100:.0f}% of velocity values are NaN - fitting may have failed.")
             if n_velocity_genes == 0:
-                print("  No genes have non-zero velocity — the spliced/unspliced signal may be too weak.")
+                print("  No genes have non-zero velocity - the spliced/unspliced signal may be too weak.")
             print()
             print("  How to fix:")
-            print("    Option 1 — Use real spliced/unspliced data from velocyto or STARsolo:")
+            print("    Option 1 - Use real spliced/unspliced data from velocyto or STARsolo:")
             print("      oc run sc-velocity-prep --input <cellranger_dir> --method velocyto --gtf <genes.gtf> --output <dir>")
-            print("    Option 2 — Try the dynamical model which may recover more signal:")
+            print("    Option 2 - Try the dynamical model which may recover more signal:")
             print("      oc run sc-velocity --input <data.h5ad> --method scvelo_dynamical --output <dir>")
-            print("    Option 3 — Check upstream preprocessing (normalize, HVG, PCA, neighbors):")
+            print("    Option 3 - Check upstream preprocessing (normalize, HVG, PCA, neighbors):")
             print("      oc run sc-preprocessing --input <data.h5ad> --output <dir>")
             print()
         else:
@@ -919,8 +919,8 @@ def main():
     # --- Next-step guidance ---
     print()
     print(">> Analysis complete. Further exploration:")
-    print(f"  • sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
-    print(f"  • sc-cytotrace:  python omicsclaw.py run sc-cytotrace --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-pseudotime: python omicsclaw.py run sc-pseudotime --input {output_dir}/processed.h5ad --output <dir>")
+    print(f"  - sc-cytotrace:  python omicsclaw.py run sc-cytotrace --input {output_dir}/processed.h5ad --output <dir>")
 
 
 if __name__ == "__main__":

--- a/tests/test_scrna_console_encoding.py
+++ b/tests/test_scrna_console_encoding.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import io
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRNA_DIR = ROOT / "skills" / "singlecell" / "scrna"
+
+
+def _load_omicsclaw_script():
+    spec = importlib.util.spec_from_file_location(
+        "omicsclaw_main_console_encoding_test",
+        ROOT / "omicsclaw.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _iter_string_fragments(node: ast.AST):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        yield node.value
+        return
+    if isinstance(node, ast.JoinedStr):
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                yield value.value
+        return
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        yield from _iter_string_fragments(node.left)
+        yield from _iter_string_fragments(node.right)
+
+
+def _is_print_call(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Name) and node.func.id == "print"
+
+
+def test_scrna_print_statements_use_ascii_only_text():
+    offenders: list[str] = []
+
+    for path in sorted(SCRNA_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        relative_path = path.relative_to(ROOT)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_print_call(node):
+                continue
+            for arg in node.args:
+                for fragment in _iter_string_fragments(arg):
+                    if any(ord(char) > 127 for char in fragment):
+                        offenders.append(
+                            f"{relative_path}:{getattr(arg, 'lineno', node.lineno)}: {fragment!r}"
+                        )
+
+    assert offenders == [], (
+        "SCRNA terminal print() strings must stay ASCII-only for Windows code pages:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_cli_stdio_reconfigure_escapes_nonencodable_output():
+    oc = _load_omicsclaw_script()
+    stdout_bytes = io.BytesIO()
+    stderr_bytes = io.BytesIO()
+    stdout_stream = io.TextIOWrapper(stdout_bytes, encoding="gbk", errors="strict")
+    stderr_stream = io.TextIOWrapper(stderr_bytes, encoding="gbk", errors="strict")
+
+    oc._configure_stdio_error_handling(stdout_stream, stderr_stream)
+
+    stdout_stream.write("bullet=•")
+    stderr_stream.write("bullet_err=•")
+    stdout_stream.flush()
+    stderr_stream.flush()
+
+    assert stdout_bytes.getvalue().decode("ascii") == r"bullet=\u2022"
+    assert stderr_bytes.getvalue().decode("ascii") == r"bullet_err=\u2022"


### PR DESCRIPTION
## Summary
- replace non-ASCII console guidance in scrna scripts with ASCII-safe output for Windows GBK terminals
- add CLI stdio fallback to `backslashreplace` so non-encodable output fails soft instead of crashing
- add regression coverage for scrna console print strings and CLI stdio behavior

## Verification
- `python -m pytest tests/test_scrna_console_encoding.py tests/test_version_cli.py -q`
- `python - <<'PY'` equivalent `py_compile` check over the touched scrna scripts, `omicsclaw.py`, and the new test

## Notes
- this PR intentionally leaves unrelated local workspace changes out of scope
- broader scrna contract tests were not run here because the current environment is missing optional dependencies such as `anndata`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console output now safely handles Unicode encoding across different terminal environments, including Windows GBK consoles.
  * Single-cell RNA command output remains ASCII-friendly with graceful degradation.

* **Documentation**
  * Added console-safe output feature documentation to README.

* **Tests**
  * Added comprehensive console encoding safety tests to verify ASCII compatibility across all single-cell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->