### PR TITLE
feat(remote): execution executors, remote endpoints, and folder-picker API

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,153 @@
+# Remote 连通性联调 — 分阶段修复方案
+
+**范围**：OmicsClaw（后端，本仓库）+ OmicsClaw-App（前端，`/data1/TianLab/zhouwg/project/OmicsClaw-App`）
+**方法**：TDD，每阶段先写测试再改代码，通过后再进入下一阶段
+**策略**：增量联调、不做大爆炸重构；保留本地模式现有行为，只在 remote 模式里引入真远端调用
+**不做的事**：
+- 不动 skills 的 SKILL.md
+- 不给前端 UI 组件改结构（只加 API route 与 lib 层适配）
+- 不引入新依赖（后端用 asyncio、前端用现成的 `backendFetch`）
+
+---
+
+## Stage 1：后端执行面接通真实 SubprocessExecutor
+**Goal**：把 `_DEFAULT_EXECUTOR` 从 `LocalExecutor`（永远返回 `executor_not_implemented`）换成真正能跑 `python omicsclaw.py run <skill> ...` 的 `SubprocessExecutor`。
+**Success Criteria**：
+- submit 一个已存在的 skill（例如 `bulkrna-de --demo`）后，job 能走完 queued → running → succeeded
+- stdout.log 有真实 skill 输出
+- artifacts/ 目录下有真实产物（不是空目录）
+- 所有现有 `tests/test_remote_routes_contract.py` 既有断言继续绿（包括 `test_job_events_streams_lifecycle` 依赖失败分支的那部分需相应调整）
+**Tests**（新增）：
+- `tests/test_execution_default_executor.py::test_default_executor_is_subprocess_executor` — 校验模块级 `_DEFAULT_EXECUTOR` 的类型
+- `tests/test_execution_default_executor.py::test_default_command_factory_maps_skill_to_omicsclaw_argv` — 校验命令工厂把 skill/inputs/params 映射成正确 argv
+- `tests/test_remote_routes_contract.py::test_submit_real_skill_succeeds_end_to_end` — 用 `--demo` 模式跑一次完整 job（用最便宜的 skill 例如 `bulkrna-qc --demo`）
+**Status**：Complete
+
+**实现要点**：
+1. 新增 `omicsclaw/execution/executors/default.py`：提供 `default_command_factory(ctx) -> list[str]`，映射 `ctx.skill/ctx.inputs/ctx.params` 到 `python omicsclaw.py run <skill> ...` argv
+2. 把 `omicsclaw/remote/routers/jobs.py` 的 `_DEFAULT_EXECUTOR = LocalExecutor()` 改为 `build_default_executor()`
+3. `tests/test_remote_routes_contract.py` fixture 显式 monkeypatch 回 `LocalExecutor()`，契约测试验证 wire format 而非执行器行为
+4. 既有 4 个 executor 测试（LocalExecutor 相关）保持不动，因为它们验证的是协议合规性
+
+**落地情况**（2026-04-15）：
+- 新增 `omicsclaw/execution/executors/default.py`（复用 `autoagent.constants.param_to_cli_flag`）
+- 新增 `tests/test_execution_default_executor.py`（10 个单元测试）
+- `omicsclaw/remote/routers/jobs.py` 切换默认 executor，docstring 同步
+- `tests/test_remote_routes_contract.py` fixture 锁回 `LocalExecutor()`
+- 8 个测试文件共 74 tests 全绿（包括 SSE/reconcile/cancel/contract/auth）
+- Code review 三路 agent 已过，`_snake_to_kebab` 换成既有 `param_to_cli_flag`，冗余 docstring 已清理
+
+---
+
+## Stage 2：前端 wire 层统一（类型 + 翻译器 + 基础设施）
+**Goal**：建立前端一层薄的"后端契约 ↔ App 契约"翻译器，让后续 Stage 3/4 的每一个 proxy route 都能用同一套适配函数，不要每个 route 各写一遍字段重命名。
+**Success Criteria**：
+- `src/lib/remote-jobs-adapter.ts` 能把后端 `Job`（`job_id/error/created_at/inputs:dict`）翻成 App 的 `Job`（`id/error_message/submitted_at/inputs:string`），反之亦然
+- `src/lib/remote-sse-adapter.ts` 能把后端 SSE 事件流翻译成 App 前端期望的 `{ type, job }`/`{ type, lines[] }`/`{ type, artifact_root }` 形状
+- 新增 `isRemoteMode()` helper，封装 `connection_mode === "remote"` 判断
+**Tests**（新增）：
+- `src/__tests__/unit/remote-jobs-adapter.test.ts`（16 tests）：双向翻译、null 处理、execution_target 注入、JSON 序列化/反序列化、字段丢弃
+- `src/__tests__/unit/remote-sse-adapter.test.ts`（11 tests）：完整生命周期、首次 snapshot、重复 artifact 去重、done 静默、error 透传
+- `src/__tests__/unit/remote-mode-helper.test.ts`（3 tests）：`isRemoteMode()` 边界
+**Status**：Complete
+
+**落地情况**（2026-04-15）：
+- 新增 `src/lib/remote-jobs-adapter.ts`：`BackendJob/BackendJobSubmitRequest/BackendJobListResponse/BackendJobSubmitResponse` 类型，`backendJobToAppJob/appJobInputToBackendSubmit`
+- 新增 `src/lib/remote-sse-adapter.ts`：`RemoteSseAdapter` 类（复用 `jobs-state-machine.ts` 的 `isTerminalJobStatus`）
+- `src/lib/backend-config.ts` 追加 `isRemoteMode(cfg?)`
+- 30 个新测试全绿；全项目 419 unit tests + typecheck 全绿
+- Review 整改：复用 `isTerminalJobStatus`、内联 `deriveDisplayName`、文档化 `exit_code` 丢弃语义、精简 docstring
+
+**关键翻译规则**：
+- `job_id ↔ id`
+- `error ↔ error_message`（null → ""）
+- `created_at ↔ submitted_at`
+- `inputs: dict ↔ inputs: JSON.stringify(dict)`
+- 后端 `stdout_tail` 不存在 → App 初次拿快照时 `stdout_tail=""`，再靠 SSE `job_log` 累积
+- 后端连续多个单行 `job_log` → App 前端逻辑不变，仍收 `{type:'job_log', lines:[...]}`，adapter 每收到一个后端 `job_log` 就映射成 `{lines:[line]}`（不合批，保持延迟最低）
+
+---
+
+## Stage 3：Jobs 控制面改造为 mode-aware proxy
+**Goal**：remote 模式下，App 的 `/api/jobs*` 不再读写本地 SQLite，而是透传到后端并翻译响应。Local 模式现状不变。
+**Success Criteria**：
+- Remote 模式下 `POST/GET/DELETE /api/jobs`、`/api/jobs/[id]`、`/cancel`、`/retry`、`/events` 全部访问后端
+- SSE 流用 adapter 翻译，前端（`jobs-client.ts` 消费方）零改动
+- `chat/route.ts:253` 的本地 createJob **保持本地**（按已定决策：chat turn 不污染远端）
+- 既有 `jobs-client.test.ts`/`jobs-api.test.ts`/`chat-route-jobs.test.ts` 全绿（local 路径不动）
+**Tests**（新增）：
+- `src/__tests__/unit/remote-jobs-proxy.test.ts`（13 tests）：proxy 工具函数 + unavailableReason→503
+- `src/__tests__/unit/jobs-routes-remote.test.ts`（11 tests）：5 路由 remote 模式集成；chat 本地 fallback
+**Status**：Complete
+
+**落地情况**（2026-04-15）：
+- 新增 `src/lib/remote-jobs-proxy.ts`：`BackendError`、`proxyListJobs/SubmitJob/GetJob/CancelJob/RetryJob`、`openRemoteJobEventStream`、`createSseProxyStream`、`executionTargetForRemote`、`ensureBackendAvailable`
+- 改造 5 个 route：`/api/jobs`（GET/POST）、`/api/jobs/[id]`（GET 带本地优先、PUT 405、DELETE 501）、`/cancel`、`/retry`、`/events`
+- chat/route.ts 不动（按决策）
+- 24 个新测试全绿；全项目 442 passing（另 1 预先 flaky 计时测试与本 stage 无关）+ typecheck 干净
+- Review 整改：`unavailableReason` → BackendError(503) 提前拦截、`createSseProxyStream` 增加 `cancel` handler 传播 reader.cancel、route 外层 500 兜底
+
+**决策点请你确认**：
+- 方案 A：remote 模式下 App 的 chat turn 也提交到后端 `/jobs`（真正一体化）
+- 方案 B：remote 模式下 chat turn 依然是 App-local display-only job，真正的 skill 执行才走 remote `/jobs`（隔离聊天与计算）
+- 我倾向 B：chat 本身不是 skill execution，把它也变成远端 job 会放大耦合，而且 chat 已经通过 `/chat/stream` 直连后端了，再记一份远端 job 是重复账本
+
+---
+
+## Stage 4：Datasets + Artifacts + Session resume
+**Goal**：把剩下 3 个控制面也改成 remote-aware proxy。
+**Success Criteria**：
+- Remote 模式 `GET /api/datasets` 返回后端列表；`POST /api/datasets` 决策如下（见下）
+- Remote 模式 artifacts list/download/preview 通过后端，不再读本机文件系统
+- 新增 `POST /api/chat/sessions/[id]/resume`：代理到 `POST /sessions/{id}/resume`，返回 `active_job_ids`，前端会话 reattach 逻辑可消费
+- SetupCenter 的"还没有数据集"判定改为：remote 模式看远端 list，local 模式看本地
+**Tests**（新增）：
+- `src/__tests__/unit/api-datasets-remote.test.ts`
+- `src/__tests__/unit/api-artifacts-remote.test.ts`（list + download streaming + preview 64KB 截断）
+- `src/__tests__/unit/api-sessions-resume.test.ts`
+**Status**：Complete
+
+**落地情况**（2026-04-16）：
+- 新增 `src/lib/remote-datasets-adapter.ts`：`BackendDatasetRef` 类型 + `backendDatasetToAppDatasetRef`
+- 新增 `src/lib/remote-datasets-proxy.ts`：`proxyListDatasets / proxyUploadDataset / proxyImportRemoteDataset`
+- 新增 `src/lib/remote-artifacts-proxy.ts`：`proxyListArtifacts / proxyDownloadArtifact / proxyPreviewArtifact`、`UnsupportedPreviewError`
+- 新增 `src/app/api/datasets/upload/route.ts`（multipart → backend）
+- 新增 `src/app/api/datasets/register/route.ts`（JSON → backend `/datasets/import-remote`）
+- 新增 `src/app/api/chat/sessions/[id]/resume/route.ts`（代理 → `/sessions/{id}/resume`）
+- 改造 `src/app/api/datasets/route.ts`（GET remote proxy；POST 405 remote）
+- 改造 `src/app/api/artifacts/*`（list/download/preview 均加 remote-fallback 分支）
+- 共享 helpers 抽到 `backend-fetch.ts`：`BackendError, readBackendErrorMessage, ensureBackendAvailable, ensureBackendOk`
+- 42+ 个新测试全绿；全项目 466/467 pass（另 1 预先 flaky 计时测试无关）+ typecheck 干净
+- Review 整改：共享 helper 消除 3x `readErrorMessage` 重复、`buildDownloadPath` 改用 literal `:` 和 `/`（不 percent-encode separator）、`UnsupportedPreviewError` typed error 替代 regex、download proxy 过滤 Content-Encoding/Transfer-Encoding、resume route 用共享 helpers
+
+---
+
+## Stage 5：测试基线重整 + 文档更新
+**Goal**：消除"本地测试全绿但联调不通"这个盲点。
+**Success Criteria**：
+- Wire-shape 契约测试锁住后端字段名（golden snapshot）
+- `datasets.test.ts`/`jobs.test.ts`/`jobs-client.test.ts` 明确标注"本地模式专用"
+- README 记 remote 模式联调指引（环境变量、字段映射、已知限制）
+**Status**：Complete
+
+**落地情况**（2026-04-16）：
+- 新增 `src/__tests__/unit/remote-wire-contract.test.ts`（8 tests）：golden payload × 3 资源（Job/Dataset/Artifact）+ SSE 生命周期 + 字段集合完整性
+- 标注 `datasets.test.ts`/`jobs.test.ts`/`jobs-client.test.ts` 为 LOCAL-MODE ONLY
+- README 新增 "Remote Mode Integration" 小节（环境变量、字段映射表、SSE 事件映射、已知限制）
+- 全项目 475 App tests + 74 backend tests + typecheck 全绿
+
+---
+
+## 跨阶段约定
+
+1. 每阶段单独一个 commit（或一组 commit），不跨阶段混改
+2. 每阶段结束跑完整 pytest + npm test，红一个都不进下一阶段
+3. 每阶段完成后更新本文件的 Status 字段
+4. 全部完成后删除本文件
+5. 任何与计划偏差的决策（例如 Stage 3 方案 A vs B）要先回到这里更新，再动手
+
+## 已定决策（2026-04-15 由作者拍板）
+
+- **阶段顺序**：严格 1→2→3→4→5
+- **Stage 3**：remote 模式下 chat turn **不**提交到远端 `/jobs`；chat 继续走 `/chat/stream` + App-local display job
+- **Stage 4**：`POST /api/datasets` 拆成两个 endpoint — `/api/datasets/upload`（multipart）与 `/api/datasets/register`（登记已有远端绝对路径文件）

--- a/README.md
+++ b/README.md
@@ -320,21 +320,11 @@ The app backend binds to `127.0.0.1:8765` by default and provides the HTTP/SSE c
 
 If `omicsclaw_kg` is installed or available from a source checkout via `OMICSCLAW_KG_SOURCE_DIR=/path/to/OmicsClaw-KG`, the same `oc app-server` process also mounts the embedded `/kg/*` routes used by the KG Explorer. The frontend dev server now proxies `/kg` to the app backend by default instead of a separate `omicsclaw-kg http serve` process.
 
-**Remote control-plane API (MVP-1, consumed by OmicsClaw-App):**
+**Remote control-plane API (used by OmicsClaw-App remote mode):**
 
-The `omicsclaw/remote/` package mounts the contract used by the desktop App when running in **remote mode** (control plane on the laptop, execution plane on a server). Workspace-scoped state is stored under `<workspace>/.omicsclaw/remote/{datasets,jobs}/`.
+The `omicsclaw/remote/` package powers OmicsClaw-App when the UI runs locally but execution happens on another machine. It covers connection checks, datasets, job lifecycle and SSE logs, artifacts, and session resume. Workspace-scoped state lives under `<workspace>/.omicsclaw/remote/`.
 
-| Method | Path | Status |
-|---|---|---|
-| POST | `/connections/test` | implemented (version + GPU + disk extras) |
-| GET | `/env/doctor` | implemented (JSON of `oc doctor`) |
-| GET / POST | `/datasets`, `/datasets/upload`, `/datasets/import-remote` | implemented (multipart ≤1 GiB; larger files via `import-remote` after scp/rsync; `execution_target` is required; deduplication is scoped by `(checksum, execution_target)`; missing files are surfaced as `status="stale"`) |
-| POST / GET | `/jobs`, `/jobs/{id}`, `/jobs/{id}/cancel`, `/jobs/{id}/retry` | persistence implemented; jobs record the resolved workspace + optional session id; stub failures persist `stdout.log` plus `diagnostics/env_doctor.json` and `diagnostics/stdout.log` under the job artifact root; orphaned `running` jobs are reconciled best-effort per job and retried on later workspace touches if diagnostics persistence partially fails; execution still ends in `executor_not_implemented` until the upstream Executor abstraction lands |
-| GET | `/jobs/{id}/events` | read-only SSE stream of persisted lifecycle state (`job_queued` / `job_started` / `job_log` / `job_failed` / `job_canceled` / `done`) |
-| GET | `/artifacts?job_id=`, `/artifacts/{id}/download` | implemented (Range-aware via `FileResponse`; rejects unsafe `job_id` / `artifact_id` traversal; exposes persisted diagnostics artifacts for failed jobs) |
-| POST | `/sessions/{id}/resume` | implemented (returns active job ids for that session only) |
-
-Contract pinned by `tests/test_remote_routes_contract.py`. Wire-format source of truth is `omicsclaw/remote/schemas.py`.
+For setup and operational details, see [docs/remote-connection-guide.md](docs/remote-connection-guide.md).
 
 **What it remembers:**
 - 📁 **Datasets** — File paths, platforms (Visium/Xenium), dimensions, preprocessing state
@@ -604,39 +594,14 @@ Skills communicate via standardized formats (`.h5ad`, `.vcf`, `.mzML`, `.csv`) a
 
 ### Remote Mode Integration
 
-OmicsClaw-App can operate in **remote mode**, forwarding jobs, datasets, and artifact requests to the Python backend via the remote control-plane API (`omicsclaw/remote/`).
+OmicsClaw-App can run in **remote mode**: keep the App on your laptop, run `oc app-server` near the data, and let the backend own datasets, jobs, logs, and artifacts over the remote control plane.
 
-**Environment variables:**
+**Minimal backend config:**
+- `OMICSCLAW_WORKSPACE` points to the backend workspace and is required.
+- `OMICSCLAW_REMOTE_AUTH_TOKEN` enables bearer-token auth and should be set whenever the service is reachable beyond localhost.
+- For large datasets, prefer copying files to the server first and importing them from path instead of browser upload.
 
-| Variable | Purpose | Default |
-|---|---|---|
-| `OMICSCLAW_WORKSPACE` | Backend workspace directory | Required |
-| `OMICSCLAW_REMOTE_AUTH_TOKEN` | Bearer token for remote auth | Unset (no auth) |
-
-**Wire contract alignment:**
-
-The App and backend use different field names for the same concepts. Translation is handled by adapter modules in `OmicsClaw-App/src/lib/`:
-
-| Backend field | App field | Notes |
-|---|---|---|
-| `job_id` | `id` | |
-| `dataset_id` | `id` | |
-| `error` | `error_message` | `null` → `""` |
-| `created_at` | `submitted_at` | |
-| `inputs` (dict) | `inputs` (JSON string) | |
-| `artifact_id` | composite of `job_id:relative_path` | |
-
-SSE events are also translated: backend `job_queued/started/log/succeeded/failed/canceled/done` → App `job_snapshot/status/log/artifact_created/job_finished`.
-
-Remote chat turns now use that same control plane: the App submits a queued backend `chat` display job first, `/chat/stream` binds to that `job_id`, and the bound job's lifecycle plus `stdout.log` are updated directly by the backend so resume/reconnect can reattach to the active turn.
-
-**Testing:** Wire-shape contract is pinned in `OmicsClaw-App/src/__tests__/unit/remote-wire-contract.test.ts`. Local-mode tests (`datasets.test.ts`, `jobs.test.ts`, `jobs-client.test.ts`) are explicitly scoped to App-local SQLite and are unaffected by backend schema changes.
-
-**Known limitations (MVP):**
-- `PUT /api/jobs/[id]` returns 405 in remote mode (backend has no general update endpoint)
-- `DELETE /api/jobs/[id]` returns 501 for remote-only jobs
-- Multipart file uploads buffer in memory before forwarding (large-file streaming deferred)
-- `proxyRetryJob` returns minimal metadata for the new job (SSE fills real state quickly)
+For the full setup flow, SSH tunnel pattern, and current operational caveats, see [docs/remote-connection-guide.md](docs/remote-connection-guide.md).
 
 ## 📱 Channels Integration — Memory-Enabled Conversational Interface
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,22 @@ The app backend binds to `127.0.0.1:8765` by default and provides the HTTP/SSE c
 
 If `omicsclaw_kg` is installed or available from a source checkout via `OMICSCLAW_KG_SOURCE_DIR=/path/to/OmicsClaw-KG`, the same `oc app-server` process also mounts the embedded `/kg/*` routes used by the KG Explorer. The frontend dev server now proxies `/kg` to the app backend by default instead of a separate `omicsclaw-kg http serve` process.
 
+**Remote control-plane API (MVP-1, consumed by OmicsClaw-App):**
+
+The `omicsclaw/remote/` package mounts the contract used by the desktop App when running in **remote mode** (control plane on the laptop, execution plane on a server). Workspace-scoped state is stored under `<workspace>/.omicsclaw/remote/{datasets,jobs}/`.
+
+| Method | Path | Status |
+|---|---|---|
+| POST | `/connections/test` | implemented (version + GPU + disk extras) |
+| GET | `/env/doctor` | implemented (JSON of `oc doctor`) |
+| GET / POST | `/datasets`, `/datasets/upload`, `/datasets/import-remote` | implemented (multipart ≤1 GiB; larger files via `import-remote` after scp/rsync; `execution_target` is required; deduplication is scoped by `(checksum, execution_target)`; missing files are surfaced as `status="stale"`) |
+| POST / GET | `/jobs`, `/jobs/{id}`, `/jobs/{id}/cancel`, `/jobs/{id}/retry` | persistence implemented; jobs record the resolved workspace + optional session id; stub failures persist `stdout.log` plus `diagnostics/env_doctor.json` and `diagnostics/stdout.log` under the job artifact root; orphaned `running` jobs are reconciled best-effort per job and retried on later workspace touches if diagnostics persistence partially fails; execution still ends in `executor_not_implemented` until the upstream Executor abstraction lands |
+| GET | `/jobs/{id}/events` | read-only SSE stream of persisted lifecycle state (`job_queued` / `job_started` / `job_log` / `job_failed` / `job_canceled` / `done`) |
+| GET | `/artifacts?job_id=`, `/artifacts/{id}/download` | implemented (Range-aware via `FileResponse`; rejects unsafe `job_id` / `artifact_id` traversal; exposes persisted diagnostics artifacts for failed jobs) |
+| POST | `/sessions/{id}/resume` | implemented (returns active job ids for that session only) |
+
+Contract pinned by `tests/test_remote_routes_contract.py`. Wire-format source of truth is `omicsclaw/remote/schemas.py`.
+
 **What it remembers:**
 - 📁 **Datasets** — File paths, platforms (Visium/Xenium), dimensions, preprocessing state
 - 📊 **Analyses** — Methods used, parameters, execution time, lineage (parent → child)
@@ -585,6 +601,42 @@ skills/<domain>/<skill>/
 Skills communicate via standardized formats (`.h5ad`, `.vcf`, `.mzML`, `.csv`) and can be chained into pipelines.
 
 </details>
+
+### Remote Mode Integration
+
+OmicsClaw-App can operate in **remote mode**, forwarding jobs, datasets, and artifact requests to the Python backend via the remote control-plane API (`omicsclaw/remote/`).
+
+**Environment variables:**
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `OMICSCLAW_WORKSPACE` | Backend workspace directory | Required |
+| `OMICSCLAW_REMOTE_AUTH_TOKEN` | Bearer token for remote auth | Unset (no auth) |
+
+**Wire contract alignment:**
+
+The App and backend use different field names for the same concepts. Translation is handled by adapter modules in `OmicsClaw-App/src/lib/`:
+
+| Backend field | App field | Notes |
+|---|---|---|
+| `job_id` | `id` | |
+| `dataset_id` | `id` | |
+| `error` | `error_message` | `null` → `""` |
+| `created_at` | `submitted_at` | |
+| `inputs` (dict) | `inputs` (JSON string) | |
+| `artifact_id` | composite of `job_id:relative_path` | |
+
+SSE events are also translated: backend `job_queued/started/log/succeeded/failed/canceled/done` → App `job_snapshot/status/log/artifact_created/job_finished`.
+
+Remote chat turns now use that same control plane: the App submits a queued backend `chat` display job first, `/chat/stream` binds to that `job_id`, and the bound job's lifecycle plus `stdout.log` are updated directly by the backend so resume/reconnect can reattach to the active turn.
+
+**Testing:** Wire-shape contract is pinned in `OmicsClaw-App/src/__tests__/unit/remote-wire-contract.test.ts`. Local-mode tests (`datasets.test.ts`, `jobs.test.ts`, `jobs-client.test.ts`) are explicitly scoped to App-local SQLite and are unaffected by backend schema changes.
+
+**Known limitations (MVP):**
+- `PUT /api/jobs/[id]` returns 405 in remote mode (backend has no general update endpoint)
+- `DELETE /api/jobs/[id]` returns 501 for remote-only jobs
+- Multipart file uploads buffer in memory before forwarding (large-file streaming deferred)
+- `proxyRetryJob` returns minimal metadata for the new job (SSE fills real state quickly)
 
 ## 📱 Channels Integration — Memory-Enabled Conversational Interface
 

--- a/docs/remote-connection-guide.md
+++ b/docs/remote-connection-guide.md
@@ -1,21 +1,35 @@
 # OmicsClaw-App 远程连接配置指南
 
-本文档说明如何在 OmicsClaw-App 中配置**远程服务器执行**。配置完成后，App 保留在本地负责 UI、聊天和结果浏览，数据处理与作业执行则放在远端 Linux 服务器上。
+本文档说明如何在 OmicsClaw-App 中把**数据处理/作业执行**放在远端 Linux 服务器上，App 本身留在本地负责 UI、聊天、结果浏览。
+
+> 对齐版本：OmicsClaw-App **v0.1.3+**（引入 `Runtimes` 页面与 Bundled 运行时）。
 
 ## 架构概览
 
+OmicsClaw-App 通过一个统一的 **Runtimes** 抽象来管理"Python 到底跑在哪"，目前有四种 `RuntimeKind`：
+
+| Runtime Kind | 说明 | 传输方式 | 典型场景 |
+|---|---|---|---|
+| `bundled` | App 自带的便携 Python（PBS）+ `omicsclaw[desktop]`，零配置 | IPC / 本地 HTTP | 开箱即用的桌面体验（Linux x64/arm64、macOS arm64、Windows x64） |
+| `local-python` | 指向用户本机的 Python 解释器（由 `launcher_python_path` 决定） | 本地 HTTP | 已有 conda / venv 想复用 |
+| `remote-ssh` | `connection_profiles` 记录 + 非空 `ssh_host`，由 Electron 隧道管理器把 `127.0.0.1:<动态端口>` 前向到 `<ssh_host>:<remote_port>` | HTTP over SSH tunnel | **本文档主要场景** |
+| `remote-url` | `connection_profiles` 记录 + 空 `ssh_host` + 直接 URL（或旧版 `remote_backend_url` fallback） | HTTP 直连 | 已有自己的 `ssh -L` / VPN / 直达公网 URL |
+
+同一时刻只有**一个** runtime 是激活的；切换通过 Runtimes 页面的 **Make Active** 完成。
+
 ```
 ┌────────── OmicsClaw-App (control plane) ────────┐
-│  Next.js UI  ·  Electron                        │
-│  SSH Tunnel Manager → 127.0.0.1:<localPort>      │
+│  Next.js UI · Electron                          │
+│  Runtimes 页面（增/删/改/激活 4 类 runtime）     │
+│  TunnelManager → 127.0.0.1:<dynamic-local>      │
 └──────────────────┬──────────────────────────────┘
                    │  HTTPS/SSE over SSH tunnel
 ┌──────────────────▼──────────────────────────────┐
 │  远程 Linux 服务器 (execution plane)              │
 │  oc app-server ── 127.0.0.1:8765                │
-│  Remote control plane + notebook routes          │
-│  Remote jobs run as local OmicsClaw subprocesses │
-│  Datasets / Jobs / Artifacts on workspace disk   │
+│  Control plane + notebook + optional KG routes  │
+│  Jobs 以本地 OmicsClaw subprocess 运行            │
+│  Datasets / Jobs / Artifacts on workspace disk  │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -26,46 +40,49 @@
 | 要求 | 说明 |
 |---|---|
 | OS | Linux（Ubuntu 20.04+、CentOS 7+、或同等） |
-| Python | 3.10+，带 `pip`，推荐 conda/venv 隔离 |
+| Python | 3.10+，推荐 conda/venv 隔离 |
 | OmicsClaw | 已完成 `git clone`，并安装 `pip install -e ".[desktop]"` |
-| SSH | 开启 sshd，允许公钥认证 |
-| 端口 | 无需公网端口 — 所有通信走 SSH tunnel |
-| 磁盘 | Workspace 目录至少 20 GB 可用空间 |
-| GPU（可选）| CUDA + PyTorch 用于 GPU 加速的 skill（如 scVI、Cell2Location）|
+| SSH | sshd 允许公钥认证 |
+| 对外端口 | 无需 — 所有通信走 SSH tunnel |
+| 磁盘 | Workspace 目录至少 20 GB 可用 |
+| GPU（可选）| CUDA + PyTorch，用于 GPU 加速的 skill（scVI、Cell2Location 等）|
 
 ### 本地（App 端）
 
 | 要求 | 说明 |
 |---|---|
-| OmicsClaw-App | 最新版本（含 Remote Connection 功能） |
-| SSH 密钥 | `~/.ssh/id_ed25519` 或 `~/.ssh/id_rsa` |
+| OmicsClaw-App | v0.1.3+（含 Runtimes 页面） |
+| SSH 密钥 | `~/.ssh/id_ed25519` 或 `~/.ssh/id_rsa`（未加密或已加入 ssh-agent） |
 | ssh-agent | 推荐运行（`eval $(ssh-agent) && ssh-add`） |
+
+> App 端**不**负责生成/导入 SSH 密钥、也不提示 passphrase — 必须是用户事先准备好并可用的私钥。
 
 ## 配置步骤
 
-### Step 1 — 启动远端 `oc app-server`
+### Step 1 — 在远端启动 `oc app-server`
 
-在远端服务器通过 SSH 登录后执行：
+SSH 登录到远端服务器后执行：
 
 ```bash
 # 激活 Python 环境
-source .venv/bin/activate   # 或 conda activate omicsclaw
+source .venv/bin/activate        # 或 conda activate omicsclaw
 
-# 设置 workspace 目录（所有数据、job产物存放位置）
+# Workspace：所有 dataset 登记、job 产物、artifact 的根目录
 export OMICSCLAW_WORKSPACE=/data/omicsclaw-workspace
 mkdir -p "$OMICSCLAW_WORKSPACE"
 
-# （推荐）设置 bearer token 作为第二层安全
+# 推荐：设置 Bearer token 作为 SSH 之外的第二层鉴权
 export OMICSCLAW_REMOTE_AUTH_TOKEN="your-secret-token-here"
 
-# 启动 app-server（绑定 127.0.0.1，不暴露公网）
+# 启动 app-server（仅绑 127.0.0.1，切勿暴露公网）
 oc app-server --host 127.0.0.1 --port 8765
 ```
 
-验证：
+自检：
+
 ```bash
 curl http://127.0.0.1:8765/health
-# 应返回 {"status":"ok","version":"..."}
+# => {"status":"ok","version":"..."}
 
 curl -X POST http://127.0.0.1:8765/connections/test \
   -H "Authorization: Bearer $OMICSCLAW_REMOTE_AUTH_TOKEN"
@@ -74,110 +91,130 @@ curl http://127.0.0.1:8765/env/doctor \
   -H "Authorization: Bearer $OMICSCLAW_REMOTE_AUTH_TOKEN"
 ```
 
-> `oc app-server` 就是 OmicsClaw-App 的统一后端入口。远程模式使用的 control-plane API、嵌入式 notebook 路由，以及可选的 KG 路由都挂在这个进程上，不需要额外再起一个 remote daemon。
+> `oc app-server` 是 OmicsClaw-App 所有后端能力的统一入口：remote control-plane、notebook 路由、可选的 KG 路由都挂在这个进程上，不需要再起额外 daemon。
 >
-> **后台运行**：可用 `nohup ... &` 或 `tmux`/`screen` 将 app-server 放到后台，这样断开 SSH 后服务不会停止。
+> **后台运行**：`nohup oc app-server ... &`、`tmux`、`screen`、`systemd --user` 均可；断开 SSH 后服务继续。
 
-### Step 2 — 在 OmicsClaw-App 创建 Connection Profile
+### Step 2 — 在 Runtimes 页面新建 Remote Runtime
 
-1. 打开 **Settings → Connections** 面板
-2. 点击 **"New Connection"**
-3. 填写：
+1. 打开 App，进入 **Runtimes** 页面（非 "Settings → Connections"，v0.1.3 起已合并）
+2. 点击 **"New Runtime"** → 选择新建 connection profile
+3. 填写字段（仅以下字段实际存库，**不再**有 "Remote Python" / "Remote Workspace" —— 前者是远端自身的环境，后者是远端 `OMICSCLAW_WORKSPACE` 的角色，不必在 App 中重复配置）：
 
-| 字段 | 示例值 | 说明 |
-|---|---|---|
-| Name | Lab GPU Server | 自定义名称 |
-| SSH Host | 192.168.1.100 | 服务器 IP 或 hostname |
-| SSH Port | 22 | 默认 22 |
-| SSH User | zhouwg | 远端 Linux 用户名 |
-| SSH Key Path | ~/.ssh/id_ed25519 | 本机私钥绝对路径 |
-| Remote Python | /path/to/.venv/bin/python | 远端 Python 路径（可选，用于环境检查） |
-| Remote Workspace | /data/omicsclaw-workspace | 与 Step 1 中 `OMICSCLAW_WORKSPACE` 一致 |
-| Remote App Server Port | 8765 | 与 Step 1 中 `--port` 一致 |
-| Auth Token | your-secret-token-here | 与 Step 1 中 `OMICSCLAW_REMOTE_AUTH_TOKEN` 一致 |
+| 字段 | 存库键 | 示例 | 说明 |
+|---|---|---|---|
+| Name | `name` | Lab GPU Server | UI 显示名 |
+| URL | `url` | `http://127.0.0.1:8765` | **direct-URL 场景必填**；SSH 场景可留空（以隧道为唯一入口） |
+| Auth Token | `auth_token` | your-secret-token-here | 与 Step 1 的 `OMICSCLAW_REMOTE_AUTH_TOKEN` 一致；存库后 GET 以 `***<后8位>` 遮罩返回 |
+| SSH Host | `ssh_host` | 192.168.1.100 | **填了它** = SSH-tunneled；**留空** = direct-URL profile |
+| SSH Port | `ssh_port` | 22 | 默认 22 |
+| SSH User | `ssh_user` | zhouwg | 远端 Linux 用户名 |
+| SSH Key Path | `ssh_key_path` | `~/.ssh/id_ed25519` | 本机私钥**绝对路径**（App 不管理密钥生命周期） |
+| Remote Port | `remote_port` | 8765 | 远端 `oc app-server` 监听端口；默认 8765 |
 
-4. 点击 **"Test Connection"** — App 会打通 SSH tunnel，并依次探测 `/connections/test` 和 `/env/doctor`
-5. 看到绿色 ✓ 后点 **"Save"**
+4. 保存 → 回到 Runtimes 列表 → 选中该条 → 点 **"Run Ping"**
+   - App 会先通过隧道 `GET /health`
+   - `/health` 通过后**自动带 Bearer token** 再探一次 `/env/doctor`（Bearer 校验同步做掉，防止"表面 200、实际 API 全 401"的假绿灯）
+5. 看到 `ok` 状态后点 **"Make Active"**
 
-### Step 3 — 切换到 Remote 模式
+> **SSH 隧道是动态端口的**：TunnelManager 打开 SSH 后会随机绑定一个本地 TCP 端口（写入 `active_tunnel_local_port` setting），后续所有 `backendFetch` 都走 `127.0.0.1:<dynamic>`。你**不需要**也**不应该**手动指定本地端口。
+>
+> 编辑 profile 的 host / user / key / port 字段时，隧道会依据指纹重开，避免"改了配置但仍连旧 host"。
 
-1. 在 **Settings → Backend** 面板将模式切换为 **Remote**
-2. 选择刚创建的 Connection Profile 为 **Active**
-3. 顶栏状态指示器变为 🌐（globe 图标） + 绿色 = 连接正常
+### Step 3 — 确认当前 Active Runtime
+
+- Runtimes 列表中，激活项会显示绿色圆点 + "Active" 标记
+- 顶栏状态指示器：
+  - 🖥 Bundled / Local Python
+  - 🌐 Remote SSH / Remote URL（绿色 = 隧道已开 + 最近健康探测 ok）
 
 ### Step 4 — 导入数据
 
-#### 方式 A：远端路径导入（大文件推荐）
+#### 方式 A：远端路径登记（大文件推荐）
 
-适用于已经在服务器上的 `.h5ad` / `.csv` 文件：
+文件已在服务器上（`.h5ad` / `.csv` / …）：
 
-1. 将文件 `scp` / `rsync` 到远端 workspace 下任意目录
-2. 在 App **Datasets** 面板点 **"Register Remote Path"**
-3. 输入远端绝对路径（如 `/data/omicsclaw-workspace/pbmc3k.h5ad`）
-4. 点 **"Register"** — 后端校验文件存在并登记为远端 dataset
+1. 用 `scp` / `rsync` 放到 `$OMICSCLAW_WORKSPACE` 下任意目录
+2. App **Datasets** 面板 → **"Register Remote Path"**
+3. 输入远端绝对路径，例如 `/data/omicsclaw-workspace/pbmc3k.h5ad`
+4. 点 **Register** — 后端校验存在并登记为远端 dataset（`storage_uri` 形如 `ssh://<profile_id>/path`）
 
 #### 方式 B：直接上传（小文件）
 
-1. 在 **Datasets** 面板点 **"Upload"**
-2. 选择本地文件 → App 通过 HTTP multipart 上传到远端
-3. 上传完成后显示 **synced** 状态
+1. **Datasets** → **"Upload"**
+2. 选本地文件，App 通过 HTTP multipart 上传到远端 workspace
+3. 完成后显示 **synced**
 
-> 当前 multipart 上传适合小文件使用；超过约 1 GiB 的数据更适合先 `scp` / `rsync` 到服务器，再走远端路径导入。
+> multipart 上传只适合小文件；超过约 1 GiB 推荐 `scp` / `rsync` 后走方式 A。
 
 ### Step 5 — 提交分析任务并观察执行
 
-1. 在聊天窗口描述分析需求，如 "对 pbmc3k.h5ad 运行 spatial-preprocessing"
-2. 或在 **Jobs** 面板手动提交：选择 Skill + 选择 Dataset + 设定参数 → Submit
-3. Job 会进入 **queued → running → succeeded/failed/canceled** 生命周期
-4. 后端会在远端 workspace 中创建持久化的 job 目录，并以本地 OmicsClaw subprocess 执行对应任务
-5. **实时日志**在 Jobs 面板以 SSE 流式显示；重连后会从已有日志继续补发
-6. 可随时点 **Cancel** 取消运行中的任务；已结束的任务可按需 **Retry**
+1. 在聊天窗口发起分析请求，例如 "对 pbmc3k.h5ad 运行 spatial-preprocessing"
+2. 或在 **Jobs** 面板手动提交：选择 Skill + Dataset + 参数 → Submit
+3. Job 生命周期：`queued → running → succeeded / failed / canceled`
+4. 后端在远端 workspace 建立持久化 job 目录，以本地 OmicsClaw subprocess 执行
+5. **实时日志**在 Jobs 面板通过 SSE 流式显示；重连后从已有日志续发
+6. 可随时 **Cancel**；已结束任务可 **Retry**
 
-### Step 6 — 查看产物与恢复上下文
+### Step 6 — 查看产物与上下文恢复
 
 1. Job 完成后进入 **Artifacts** 面板
-2. 按 job 分组浏览：`report.md` / `figures/*.png` / `result.json` / processed `.h5ad`
-3. 支持 Markdown / 图片预览，以及大文件下载
-4. 若连接中断后重新打开 App，运行中的 job 和会话可从远端状态继续恢复
+2. 按 job 分组浏览：`report.md` / `figures/*.png` / `result.json` / 处理后的 `.h5ad`
+3. 支持 Markdown / 图片预览 + 大文件下载
+4. 断线或 App 重启后，运行中的 job 与会话可从远端状态恢复
 
-> 失败任务通常会保留 `stdout.log` 以及诊断文件，便于在 App 中回看失败原因。
+> 失败任务会保留 `stdout.log` 和诊断文件（如 `diagnostics/env_doctor.json`），便于复盘。
+
+## Bundled vs Local vs Remote — 怎么选？
+
+| 场景 | 推荐 Runtime |
+|---|---|
+| 只在本机偶尔试一下，不想装 Python | `bundled`（Linux x64/arm64、macOS arm64、Windows x64 自带；Intel Mac 和 Windows arm64 回退 BYO） |
+| 已有 conda/venv 想复用科学计算栈 | `local-python`（Settings → Python environment 指定路径） |
+| 数据/算力在实验室服务器 | `remote-ssh`（本文主场景） |
+| 已有自己的 `ssh -L` / VPN / 直达公网 URL | `remote-url`（ssh_host 留空，只填 URL） |
+
+> Bundled runtime 只自带 app-server + notebook 必需的最小依赖，不包含 scanpy/numpy/pandas 等科学栈。**首次用到时**在 notebook 里 `!pip install scanpy anndata` 即可，包会装进 bundled 的 site-packages 并持久保留。详见 `OmicsClaw-App/docs/bundled-backend.md`。
 
 ## 安全说明
 
 | 层 | 机制 |
 |---|---|
-| 第一层 | SSH tunnel — 所有流量加密；远端 app-server 仅绑 `127.0.0.1` |
-| 第二层 | Bearer token — `OMICSCLAW_REMOTE_AUTH_TOKEN` 环境变量；App 会在受保护的 remote 请求上附加 `Authorization: Bearer <token>` |
-| 数据隔离 | 遗传数据不离开服务器 — App 只拉 artifact（图表/报告），原始 `.h5ad` 留在远端 |
+| 第一层 | SSH tunnel — 所有流量加密；远端 `oc app-server` 仅绑 `127.0.0.1` |
+| 第二层 | Bearer token — 来自远端 `OMICSCLAW_REMOTE_AUTH_TOKEN`；App 在受保护路由（`/connections/test`、`/env/doctor`、`/datasets`、`/jobs/*`…）上附加 `Authorization: Bearer <token>` |
+| Token 存储 | App 端 SQLite 明文存（与 `anthropic_auth_token` 处理方式一致），GET 路由以 `***<后8位>` 返回，PUT 识别遮罩值即跳过覆盖 |
+| 数据隔离 | 遗传/原始数据不离开服务器，App 只拉 artifact（图表/报告） |
 
-> **绝不要**将远端 app-server 的端口暴露到公网。如需从外网访问，始终通过 SSH tunnel 或 VPN。
+> **严禁**把远端 `oc app-server` 的端口暴露到公网。外网访问请始终走 SSH tunnel 或 VPN。
 
 ## Session Resume（断线恢复）
 
-- **Tunnel 断开**：App 自动检测断连；恢复后会重新订阅 job 事件并补齐日志
-- **窗口关闭再打开**：再次进入 Jobs / Chat 时，App 会从远端状态恢复仍在运行的任务
-- **服务器重启**：app-server 会把失去执行上下文的 orphaned `running` job 重新标记为失败，并保留诊断信息
+- **Tunnel 断开**：App 自动检测，恢复后重新订阅 job 事件、补齐日志；`active_tunnel_local_port` 按需重新发布
+- **窗口关闭再打开**：Jobs / Chat 会从远端状态恢复仍在运行的任务
+- **服务器重启**：`oc app-server` 会把失去执行上下文的 orphaned `running` job 标记为失败（`server_restart_orphaned_job`），保留诊断信息
 
 ## 故障排查
 
 | 症状 | 检查 |
 |---|---|
-| Test Connection 失败 | 先确认 `ssh -i <key> <user>@<host>` 能否登录；再确认远端 `oc app-server` 正在运行，token 和端口填写正确 |
-| 连接后显示不可用 | 确认 Active Profile 的 workspace / port 与远端实际配置一致；必要时直接 `curl /connections/test` 与 `/env/doctor` 复核 |
-| 提示 workspace 未配置或目录不存在 | 确认远端 `OMICSCLAW_WORKSPACE` 已设置且目录真实存在；如需切换目录，也可以让 App 重新同步 workspace |
-| 上传失败或提示文件过大 | 改用 `scp` / `rsync` 先传到服务器，再在 App 中走远端路径导入 |
-| Job 很快失败 | 先看该 job 的 `stdout.log`；如果有诊断文件，再看 `diagnostics/env_doctor.json` 和 `diagnostics/stdout.log` |
-| Job failed + `server_restart_orphaned_job` | 说明 app-server 重启前有未完成任务；这是保护性失败，不是数据损坏 |
-| SSE 日志不显示 | 检查 tunnel 状态，确认远端 `/jobs/{id}/events` 可达，且 App 当前连接的是正确 profile |
+| "Run Ping" `/health` 失败 | 先确认 `ssh -i <key> <user>@<host>` 本机能登录；再确认远端 `oc app-server` 在跑，port/remote_port 一致 |
+| `/health` 绿但 `/env/doctor` 红 | Bearer token 不匹配 — 核对远端 `OMICSCLAW_REMOTE_AUTH_TOKEN` 与 profile `auth_token`（注意 GET 返回的是 `***<后8位>` 遮罩） |
+| 顶栏图标绿但实际请求 401 | 同上；v0.1.3 起 ping 会主动做这层校验，老 profile 建议改密码后重新 Save |
+| 提示 workspace 未配置 / 目录不存在 | 远端 `OMICSCLAW_WORKSPACE` 未 export 或目录不存在 |
+| 上传失败 / 文件过大 | 改走 **Register Remote Path**，先 `scp` / `rsync` 上去 |
+| Job 很快失败 | 看 job 的 `stdout.log`；再看 `diagnostics/env_doctor.json` + `diagnostics/stdout.log` |
+| Job failed + `server_restart_orphaned_job` | app-server 重启前有未完成任务；这是保护性失败，非数据损坏 |
+| SSE 日志不显示 | 隧道是否存活、`active_tunnel_local_port` 是否仍有效、当前 Active Runtime 是否变过 |
+| 编辑了 SSH 字段没生效 | 指纹变更会触发隧道重开；如未发生，检查 Runtimes 页面是否仍 Active，或手动 "Make Active" 一次 |
 
 ## 常用命令速查
 
 ```bash
-# 远端：启动 app-server（前台，便于看日志）
+# 远端：前台启动 app-server（便于看日志）
 OMICSCLAW_WORKSPACE=/data/ws OMICSCLAW_REMOTE_AUTH_TOKEN=xxx \
   oc app-server --host 127.0.0.1 --port 8765
 
-# 远端：检查健康
+# 远端：环境体检（同 App 端 Run Ping 的第二阶段）
 curl http://127.0.0.1:8765/health
 curl -X POST http://127.0.0.1:8765/connections/test \
   -H "Authorization: Bearer xxx"
@@ -190,9 +227,19 @@ curl -X PUT http://127.0.0.1:8765/workspace \
   -H "Content-Type: application/json" \
   -d '{"workspace":"/data/ws"}'
 
-# 远端：列出 datasets
+# 远端：列 datasets / jobs
 curl http://127.0.0.1:8765/datasets -H "Authorization: Bearer xxx"
+curl http://127.0.0.1:8765/jobs     -H "Authorization: Bearer xxx"
 
-# 远端：列出 jobs
-curl http://127.0.0.1:8765/jobs -H "Authorization: Bearer xxx"
+# App 端（Next.js 路由，调试用）
+#   GET  /api/runtimes               列出所有 runtime（bundled/local/remote-ssh/remote-url）
+#   GET  /api/runtimes/:id           单个 runtime 详情 + 最近健康快照
+#   POST /api/runtimes/:id/ping      手动触发 /health + /env/doctor（含 Bearer 校验）
 ```
+
+## 相关文档
+
+- `OmicsClaw-App/docs/bundled-backend.md` — bundled runtime 的构建/目录契约与 BYO 回退规则
+- `OmicsClaw-App/docs/LOCAL_SETUP_GUIDE.md` — 本地 / bundled / local-python 的首次配置
+- `OmicsClaw-App/src/lib/runtimes/types.ts` — `RuntimeKind` / `RuntimeTransport` / 健康快照字段的权威定义
+- `OmicsClaw-App/src/types/index.ts`（`ConnectionProfile`）— Profile 字段及语义

--- a/docs/remote-connection-guide.md
+++ b/docs/remote-connection-guide.md
@@ -1,0 +1,179 @@
+# OmicsClaw Desktop 远程连接配置指南
+
+本文档说明如何在 OmicsClaw Desktop App 中配置**远程服务器执行**（control plane / execution plane 分离）。配置完成后，您的分析任务将在远端 Linux 服务器上运行，Desktop App 仅负责 UI 展示和交互。
+
+## 架构概览
+
+```
+┌────────── Desktop App (control plane) ──────────┐
+│  Next.js UI  ·  Electron                        │
+│  SSH Tunnel Manager → 127.0.0.1:<localPort>      │
+└──────────────────┬──────────────────────────────┘
+                   │  HTTPS/SSE over SSH tunnel
+┌──────────────────▼──────────────────────────────┐
+│  远程 Linux 服务器 (execution plane)              │
+│  oc app-server ── 127.0.0.1:8765                │
+│  SubprocessExecutor → python omicsclaw.py run    │
+│  Datasets / Jobs / Artifacts on workspace disk   │
+└─────────────────────────────────────────────────┘
+```
+
+## 前置条件
+
+### 远端服务器
+
+| 要求 | 说明 |
+|---|---|
+| OS | Linux（Ubuntu 20.04+、CentOS 7+、或同等） |
+| Python | 3.10+，带 `pip`，推荐 conda/venv 隔离 |
+| OmicsClaw | `git clone` 并 `pip install -e .` 完成 |
+| SSH | 开启 sshd，允许公钥认证 |
+| 端口 | 无需公网端口 — 所有通信走 SSH tunnel |
+| 磁盘 | Workspace 目录至少 20 GB 可用空间 |
+| GPU（可选）| CUDA + PyTorch 用于 GPU 加速的 skill（如 scVI、Cell2Location）|
+
+### 本地（Desktop App 端）
+
+| 要求 | 说明 |
+|---|---|
+| OmicsClaw Desktop | 最新版本（含 Remote Connection 功能） |
+| SSH 密钥 | `~/.ssh/id_ed25519` 或 `~/.ssh/id_rsa` |
+| ssh-agent | 推荐运行（`eval $(ssh-agent) && ssh-add`） |
+
+## 配置步骤
+
+### Step 1 — 启动远端 OmicsClaw App Server
+
+在远端服务器通过 SSH 登录后执行：
+
+```bash
+# 进入 OmicsClaw 仓库
+cd /path/to/OmicsClaw
+
+# 激活 Python 环境
+source .venv/bin/activate   # 或 conda activate omicsclaw
+
+# 设置 workspace 目录（所有数据、job产物存放位置）
+export OMICSCLAW_WORKSPACE=/data/omicsclaw-workspace
+mkdir -p "$OMICSCLAW_WORKSPACE"
+
+# （可选）设置 bearer token 作为第二层安全（推荐）
+export OMICSCLAW_REMOTE_AUTH_TOKEN="your-secret-token-here"
+
+# 启动 app-server（绑定 127.0.0.1，不暴露公网）
+python -m omicsclaw app-server --host 127.0.0.1 --port 8765
+```
+
+验证：
+```bash
+curl http://127.0.0.1:8765/health
+# 应返回 {"status":"ok","version":"..."}
+```
+
+> **后台运行**：可用 `nohup ... &` 或 `tmux`/`screen` 将 app-server 放到后台，这样断开 SSH 后服务不会停止。
+
+### Step 2 — 在 Desktop App 创建 Connection Profile
+
+1. 打开 **Settings → Connections** 面板
+2. 点击 **"New Connection"**
+3. 填写：
+
+| 字段 | 示例值 | 说明 |
+|---|---|---|
+| Name | Lab GPU Server | 自定义名称 |
+| SSH Host | 192.168.1.100 | 服务器 IP 或 hostname |
+| SSH Port | 22 | 默认 22 |
+| SSH User | zhouwg | 远端 Linux 用户名 |
+| SSH Key Path | ~/.ssh/id_ed25519 | 本机私钥绝对路径 |
+| Remote Python | /path/to/.venv/bin/python | 远端 Python 路径（可选，用于环境检查） |
+| Remote Workspace | /data/omicsclaw-workspace | 与 Step 1 中 `OMICSCLAW_WORKSPACE` 一致 |
+| Remote App Server Port | 8765 | 与 Step 1 中 `--port` 一致 |
+| Auth Token | your-secret-token-here | 与 Step 1 中 `OMICSCLAW_REMOTE_AUTH_TOKEN` 一致（留空则不使用 token） |
+
+4. 点击 **"Test Connection"** — App 会打通 SSH tunnel → 探测 `/connections/test` + `/env/doctor`
+5. 看到绿色 ✓ 后点 **"Save"**
+
+### Step 3 — 切换到 Remote 模式
+
+1. 在 **Settings → Backend** 面板将模式切换为 **Remote**
+2. 选择刚创建的 Connection Profile 为 **Active**
+3. 顶栏状态指示器变为 🌐（globe 图标） + 绿色 = 连接正常
+
+### Step 4 — 导入数据
+
+#### 方式 A：远端路径注册（大文件推荐）
+
+适用于已经在服务器上的 `.h5ad` / `.csv` 文件：
+
+1. 将文件 `scp` / `rsync` 到远端 workspace 下任意目录
+2. 在 App **Datasets** 面板点 **"Register Remote Path"**
+3. 输入远端绝对路径（如 `/data/omicsclaw-workspace/pbmc3k.h5ad`）
+4. 点 **"Register"** — 后端校验文件存在 + 计算 checksum
+
+#### 方式 B：直接上传（< 1 GB 小文件）
+
+1. 在 **Datasets** 面板点 **"Upload"**
+2. 选择本地文件 → App 通过 HTTP multipart 上传到远端
+3. 上传完成后显示 **synced** 状态
+
+### Step 5 — 提交分析任务
+
+1. 在聊天窗口描述分析需求，如 "对 pbmc3k.h5ad 运行 spatial-preprocessing"
+2. 或在 **Jobs** 面板手动提交：选择 Skill + 选择 Dataset + 设定参数 → Submit
+3. Job 进入 **queued → running → succeeded/failed** 生命周期
+4. **实时日志**在 Jobs 面板以 SSE 流式显示（断线重连自动续传）
+5. 可随时点 **Cancel** 取消运行中的任务（subprocess 会被 SIGTERM）
+
+### Step 6 — 查看产物
+
+1. Job 完成后进入 **Artifacts** 面板
+2. 按 job 分组浏览：`report.md` / `figures/*.png` / `result.json` / processed `.h5ad`
+3. 支持 Markdown / 图片预览、Range-aware 大文件下载
+
+## 安全说明
+
+| 层 | 机制 |
+|---|---|
+| 第一层 | SSH tunnel — 所有流量加密；远端 app-server 仅绑 `127.0.0.1` |
+| 第二层 | Bearer token — `OMICSCLAW_REMOTE_AUTH_TOKEN` 环境变量；App 自动在每个请求附加 `Authorization: Bearer <token>` |
+| 数据隔离 | 遗传数据不离开服务器 — App 只拉 artifact（图表/报告），原始 `.h5ad` 留在远端 |
+
+> **绝不要**将远端 app-server 的端口暴露到公网。如需从外网访问，始终通过 SSH tunnel 或 VPN。
+
+## Session Resume（断线恢复）
+
+- **Tunnel 断开**：App 自动检测 → 显示断连提示 → 重连后自动续传 SSE 日志（Last-Event-ID cursor）
+- **窗口关闭再打开**：进入 Jobs 面板 → 之前 running 的 job 仍显示 → SSE 重订阅
+- **服务器重启**：app-server 启动时自动 reconcile 孤儿 running job → 标记为 failed 并保存诊断
+
+## 故障排查
+
+| 症状 | 检查 |
+|---|---|
+| Test Connection 失败 | `ssh -i <key> <user>@<host>` 能否登录？远端 app-server 是否在运行？ |
+| 连接后显示 "unavailable" | 确认 Active Profile 的 port/workspace 与远端 app-server 参数一致 |
+| Job 一直 queued | 查看远端 app-server 的 stdout 是否有错误日志 |
+| Job failed + "executor_not_implemented" | 远端 OmicsClaw 版本过旧；`pip install -e .` 更新到最新 |
+| Job failed + "server_restart_orphaned_job" | 正常——说明 app-server 重启前有未完成的 job，已安全标记为失败 |
+| SSE 日志不显示 | 检查 tunnel 状态（顶栏图标）；确认远端 `/jobs/{id}/events` 可达 |
+| Dataset 删除后重新出现 | 升级 Desktop App 到最新版本（修复了 DELETE 未代理到远端的 bug） |
+| Env Doctor 显示 "not_supported" | 远端 OmicsClaw 版本不含 `/env/doctor` 端点；更新到最新 |
+
+## 常用命令速查
+
+```bash
+# 远端：启动 app-server（前台，便于看日志）
+OMICSCLAW_WORKSPACE=/data/ws OMICSCLAW_REMOTE_AUTH_TOKEN=xxx \
+  python -m omicsclaw app-server --host 127.0.0.1 --port 8765
+
+# 远端：检查健康
+curl http://127.0.0.1:8765/health
+curl http://127.0.0.1:8765/connections/test -X POST
+curl http://127.0.0.1:8765/env/doctor
+
+# 远端：列出 datasets
+curl http://127.0.0.1:8765/datasets -H "Authorization: Bearer xxx"
+
+# 远端：列出 jobs
+curl http://127.0.0.1:8765/jobs -H "Authorization: Bearer xxx"
+```

--- a/docs/remote-connection-guide.md
+++ b/docs/remote-connection-guide.md
@@ -1,11 +1,11 @@
-# OmicsClaw Desktop 远程连接配置指南
+# OmicsClaw-App 远程连接配置指南
 
-本文档说明如何在 OmicsClaw Desktop App 中配置**远程服务器执行**（control plane / execution plane 分离）。配置完成后，您的分析任务将在远端 Linux 服务器上运行，Desktop App 仅负责 UI 展示和交互。
+本文档说明如何在 OmicsClaw-App 中配置**远程服务器执行**。配置完成后，App 保留在本地负责 UI、聊天和结果浏览，数据处理与作业执行则放在远端 Linux 服务器上。
 
 ## 架构概览
 
 ```
-┌────────── Desktop App (control plane) ──────────┐
+┌────────── OmicsClaw-App (control plane) ────────┐
 │  Next.js UI  ·  Electron                        │
 │  SSH Tunnel Manager → 127.0.0.1:<localPort>      │
 └──────────────────┬──────────────────────────────┘
@@ -13,7 +13,8 @@
 ┌──────────────────▼──────────────────────────────┐
 │  远程 Linux 服务器 (execution plane)              │
 │  oc app-server ── 127.0.0.1:8765                │
-│  SubprocessExecutor → python omicsclaw.py run    │
+│  Remote control plane + notebook routes          │
+│  Remote jobs run as local OmicsClaw subprocesses │
 │  Datasets / Jobs / Artifacts on workspace disk   │
 └─────────────────────────────────────────────────┘
 ```
@@ -26,30 +27,27 @@
 |---|---|
 | OS | Linux（Ubuntu 20.04+、CentOS 7+、或同等） |
 | Python | 3.10+，带 `pip`，推荐 conda/venv 隔离 |
-| OmicsClaw | `git clone` 并 `pip install -e .` 完成 |
+| OmicsClaw | 已完成 `git clone`，并安装 `pip install -e ".[desktop]"` |
 | SSH | 开启 sshd，允许公钥认证 |
 | 端口 | 无需公网端口 — 所有通信走 SSH tunnel |
 | 磁盘 | Workspace 目录至少 20 GB 可用空间 |
 | GPU（可选）| CUDA + PyTorch 用于 GPU 加速的 skill（如 scVI、Cell2Location）|
 
-### 本地（Desktop App 端）
+### 本地（App 端）
 
 | 要求 | 说明 |
 |---|---|
-| OmicsClaw Desktop | 最新版本（含 Remote Connection 功能） |
+| OmicsClaw-App | 最新版本（含 Remote Connection 功能） |
 | SSH 密钥 | `~/.ssh/id_ed25519` 或 `~/.ssh/id_rsa` |
 | ssh-agent | 推荐运行（`eval $(ssh-agent) && ssh-add`） |
 
 ## 配置步骤
 
-### Step 1 — 启动远端 OmicsClaw App Server
+### Step 1 — 启动远端 `oc app-server`
 
 在远端服务器通过 SSH 登录后执行：
 
 ```bash
-# 进入 OmicsClaw 仓库
-cd /path/to/OmicsClaw
-
 # 激活 Python 环境
 source .venv/bin/activate   # 或 conda activate omicsclaw
 
@@ -57,22 +55,30 @@ source .venv/bin/activate   # 或 conda activate omicsclaw
 export OMICSCLAW_WORKSPACE=/data/omicsclaw-workspace
 mkdir -p "$OMICSCLAW_WORKSPACE"
 
-# （可选）设置 bearer token 作为第二层安全（推荐）
+# （推荐）设置 bearer token 作为第二层安全
 export OMICSCLAW_REMOTE_AUTH_TOKEN="your-secret-token-here"
 
 # 启动 app-server（绑定 127.0.0.1，不暴露公网）
-python -m omicsclaw app-server --host 127.0.0.1 --port 8765
+oc app-server --host 127.0.0.1 --port 8765
 ```
 
 验证：
 ```bash
 curl http://127.0.0.1:8765/health
 # 应返回 {"status":"ok","version":"..."}
+
+curl -X POST http://127.0.0.1:8765/connections/test \
+  -H "Authorization: Bearer $OMICSCLAW_REMOTE_AUTH_TOKEN"
+
+curl http://127.0.0.1:8765/env/doctor \
+  -H "Authorization: Bearer $OMICSCLAW_REMOTE_AUTH_TOKEN"
 ```
 
+> `oc app-server` 就是 OmicsClaw-App 的统一后端入口。远程模式使用的 control-plane API、嵌入式 notebook 路由，以及可选的 KG 路由都挂在这个进程上，不需要额外再起一个 remote daemon。
+>
 > **后台运行**：可用 `nohup ... &` 或 `tmux`/`screen` 将 app-server 放到后台，这样断开 SSH 后服务不会停止。
 
-### Step 2 — 在 Desktop App 创建 Connection Profile
+### Step 2 — 在 OmicsClaw-App 创建 Connection Profile
 
 1. 打开 **Settings → Connections** 面板
 2. 点击 **"New Connection"**
@@ -88,9 +94,9 @@ curl http://127.0.0.1:8765/health
 | Remote Python | /path/to/.venv/bin/python | 远端 Python 路径（可选，用于环境检查） |
 | Remote Workspace | /data/omicsclaw-workspace | 与 Step 1 中 `OMICSCLAW_WORKSPACE` 一致 |
 | Remote App Server Port | 8765 | 与 Step 1 中 `--port` 一致 |
-| Auth Token | your-secret-token-here | 与 Step 1 中 `OMICSCLAW_REMOTE_AUTH_TOKEN` 一致（留空则不使用 token） |
+| Auth Token | your-secret-token-here | 与 Step 1 中 `OMICSCLAW_REMOTE_AUTH_TOKEN` 一致 |
 
-4. 点击 **"Test Connection"** — App 会打通 SSH tunnel → 探测 `/connections/test` + `/env/doctor`
+4. 点击 **"Test Connection"** — App 会打通 SSH tunnel，并依次探测 `/connections/test` 和 `/env/doctor`
 5. 看到绿色 ✓ 后点 **"Save"**
 
 ### Step 3 — 切换到 Remote 模式
@@ -101,75 +107,88 @@ curl http://127.0.0.1:8765/health
 
 ### Step 4 — 导入数据
 
-#### 方式 A：远端路径注册（大文件推荐）
+#### 方式 A：远端路径导入（大文件推荐）
 
 适用于已经在服务器上的 `.h5ad` / `.csv` 文件：
 
 1. 将文件 `scp` / `rsync` 到远端 workspace 下任意目录
 2. 在 App **Datasets** 面板点 **"Register Remote Path"**
 3. 输入远端绝对路径（如 `/data/omicsclaw-workspace/pbmc3k.h5ad`）
-4. 点 **"Register"** — 后端校验文件存在 + 计算 checksum
+4. 点 **"Register"** — 后端校验文件存在并登记为远端 dataset
 
-#### 方式 B：直接上传（< 1 GB 小文件）
+#### 方式 B：直接上传（小文件）
 
 1. 在 **Datasets** 面板点 **"Upload"**
 2. 选择本地文件 → App 通过 HTTP multipart 上传到远端
 3. 上传完成后显示 **synced** 状态
 
-### Step 5 — 提交分析任务
+> 当前 multipart 上传适合小文件使用；超过约 1 GiB 的数据更适合先 `scp` / `rsync` 到服务器，再走远端路径导入。
+
+### Step 5 — 提交分析任务并观察执行
 
 1. 在聊天窗口描述分析需求，如 "对 pbmc3k.h5ad 运行 spatial-preprocessing"
 2. 或在 **Jobs** 面板手动提交：选择 Skill + 选择 Dataset + 设定参数 → Submit
-3. Job 进入 **queued → running → succeeded/failed** 生命周期
-4. **实时日志**在 Jobs 面板以 SSE 流式显示（断线重连自动续传）
-5. 可随时点 **Cancel** 取消运行中的任务（subprocess 会被 SIGTERM）
+3. Job 会进入 **queued → running → succeeded/failed/canceled** 生命周期
+4. 后端会在远端 workspace 中创建持久化的 job 目录，并以本地 OmicsClaw subprocess 执行对应任务
+5. **实时日志**在 Jobs 面板以 SSE 流式显示；重连后会从已有日志继续补发
+6. 可随时点 **Cancel** 取消运行中的任务；已结束的任务可按需 **Retry**
 
-### Step 6 — 查看产物
+### Step 6 — 查看产物与恢复上下文
 
 1. Job 完成后进入 **Artifacts** 面板
 2. 按 job 分组浏览：`report.md` / `figures/*.png` / `result.json` / processed `.h5ad`
-3. 支持 Markdown / 图片预览、Range-aware 大文件下载
+3. 支持 Markdown / 图片预览，以及大文件下载
+4. 若连接中断后重新打开 App，运行中的 job 和会话可从远端状态继续恢复
+
+> 失败任务通常会保留 `stdout.log` 以及诊断文件，便于在 App 中回看失败原因。
 
 ## 安全说明
 
 | 层 | 机制 |
 |---|---|
 | 第一层 | SSH tunnel — 所有流量加密；远端 app-server 仅绑 `127.0.0.1` |
-| 第二层 | Bearer token — `OMICSCLAW_REMOTE_AUTH_TOKEN` 环境变量；App 自动在每个请求附加 `Authorization: Bearer <token>` |
+| 第二层 | Bearer token — `OMICSCLAW_REMOTE_AUTH_TOKEN` 环境变量；App 会在受保护的 remote 请求上附加 `Authorization: Bearer <token>` |
 | 数据隔离 | 遗传数据不离开服务器 — App 只拉 artifact（图表/报告），原始 `.h5ad` 留在远端 |
 
 > **绝不要**将远端 app-server 的端口暴露到公网。如需从外网访问，始终通过 SSH tunnel 或 VPN。
 
 ## Session Resume（断线恢复）
 
-- **Tunnel 断开**：App 自动检测 → 显示断连提示 → 重连后自动续传 SSE 日志（Last-Event-ID cursor）
-- **窗口关闭再打开**：进入 Jobs 面板 → 之前 running 的 job 仍显示 → SSE 重订阅
-- **服务器重启**：app-server 启动时自动 reconcile 孤儿 running job → 标记为 failed 并保存诊断
+- **Tunnel 断开**：App 自动检测断连；恢复后会重新订阅 job 事件并补齐日志
+- **窗口关闭再打开**：再次进入 Jobs / Chat 时，App 会从远端状态恢复仍在运行的任务
+- **服务器重启**：app-server 会把失去执行上下文的 orphaned `running` job 重新标记为失败，并保留诊断信息
 
 ## 故障排查
 
 | 症状 | 检查 |
 |---|---|
-| Test Connection 失败 | `ssh -i <key> <user>@<host>` 能否登录？远端 app-server 是否在运行？ |
-| 连接后显示 "unavailable" | 确认 Active Profile 的 port/workspace 与远端 app-server 参数一致 |
-| Job 一直 queued | 查看远端 app-server 的 stdout 是否有错误日志 |
-| Job failed + "executor_not_implemented" | 远端 OmicsClaw 版本过旧；`pip install -e .` 更新到最新 |
-| Job failed + "server_restart_orphaned_job" | 正常——说明 app-server 重启前有未完成的 job，已安全标记为失败 |
-| SSE 日志不显示 | 检查 tunnel 状态（顶栏图标）；确认远端 `/jobs/{id}/events` 可达 |
-| Dataset 删除后重新出现 | 升级 Desktop App 到最新版本（修复了 DELETE 未代理到远端的 bug） |
-| Env Doctor 显示 "not_supported" | 远端 OmicsClaw 版本不含 `/env/doctor` 端点；更新到最新 |
+| Test Connection 失败 | 先确认 `ssh -i <key> <user>@<host>` 能否登录；再确认远端 `oc app-server` 正在运行，token 和端口填写正确 |
+| 连接后显示不可用 | 确认 Active Profile 的 workspace / port 与远端实际配置一致；必要时直接 `curl /connections/test` 与 `/env/doctor` 复核 |
+| 提示 workspace 未配置或目录不存在 | 确认远端 `OMICSCLAW_WORKSPACE` 已设置且目录真实存在；如需切换目录，也可以让 App 重新同步 workspace |
+| 上传失败或提示文件过大 | 改用 `scp` / `rsync` 先传到服务器，再在 App 中走远端路径导入 |
+| Job 很快失败 | 先看该 job 的 `stdout.log`；如果有诊断文件，再看 `diagnostics/env_doctor.json` 和 `diagnostics/stdout.log` |
+| Job failed + `server_restart_orphaned_job` | 说明 app-server 重启前有未完成任务；这是保护性失败，不是数据损坏 |
+| SSE 日志不显示 | 检查 tunnel 状态，确认远端 `/jobs/{id}/events` 可达，且 App 当前连接的是正确 profile |
 
 ## 常用命令速查
 
 ```bash
 # 远端：启动 app-server（前台，便于看日志）
 OMICSCLAW_WORKSPACE=/data/ws OMICSCLAW_REMOTE_AUTH_TOKEN=xxx \
-  python -m omicsclaw app-server --host 127.0.0.1 --port 8765
+  oc app-server --host 127.0.0.1 --port 8765
 
 # 远端：检查健康
 curl http://127.0.0.1:8765/health
-curl http://127.0.0.1:8765/connections/test -X POST
-curl http://127.0.0.1:8765/env/doctor
+curl -X POST http://127.0.0.1:8765/connections/test \
+  -H "Authorization: Bearer xxx"
+curl http://127.0.0.1:8765/env/doctor \
+  -H "Authorization: Bearer xxx"
+
+# 远端：查看 / 同步 workspace
+curl http://127.0.0.1:8765/workspace
+curl -X PUT http://127.0.0.1:8765/workspace \
+  -H "Content-Type: application/json" \
+  -d '{"workspace":"/data/ws"}'
 
 # 远端：列出 datasets
 curl http://127.0.0.1:8765/datasets -H "Authorization: Bearer xxx"

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -24,6 +24,9 @@ preserve the reference skills' core design:
 
 Recent additions:
 
+- `plans/2026-04-15-remote-contract-hardening.md` — harden the new remote
+  control-plane contract so session ownership, job state transitions, and
+  persisted metadata stay truthful before the real Executor lands
 - `plans/2026-04-14-provider-model-normalization.md` — normalize stale
   cross-provider model leftovers so backend status surfaces stop exposing
   contradictory provider/model pairs

--- a/docs/superpowers/plans/2026-04-16-remote-connection-guide-refresh.md
+++ b/docs/superpowers/plans/2026-04-16-remote-connection-guide-refresh.md
@@ -1,0 +1,67 @@
+# 2026-04-16 Remote Connection Guide Refresh
+
+## Goal
+
+Refresh `docs/remote-connection-guide.md` so it matches the current
+`oc app-server` + remote control-plane behavior after the recent remote/app
+backend optimizations, while keeping README-level detail out of the guide.
+
+## Scope
+
+- Update the remote connection guide's setup, architecture, and troubleshooting
+  language to match the current implementation.
+- Remove or rewrite statements that are now outdated after the executor and
+  remote route hardening work.
+- Keep the guide user-facing; do not turn it into a route-by-route API spec.
+
+## Non-Goals
+
+- No backend code changes.
+- No OmicsClaw-App code changes.
+- No new remote features beyond documenting what already exists.
+
+## Assumptions / Constraints
+
+- Source of truth is the current Python backend implementation under
+  `omicsclaw/app/server.py`, `omicsclaw/remote/`, and the relevant tests.
+- README already carries the high-level remote-mode summary, so this guide can
+  focus on practical setup and operations.
+- Verification for this task is direct inspection of the edited docs and diff.
+
+## File Map
+
+- Modify `docs/remote-connection-guide.md`
+- Modify `docs/superpowers/plans/README.md`
+- Add `docs/superpowers/plans/2026-04-16-remote-connection-guide-refresh.md`
+
+## Ordered Tasks
+
+1. Compare the existing guide against the current backend behavior.
+2. Record the refresh plan and update the plans index.
+3. Rewrite the guide sections that are stale:
+   - architecture / prerequisites
+   - remote server startup
+   - connection-profile guidance
+   - dataset import / upload advice
+   - job execution / logs / artifacts wording
+   - troubleshooting entries
+4. Re-read the edited sections and inspect the diff for correctness and scope.
+
+## Verification Strategy
+
+- Inspect the exact edited sections in `docs/remote-connection-guide.md`.
+- Inspect `git diff -- docs/remote-connection-guide.md docs/superpowers/plans/README.md`.
+- Confirm all doc claims line up with:
+  - `README.md`
+  - `omicsclaw/app/server.py`
+  - `omicsclaw/remote/`
+  - relevant tests under `tests/test_remote_*.py` and `tests/test_app_server.py`
+
+## Acceptance Criteria
+
+- The guide no longer claims remote execution is stubbed or blocked on
+  `executor_not_implemented` as the normal path.
+- Startup instructions use the current `oc app-server` flow.
+- The guide reflects current workspace/auth behavior and large-file import
+  guidance.
+- Troubleshooting advice matches current backend behavior and supported routes.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -5,6 +5,9 @@ development work.
 
 ## Tracked Entries
 
+- [2026-04-15-remote-contract-hardening.md](2026-04-15-remote-contract-hardening.md)
+  — harden the new remote control-plane contract so session ownership, job
+  state transitions, and metadata stay truthful before the real Executor lands.
 - [2026-04-14-provider-model-normalization.md](2026-04-14-provider-model-normalization.md)
   — normalize stale cross-provider model leftovers so backend status surfaces
   expose a coherent provider/model pair.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -5,6 +5,10 @@ development work.
 
 ## Tracked Entries
 
+- [2026-04-16-remote-connection-guide-refresh.md](2026-04-16-remote-connection-guide-refresh.md)
+  — refresh the remote connection guide so it matches the current
+  `oc app-server` + remote control-plane behavior after the latest backend
+  optimizations.
 - [2026-04-15-remote-contract-hardening.md](2026-04-15-remote-contract-hardening.md)
   — harden the new remote control-plane contract so session ownership, job
   state transitions, and metadata stay truthful before the real Executor lands.

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -1861,6 +1861,86 @@ async def set_workspace(req: WorkspaceRequest):
 
 
 # ---------------------------------------------------------------------------
+# GET /files/browse — directory browser for remote-runtime folder pickers
+# ---------------------------------------------------------------------------
+#
+# Desktop clients need to let the user pick a workspace directory that
+# lives on THIS host (the backend's filesystem), not on the client's
+# local machine. The App's local `/api/files/browse` only works for
+# co-located backends; when the backend is on a remote SSH runtime the
+# App proxies here instead.
+#
+# Read-only. Authorization is the same bearer-token middleware the rest
+# of the app_server already enforces, plus OS filesystem permissions
+# (we can only surface what the backend process itself can read). The
+# endpoint deliberately does NOT consult TRUSTED_DATA_DIRS — the user
+# is in the middle of PICKING a workspace, so gating by trust would
+# prevent the first-time-pick flow. `PUT /workspace` does the
+# is_dir() + absolute-path validation when the choice is committed.
+
+@app.get("/files/browse")
+async def browse_directories(path: Optional[str] = None):
+    """List subdirectories under `path` (or $HOME when omitted).
+
+    Response shape matches the App's existing local
+    `/api/files/browse` route so `<FolderPicker/>` can consume either
+    implementation interchangeably.
+    """
+    base_raw = (path or "").strip()
+    try:
+        base = Path(base_raw).expanduser() if base_raw else Path.home()
+        base = base.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise HTTPException(404, detail="directory does not exist") from exc
+    except (OSError, RuntimeError) as exc:
+        raise HTTPException(400, detail=f"invalid path: {exc}") from exc
+
+    if not base.is_dir():
+        raise HTTPException(400, detail="path is not a directory")
+
+    directories: list[dict[str, Any]] = []
+    try:
+        entries = list(base.iterdir())
+    except PermissionError as exc:
+        raise HTTPException(403, detail="permission denied") from exc
+
+    for entry in entries:
+        # Skip dotfiles to match the App's local implementation — users
+        # expect the same filter on both sides, and cluttered pickers
+        # get ignored.
+        if entry.name.startswith("."):
+            continue
+        is_symlink = entry.is_symlink()
+        try:
+            is_dir = entry.is_dir()  # follows symlinks
+        except OSError:
+            continue
+        if not is_dir:
+            continue
+        item: dict[str, Any] = {
+            "name": entry.name,
+            "path": str(entry),
+            "isSymbolicLink": is_symlink,
+        }
+        if is_symlink:
+            try:
+                item["targetPath"] = str(entry.resolve())
+            except OSError:
+                # Broken symlink — skip rather than return a bogus entry.
+                continue
+        directories.append(item)
+
+    directories.sort(key=lambda d: d["name"].lower())
+
+    parent_path = str(base.parent) if str(base.parent) != str(base) else None
+    return {
+        "current": str(base),
+        "parent": parent_path,
+        "directories": directories,
+    }
+
+
+# ---------------------------------------------------------------------------
 # GET /health
 # ---------------------------------------------------------------------------
 

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -53,6 +53,12 @@ except ImportError as _nb_err:
     install_live_session_support = None  # type: ignore[assignment]
     notebook_router = None  # type: ignore[assignment]
 from omicsclaw.runtime.policy_state import ToolPolicyState
+from omicsclaw.remote.routers.jobs import (
+    append_job_stdout_line,
+    bind_chat_stream_job,
+    finalize_chat_stream_job,
+)
+from omicsclaw.remote.storage import resolve_workspace
 from omicsclaw.version import __version__
 
 # ---------------------------------------------------------------------------
@@ -471,6 +477,10 @@ _register_optional_kg_router(app)
 if _NOTEBOOK_AVAILABLE:
     app.include_router(notebook_router, prefix="/notebook", tags=["notebook"])
 
+# Remote control-plane API consumed by OmicsClaw-App (see omicsclaw/remote/).
+from omicsclaw.remote.app_integration import register_remote_routers  # noqa: E402
+register_remote_routers(app)
+
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -487,6 +497,7 @@ class ProviderConfig(BaseModel):
 class ChatRequest(BaseModel):
     """POST /chat/stream body."""
     session_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    job_id: str = ""
     content: str
     workspace: str = ""
     pipeline_workspace: str = ""
@@ -957,6 +968,34 @@ async def chat_stream(req: ChatRequest):
     """
     core = _get_core()
     session_id = req.session_id
+    bound_remote_job_id = str(req.job_id or "").strip()
+    bound_remote_workspace: Path | None = None
+    if bound_remote_job_id:
+        try:
+            bound_remote_workspace = resolve_workspace()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        try:
+            bound_job = bind_chat_stream_job(
+                bound_remote_workspace,
+                bound_remote_job_id,
+                session_id=session_id,
+            )
+        except LookupError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        # ``bind_chat_stream_job`` intentionally passes through
+        # already-canceled jobs so the cancel handler can finalize them
+        # without clobbering state — but that's not a valid input for
+        # starting the tool loop. Bail with 409 so the caller drops the
+        # request instead of running a chat turn whose job row is
+        # permanently ``canceled``.
+        if bound_job.status == "canceled":
+            raise HTTPException(
+                status_code=409,
+                detail=f"chat stream job was canceled before bind: {bound_remote_job_id}",
+            )
 
     # If a provider config override is supplied, re-init the core.
     # NOTE: In a production multi-tenant setup you would scope this per-request
@@ -1091,7 +1130,32 @@ async def chat_stream(req: ChatRequest):
         "output_style": req.output_style or "",
     }
 
+    def _finalize_bound_remote_job(status: str, error: str | None = None) -> None:
+        if not bound_remote_workspace or not bound_remote_job_id:
+            return
+        try:
+            finalize_chat_stream_job(
+                bound_remote_workspace,
+                bound_remote_job_id,
+                status=status,  # type: ignore[arg-type]
+                error=error,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to finalize bound remote chat job %s with status %s",
+                bound_remote_job_id,
+                status,
+            )
+
     async def _queue_event(event_type: str, data: Any) -> None:
+        if (
+            bound_remote_workspace is not None
+            and bound_remote_job_id
+            and event_type == "tool_output"
+            and isinstance(data, str)
+        ):
+            for line in data.splitlines():
+                append_job_stdout_line(bound_remote_workspace, bound_remote_job_id, line)
         await queue.put({"type": event_type, "data": data})
 
     def _current_tool_use_id(tool_name: str) -> str:
@@ -1562,11 +1626,14 @@ async def chat_stream(req: ChatRequest):
                     default=str,
                 ),
             )
+            _finalize_bound_remote_job("succeeded")
         except asyncio.CancelledError:
             await _queue_event("error", "Session aborted")
+            _finalize_bound_remote_job("canceled", error="session_aborted")
         except Exception as exc:
             logger.exception("llm_tool_loop error for session %s", session_id)
             await _queue_event("error", str(exc))
+            _finalize_bound_remote_job("failed", error=str(exc))
         finally:
             for permission_request_id in list(permission_request_ids):
                 pending = _pending_permission_requests.pop(permission_request_id, None)

--- a/omicsclaw/execution/executors/__init__.py
+++ b/omicsclaw/execution/executors/__init__.py
@@ -1,0 +1,16 @@
+"""Executor interface and implementations for remote job dispatch."""
+
+from .base import Executor, JobContext, JobOutcome
+from .default import build_default_executor, default_command_factory
+from .local import LocalExecutor
+from .subprocess import SubprocessExecutor
+
+__all__ = [
+    "Executor",
+    "JobContext",
+    "JobOutcome",
+    "LocalExecutor",
+    "SubprocessExecutor",
+    "build_default_executor",
+    "default_command_factory",
+]

--- a/omicsclaw/execution/executors/base.py
+++ b/omicsclaw/execution/executors/base.py
@@ -1,0 +1,49 @@
+"""Executor Protocol + data contracts.
+
+A job lifecycle is: router creates a ``JobContext`` describing the work
+→ executor ``run``s it asynchronously → returns a ``JobOutcome`` that
+the router maps to queued/running/succeeded/failed. The executor owns
+process management and log capture; the router owns persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class JobContext:
+    """Everything an executor needs to run a job.
+
+    ``stdout_log`` and ``artifact_root`` are pre-resolved absolute paths
+    chosen by the router; the executor must not invent alternative
+    locations (otherwise the artifacts router can't discover them).
+    """
+
+    job_id: str
+    workspace: Path
+    skill: str
+    inputs: dict[str, Any]
+    params: dict[str, Any]
+    artifact_root: Path
+    stdout_log: Path
+
+
+@dataclass(frozen=True)
+class JobOutcome:
+    """Terminal state reported by an executor.
+
+    ``stdout_text`` carries a tail / summary that the router will persist
+    verbatim into ``stdout.log`` for the diagnostics artifact bundle.
+    """
+
+    exit_code: int
+    error: Optional[str] = None
+    stdout_text: str = ""
+
+
+@runtime_checkable
+class Executor(Protocol):
+    async def run(self, ctx: JobContext) -> JobOutcome: ...

--- a/omicsclaw/execution/executors/default.py
+++ b/omicsclaw/execution/executors/default.py
@@ -1,0 +1,71 @@
+"""``JobContext`` → ``python omicsclaw.py run ...`` argv factory.
+
+Mapping from wire contract (``JobContext.inputs`` + ``JobContext.params``)
+to CLI argv:
+
+- ``inputs["demo"] == True``   → ``--demo``
+- ``inputs["input"] | "path"`` → ``--input <value>`` (first non-empty wins)
+- ``params["<key>"] == True``  → ``--<kebab-key>`` (standalone flag)
+- ``params["<key>"] == False`` → omitted (NOT ``--no-...``)
+- ``params["<key>"] is None``  → omitted
+- other ``params["<key>"]``     → ``--<kebab-key> <str(value)>``
+
+The factory is a pure ``JobContext -> list[str]`` function so it can be
+unit-tested without spawning, and so future executors (Slurm, SSH) can
+reuse the same argv shape.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from omicsclaw.autoagent.constants import param_to_cli_flag
+
+from .base import JobContext
+from .subprocess import SubprocessExecutor
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_ENTRY_POINT = _PROJECT_ROOT / "omicsclaw.py"
+
+
+def _coerce_param_value(value: Any) -> str:
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False)
+
+
+def default_command_factory(ctx: JobContext) -> list[str]:
+    argv: list[str] = [
+        sys.executable,
+        str(_ENTRY_POINT),
+        "run",
+        ctx.skill,
+        "--output",
+        str(ctx.artifact_root),
+    ]
+
+    if ctx.inputs.get("demo"):
+        argv.append("--demo")
+
+    input_path = ctx.inputs.get("input") or ctx.inputs.get("path")
+    if input_path:
+        argv.extend(["--input", str(input_path)])
+
+    for key, value in ctx.params.items():
+        if value is None or value is False:
+            continue
+        flag = param_to_cli_flag(key)
+        if value is True:
+            argv.append(flag)
+        else:
+            argv.extend([flag, _coerce_param_value(value)])
+
+    return argv
+
+
+def build_default_executor() -> SubprocessExecutor:
+    return SubprocessExecutor(command_factory=default_command_factory)

--- a/omicsclaw/execution/executors/local.py
+++ b/omicsclaw/execution/executors/local.py
@@ -1,0 +1,25 @@
+"""``LocalExecutor`` — in-process baseline.
+
+MVP-1 keeps the ``executor_not_implemented`` behavior of the previous
+inline stub: return a failed outcome with a diagnostic stdout tail. The
+abstraction makes this a 10-line swap once the real subprocess runner
+(spawning ``python omicsclaw.py run <skill> …``) is ready.
+"""
+
+from __future__ import annotations
+
+from .base import JobContext, JobOutcome
+
+EXECUTOR_NOT_IMPLEMENTED_LINE = (
+    "executor_not_implemented: see omicsclaw/execution/ "
+    "for the upcoming Executor abstraction"
+)
+
+
+class LocalExecutor:
+    async def run(self, ctx: JobContext) -> JobOutcome:  # noqa: D401
+        return JobOutcome(
+            exit_code=1,
+            error="executor_not_implemented",
+            stdout_text=EXECUTOR_NOT_IMPLEMENTED_LINE,
+        )

--- a/omicsclaw/execution/executors/subprocess.py
+++ b/omicsclaw/execution/executors/subprocess.py
@@ -1,0 +1,123 @@
+"""``SubprocessExecutor`` — spawn an OS process, stream its output.
+
+Where ``LocalExecutor`` is an instant-return stub, this executor runs a
+real command built from a ``command_factory(ctx)``. Stdout and stderr are
+merged and appended to ``ctx.stdout_log`` line-by-line so the Stage-4 SSE
+log-tail picks the output up live.
+
+Cooperative cancel path (user clicks "Cancel"):
+    asyncio cancels the run task → executor catches ``CancelledError`` →
+    ``proc.terminate()`` → wait up to 5s → ``proc.kill()`` if still alive.
+
+Failure modes are surfaced as ``JobOutcome`` values rather than raised
+exceptions so the jobs router's terminal-state path never has to special-
+case executor implementations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import inspect
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Optional, Union
+
+from .base import JobContext, JobOutcome
+
+CommandFactory = Callable[[JobContext], Union[list[str], Awaitable[list[str]]]]
+
+_TAIL_LINES = 100
+_TERMINATE_GRACE_SECONDS = 5.0
+
+
+class SubprocessExecutor:
+    def __init__(
+        self,
+        *,
+        command_factory: CommandFactory,
+        env: Optional[dict[str, str]] = None,
+        cwd: Optional[Path] = None,
+    ) -> None:
+        self._command_factory = command_factory
+        self._env = env
+        self._cwd = cwd
+
+    async def run(self, ctx: JobContext) -> JobOutcome:
+        try:
+            command_or_awaitable = self._command_factory(ctx)
+            if inspect.isawaitable(command_or_awaitable):
+                command = await command_or_awaitable
+            else:
+                command = command_or_awaitable
+            if not command or not isinstance(command, (list, tuple)):
+                raise ValueError("command_factory must return a non-empty list")
+        except Exception as exc:
+            return JobOutcome(
+                exit_code=1,
+                error=f"command_factory_failed: {exc}",
+                stdout_text=str(exc),
+            )
+
+        ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=str(self._cwd or ctx.workspace),
+                env=self._env,
+            )
+        except (OSError, FileNotFoundError) as exc:
+            return JobOutcome(
+                exit_code=127,
+                error=f"spawn_failed: {exc}",
+                stdout_text=str(exc),
+            )
+
+        tail: collections.deque[str] = collections.deque(maxlen=_TAIL_LINES)
+
+        async def _pump_stdout() -> None:
+            assert proc.stdout is not None
+            with ctx.stdout_log.open("ab") as sink:
+                async for raw in proc.stdout:
+                    sink.write(raw)
+                    sink.flush()
+                    tail.append(raw.decode("utf-8", errors="replace").rstrip("\n"))
+
+        try:
+            await _pump_stdout()
+            await proc.wait()
+        except BaseException:
+            # Any exit path — cancel, disk-full, interpreter shutdown —
+            # must reap the subprocess to avoid orphaning a skill run.
+            await _terminate_process(proc)
+            raise
+
+        exit_code = proc.returncode if proc.returncode is not None else -1
+        return JobOutcome(
+            exit_code=exit_code,
+            error=None if exit_code == 0 else f"subprocess_exit_{exit_code}",
+            stdout_text="\n".join(tail),
+        )
+
+
+async def _terminate_process(proc: asyncio.subprocess.Process) -> None:
+    if proc.returncode is not None:
+        return
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_GRACE_SECONDS)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            return
+        try:
+            await proc.wait()
+        except Exception:
+            pass

--- a/omicsclaw/remote/__init__.py
+++ b/omicsclaw/remote/__init__.py
@@ -1,0 +1,6 @@
+"""Remote control-plane API for the OmicsClaw desktop App.
+
+Implements the HTTP/SSE contract consumed by ``OmicsClaw-App`` (Stage 0/1
+already shipped). Mounted onto ``oc app-server`` via ``include_router`` so
+the legacy single-file ``omicsclaw/app/server.py`` stays untouched.
+"""

--- a/omicsclaw/remote/app_integration.py
+++ b/omicsclaw/remote/app_integration.py
@@ -1,0 +1,35 @@
+"""Single integration point used by ``omicsclaw/app/server.py``.
+
+Adds one call to ``server.py`` (``register_remote_routers(app)``) instead of
+seven ``include_router`` lines, keeping the legacy file untouched.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+
+from omicsclaw.remote.auth import require_bearer_token
+from omicsclaw.remote.routers import (
+    artifacts,
+    connections,
+    datasets,
+    env,
+    jobs,
+    sessions,
+)
+
+
+def register_remote_routers(app: FastAPI) -> None:
+    """Mount the remote control-plane routers onto ``app``.
+
+    Every router shares the same bearer-token dependency — no back-door
+    endpoints. The gate is a no-op when ``OMICSCLAW_REMOTE_AUTH_TOKEN`` is
+    unset (local-dev / single-user SSH-tunnel default).
+    """
+    deps = [Depends(require_bearer_token)]
+    app.include_router(connections.router, dependencies=deps)
+    app.include_router(env.router, dependencies=deps)
+    app.include_router(datasets.router, dependencies=deps)
+    app.include_router(jobs.router, dependencies=deps)
+    app.include_router(artifacts.router, dependencies=deps)
+    app.include_router(sessions.router, dependencies=deps)

--- a/omicsclaw/remote/auth.py
+++ b/omicsclaw/remote/auth.py
@@ -1,0 +1,42 @@
+"""Bearer-token gate for remote control-plane routers.
+
+Enabled when ``OMICSCLAW_REMOTE_AUTH_TOKEN`` is set to a non-empty value.
+When unset (or whitespace-only) the gate is a no-op so local development
+and single-user SSH-tunnel setups (the MVP-1 default) keep working.
+
+The token is validated constant-time to avoid timing side-channels.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastapi import Header, HTTPException, status
+
+TOKEN_ENV = "OMICSCLAW_REMOTE_AUTH_TOKEN"
+
+
+def _expected_token() -> str:
+    return os.environ.get(TOKEN_ENV, "").strip()
+
+
+async def require_bearer_token(
+    authorization: str | None = Header(default=None),
+) -> None:
+    expected = _expected_token()
+    if not expected:
+        return
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing bearer token",
+            headers={"WWW-Authenticate": 'Bearer realm="omicsclaw-remote"'},
+        )
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not hmac.compare_digest(token.strip(), expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid bearer token",
+            headers={"WWW-Authenticate": 'Bearer realm="omicsclaw-remote"'},
+        )

--- a/omicsclaw/remote/routers/__init__.py
+++ b/omicsclaw/remote/routers/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP routers for the remote control-plane contract."""

--- a/omicsclaw/remote/routers/artifacts.py
+++ b/omicsclaw/remote/routers/artifacts.py
@@ -1,0 +1,117 @@
+"""GET /artifacts?job_id=  +  GET /artifacts/{artifact_id}/download
+
+Artifacts are looked up under ``<workspace>/.omicsclaw/remote/jobs/<job_id>/artifacts/``.
+Until the Executor abstraction is wired in, ``GET /artifacts`` returns an
+empty list and ``download`` returns 404. The shape stays stable so the App
+side ArtifactsBrowser can render an empty state today and gain content
+automatically once jobs start producing files.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
+
+from omicsclaw.remote.schemas import Artifact, ArtifactListResponse
+from omicsclaw.remote.storage import jobs_root, path_modified_at_iso, resolve_workspace
+
+router = APIRouter(tags=["remote"])
+
+
+def _resolve_or_400() -> Path:
+    try:
+        return resolve_workspace()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _artifact_id(job_id: str, relative: Path) -> str:
+    # Stable, URL-safe id: "<job_id>:<relative-posix-path>".
+    return f"{job_id}:{relative.as_posix()}"
+
+
+def _validate_job_id(job_id: str) -> str:
+    candidate = str(job_id or "").strip()
+    path = Path(candidate)
+    if (
+        not candidate
+        or ":" in candidate
+        or path.is_absolute()
+        or len(path.parts) != 1
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        raise HTTPException(status_code=400, detail="job_id contains an unsafe path")
+    return candidate
+
+
+def _split_artifact_id(artifact_id: str) -> tuple[str, Path]:
+    if ":" not in artifact_id:
+        raise HTTPException(status_code=400, detail="artifact_id must be 'job_id:relative_path'")
+    job_id, _, rel = artifact_id.partition(":")
+    safe_job_id = _validate_job_id(job_id)
+    rel_path = Path(rel)
+    if rel_path.is_absolute() or any(part == ".." for part in rel_path.parts):
+        raise HTTPException(status_code=400, detail="artifact_id contains an unsafe relative path")
+    return safe_job_id, rel_path
+
+
+def _artifacts_dir(workspace: Path, job_id: str) -> Path:
+    root = jobs_root(workspace).resolve()
+    target = (root / _validate_job_id(job_id) / "artifacts").resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="job_id contains an unsafe path") from exc
+    return target
+
+
+def _resolve_artifact_target(base: Path, rel: Path) -> Path:
+    target = (base / rel).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="artifact_id escapes artifact root") from exc
+    return target
+
+
+@router.get("/artifacts", response_model=ArtifactListResponse)
+async def list_artifacts(job_id: str = Query(...)) -> ArtifactListResponse:
+    workspace = _resolve_or_400()
+    base = _artifacts_dir(workspace, job_id)
+    if not base.is_dir():
+        return ArtifactListResponse(artifacts=[], total=0)
+    rows: list[Artifact] = []
+    for path in sorted(base.rglob("*")):
+        if not path.is_file():
+            continue
+        resolved = _resolve_artifact_target(base, path.relative_to(base))
+        rel = path.relative_to(base)
+        mime, _ = mimetypes.guess_type(str(resolved))
+        rows.append(Artifact(
+            artifact_id=_artifact_id(job_id, rel),
+            job_id=job_id,
+            relative_path=rel.as_posix(),
+            size_bytes=resolved.stat().st_size,
+            mime_type=mime or "application/octet-stream",
+            created_at=path_modified_at_iso(resolved),
+        ))
+    return ArtifactListResponse(artifacts=rows, total=len(rows))
+
+
+@router.get("/artifacts/{artifact_id:path}/download")
+async def download_artifact(artifact_id: str) -> FileResponse:
+    workspace = _resolve_or_400()
+    job_id, rel = _split_artifact_id(artifact_id)
+    base = _artifacts_dir(workspace, job_id)
+    target = _resolve_artifact_target(base, rel)
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail=f"artifact not found: {artifact_id}")
+    # FileResponse streams + supports Range requests automatically.
+    return FileResponse(
+        path=target,
+        filename=rel.name,
+        media_type=mimetypes.guess_type(str(target))[0] or "application/octet-stream",
+    )

--- a/omicsclaw/remote/routers/connections.py
+++ b/omicsclaw/remote/routers/connections.py
@@ -1,0 +1,52 @@
+"""POST /connections/test — tunnel + version + extras probe.
+
+App calls this immediately after opening the SSH tunnel to confirm:
+- the backend is reachable
+- versions are compatible
+- optional extras (gpu, disk free) for the Settings UI
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from fastapi import APIRouter
+
+from omicsclaw.remote.schemas import ConnectionTestResponse
+from omicsclaw.remote.storage import utc_now_iso
+from omicsclaw.version import __version__
+
+router = APIRouter(tags=["remote"])
+
+
+def _detect_gpu() -> dict[str, object]:
+    try:
+        import torch  # type: ignore[import-not-found]
+    except ImportError:
+        return {"available": False, "reason": "torch not installed"}
+    if not torch.cuda.is_available():
+        return {"available": False, "reason": "cuda not available"}
+    devices = []
+    for idx in range(torch.cuda.device_count()):
+        devices.append({"index": idx, "name": torch.cuda.get_device_name(idx)})
+    return {"available": True, "device_count": len(devices), "devices": devices}
+
+
+def _disk_free_bytes(path: str = "/") -> int:
+    try:
+        return shutil.disk_usage(path).free
+    except OSError:
+        return -1
+
+
+@router.post("/connections/test", response_model=ConnectionTestResponse)
+async def connections_test() -> ConnectionTestResponse:
+    return ConnectionTestResponse(
+        ok=True,
+        version=__version__,
+        server_time=utc_now_iso(),
+        extras={
+            "gpu": _detect_gpu(),
+            "disk_free_bytes": _disk_free_bytes(),
+        },
+    )

--- a/omicsclaw/remote/routers/datasets.py
+++ b/omicsclaw/remote/routers/datasets.py
@@ -1,0 +1,291 @@
+"""Dataset registration & retrieval for the remote control plane.
+
+Real implementation (not a placeholder):
+- ``POST /datasets/upload``        — multipart upload, fingerprint, persist
+- ``POST /datasets/import-remote`` — register a path that already exists on
+                                     the server (for users who scp/rsync)
+- ``GET  /datasets``               — list registered DatasetRefs
+- ``DELETE /datasets/{id}``        — unregister (and for uploads, free disk)
+
+Storage layout (see ``omicsclaw.remote.storage``)::
+
+    <workspace>/.omicsclaw/remote/datasets/<dataset_id>/
+        <original_filename>          (upload only)
+        meta.json
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from fastapi import APIRouter, File, Form, HTTPException, Response, UploadFile
+
+from omicsclaw.remote.schemas import (
+    DatasetImportRemoteRequest,
+    DatasetListResponse,
+    DatasetRef,
+)
+from omicsclaw.remote.storage import (
+    composite_checksum,
+    datasets_root,
+    path_modified_at_iso,
+    resolve_workspace,
+)
+
+router = APIRouter(tags=["remote"])
+
+_MAX_UPLOAD_BYTES = 1024 * 1024 * 1024  # 1 GiB — boring MVP cap
+
+
+def _meta_path(dataset_dir: Path) -> Path:
+    return dataset_dir / "meta.json"
+
+
+def _read_meta(dataset_dir: Path) -> DatasetRef | None:
+    meta = _meta_path(dataset_dir)
+    if not meta.is_file():
+        return None
+    try:
+        payload = json.loads(meta.read_text(encoding="utf-8"))
+        return DatasetRef.model_validate(payload)
+    except (OSError, ValueError):
+        return None
+
+
+def _write_meta(dataset_dir: Path, ref: DatasetRef) -> None:
+    _meta_path(dataset_dir).write_text(
+        json.dumps(ref.model_dump(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _find_existing_by_checksum(
+    root: Path,
+    checksum: str,
+    execution_target: str,
+    *,
+    exclude_dir: Path | None = None,
+) -> DatasetRef | None:
+    for entry in root.iterdir():
+        if not entry.is_dir() or entry == exclude_dir:
+            continue
+        ref = _read_meta(entry)
+        if ref is not None:
+            ref = _refresh_dataset_ref(entry, ref)
+        if (
+            ref is not None
+            and ref.checksum == checksum
+            and ref.execution_target == execution_target
+            and ref.status != "stale"
+        ):
+            return ref
+    return None
+
+
+def _normalize_execution_target(raw: str) -> str:
+    value = str(raw or "").strip()
+    if value == "local":
+        return value
+    if value.startswith("remote:") and value != "remote:":
+        return value
+    raise HTTPException(
+        status_code=400,
+        detail="execution_target must be 'local' or 'remote:<profile_id>'",
+    )
+
+
+def _storage_path_from_uri(storage_uri: str) -> Path | None:
+    parsed = urlparse(storage_uri)
+    if parsed.scheme in ("", "file"):
+        return Path(unquote(parsed.path if parsed.scheme else storage_uri))
+    return None
+
+
+def _refresh_dataset_ref(dataset_dir: Path, ref: DatasetRef) -> DatasetRef:
+    storage_path = _storage_path_from_uri(ref.storage_uri)
+    storage_exists = storage_path is None or storage_path.exists()
+    expected_status = ref.status
+    if storage_exists and ref.status == "stale":
+        expected_status = "synced"
+    elif not storage_exists:
+        expected_status = "stale"
+
+    if expected_status == ref.status:
+        return ref
+
+    updated = ref.model_copy(update={"status": expected_status})
+    _write_meta(dataset_dir, updated)
+    return updated
+
+
+def _resolve_or_400() -> Path:
+    try:
+        return resolve_workspace()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _validate_dataset_id(dataset_id: str) -> str:
+    """Reject path-traversal / absolute / multi-segment ids.
+
+    Same shape as ``artifacts._validate_job_id`` — dataset_id must be a
+    single safe path component so ``datasets_root / id`` can never
+    escape the workspace.
+    """
+    candidate = str(dataset_id or "").strip()
+    path = Path(candidate)
+    if (
+        not candidate
+        or path.is_absolute()
+        or len(path.parts) != 1
+        or any(part in ("", ".", "..") for part in path.parts)
+    ):
+        raise HTTPException(
+            status_code=400, detail="dataset_id contains an unsafe path"
+        )
+    return candidate
+
+
+@router.get("/datasets", response_model=DatasetListResponse)
+async def list_datasets() -> DatasetListResponse:
+    workspace = _resolve_or_400()
+    root = datasets_root(workspace)
+    refs: list[DatasetRef] = []
+    for entry in sorted(root.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if not entry.is_dir():
+            continue
+        ref = _read_meta(entry)
+        if ref is not None:
+            refs.append(_refresh_dataset_ref(entry, ref))
+    return DatasetListResponse(
+        datasets=refs,
+        total=len(refs),
+        workspace=str(workspace),
+    )
+
+
+@router.post("/datasets/upload", response_model=DatasetRef)
+async def upload_dataset(
+    file: UploadFile = File(...),
+    display_name: str = Form(""),
+    execution_target: str = Form(...),
+) -> DatasetRef:
+    workspace = _resolve_or_400()
+    root = datasets_root(workspace)
+    normalized_execution_target = _normalize_execution_target(execution_target)
+    dataset_id = uuid.uuid4().hex
+    dataset_dir = root / dataset_id
+    dataset_dir.mkdir(parents=True, exist_ok=False)
+
+    safe_name = Path(file.filename or "dataset.bin").name
+    target = dataset_dir / safe_name
+    written = 0
+    try:
+        with target.open("wb") as out:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > _MAX_UPLOAD_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"upload exceeds {_MAX_UPLOAD_BYTES} bytes; use "
+                            "POST /datasets/import-remote after scp/rsync"
+                        ),
+                    )
+                out.write(chunk)
+    except HTTPException:
+        shutil.rmtree(dataset_dir, ignore_errors=True)
+        raise
+    except OSError as exc:
+        shutil.rmtree(dataset_dir, ignore_errors=True)
+        raise HTTPException(status_code=500, detail=f"failed to persist upload: {exc}") from exc
+    finally:
+        await file.close()
+
+    checksum = composite_checksum(target)
+    existing = _find_existing_by_checksum(
+        root,
+        checksum,
+        normalized_execution_target,
+        exclude_dir=dataset_dir,
+    )
+    if existing is not None:
+        shutil.rmtree(dataset_dir, ignore_errors=True)
+        return _refresh_dataset_ref(root / existing.dataset_id, existing)
+
+    ref = DatasetRef(
+        dataset_id=dataset_id,
+        display_name=(display_name or safe_name).strip(),
+        storage_uri=target.as_uri(),
+        execution_target=normalized_execution_target,
+        checksum=checksum,
+        size_bytes=target.stat().st_size,
+        modified_at=path_modified_at_iso(target),
+        status="synced",
+    )
+    _write_meta(dataset_dir, ref)
+    return ref
+
+
+@router.post("/datasets/import-remote", response_model=DatasetRef)
+async def import_remote_dataset(req: DatasetImportRemoteRequest) -> DatasetRef:
+    workspace = _resolve_or_400()
+    normalized_execution_target = _normalize_execution_target(req.execution_target)
+    src = Path(req.remote_path).expanduser()
+    if not src.is_absolute():
+        raise HTTPException(status_code=400, detail="remote_path must be absolute")
+    if not src.is_file():
+        raise HTTPException(status_code=404, detail=f"file not found on server: {src}")
+
+    root = datasets_root(workspace)
+    checksum = composite_checksum(src)
+    existing = _find_existing_by_checksum(root, checksum, normalized_execution_target)
+    if existing is not None:
+        return _refresh_dataset_ref(root / existing.dataset_id, existing)
+
+    dataset_id = uuid.uuid4().hex
+    dataset_dir = root / dataset_id
+    dataset_dir.mkdir(parents=True, exist_ok=False)
+
+    ref = DatasetRef(
+        dataset_id=dataset_id,
+        display_name=(req.display_name or src.name).strip(),
+        storage_uri=src.resolve().as_uri(),
+        execution_target=normalized_execution_target,
+        checksum=checksum,
+        size_bytes=src.stat().st_size,
+        modified_at=path_modified_at_iso(src),
+        status="synced",
+    )
+    _write_meta(dataset_dir, ref)
+    return ref
+
+
+@router.delete("/datasets/{dataset_id}", status_code=204)
+async def delete_dataset(dataset_id: str) -> Response:
+    """Unregister a dataset.
+
+    Upload-type datasets: removing the dataset dir frees the stored
+    file plus ``meta.json``.
+
+    Import-remote datasets: the dataset dir holds ONLY ``meta.json`` —
+    the user's source file at ``storage_uri`` lives outside the
+    workspace and is deliberately NOT touched. Rmtree on the workspace-
+    local dataset dir is therefore safe for both shapes.
+    """
+    workspace = _resolve_or_400()
+    safe_id = _validate_dataset_id(dataset_id)
+    dataset_dir = datasets_root(workspace) / safe_id
+    if not dataset_dir.is_dir():
+        raise HTTPException(
+            status_code=404, detail=f"dataset not found: {safe_id}"
+        )
+    shutil.rmtree(dataset_dir)
+    return Response(status_code=204)

--- a/omicsclaw/remote/routers/env.py
+++ b/omicsclaw/remote/routers/env.py
@@ -1,0 +1,58 @@
+"""GET /env/doctor — JSON shape of ``omicsclaw.diagnostics.build_doctor_report``.
+
+Reuses the existing ``oc doctor`` machinery so the App's Env tab and the CLI
+agree byte-for-byte on what counts as a healthy environment.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from omicsclaw.diagnostics import build_doctor_report
+from omicsclaw.remote.schemas import EnvDoctorCheck, EnvDoctorReport
+from omicsclaw.remote.storage import resolve_workspace
+
+router = APIRouter(tags=["remote"])
+
+
+def build_env_doctor_report_payload(*, workspace_dir: str = "") -> EnvDoctorReport:
+    resolved_workspace = str(workspace_dir or "").strip()
+    if not resolved_workspace:
+        try:
+            resolved_workspace = str(resolve_workspace())
+        except RuntimeError:
+            resolved_workspace = ""
+
+    # ``omicsclaw_dir`` mirrors what server.py exposes via /health.
+    try:
+        from omicsclaw.app.server import _omicsclaw_project_dir
+        omicsclaw_dir = str(_omicsclaw_project_dir())
+    except Exception:
+        omicsclaw_dir = ""
+
+    report = build_doctor_report(
+        omicsclaw_dir=omicsclaw_dir,
+        workspace_dir=resolved_workspace,
+    )
+    return EnvDoctorReport(
+        generated_at=report.generated_at,
+        workspace_dir=report.workspace_dir,
+        omicsclaw_dir=report.omicsclaw_dir,
+        overall_status=report.overall_status,
+        failure_count=report.failure_count,
+        warning_count=report.warning_count,
+        checks=[
+            EnvDoctorCheck(
+                name=check.name,
+                status=check.status,
+                summary=check.summary,
+                details=list(check.details),
+            )
+            for check in report.checks
+        ],
+    )
+
+
+@router.get("/env/doctor", response_model=EnvDoctorReport)
+async def env_doctor() -> EnvDoctorReport:
+    return build_env_doctor_report_payload()

--- a/omicsclaw/remote/routers/jobs.py
+++ b/omicsclaw/remote/routers/jobs.py
@@ -1,0 +1,660 @@
+"""Job submission, listing, SSE event stream, cancel, retry.
+
+Jobs are persisted as JSON sidecars on disk so they survive process
+restarts. Each queued job is driven to a terminal state by the active
+``Executor`` (``omicsclaw.execution.executors``); the default spawns
+``python omicsclaw.py run <skill> ...``.
+
+Critical constraints:
+- ``GET /jobs/{id}/events`` is read-only — streaming must never rewrite
+  terminal state such as ``canceled``.
+- Running jobs orphaned by a server restart are reconciled to ``failed``
+  on first workspace touch (``_reconcile_orphaned_jobs``).
+- A cancel during executor run wins: the runner re-reads the job after
+  ``executor.run()`` and skips the terminal write if status already moved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import AsyncIterator, Optional
+
+from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi.responses import StreamingResponse
+
+from omicsclaw.execution.executors import (
+    Executor,
+    JobContext,
+    JobOutcome,
+    build_default_executor,
+)
+from omicsclaw.execution.executors.local import EXECUTOR_NOT_IMPLEMENTED_LINE
+from omicsclaw.remote.schemas import (
+    Job,
+    JobListResponse,
+    JobStatus,
+    JobSubmitRequest,
+    JobSubmitResponse,
+)
+from omicsclaw.remote.routers.env import build_env_doctor_report_payload
+from omicsclaw.remote.storage import jobs_root, resolve_workspace, utc_now_iso
+
+router = APIRouter(tags=["remote"])
+logger = logging.getLogger(__name__)
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "canceled"})
+_STUB_JOB_TASKS: dict[str, asyncio.Task[None]] = {}
+_EXECUTOR_NOT_IMPLEMENTED_LINE = EXECUTOR_NOT_IMPLEMENTED_LINE
+_DEFAULT_EXECUTOR: Executor = build_default_executor()
+_ORPHANED_JOB_LINE = (
+    "server_restart_orphaned_job: job was in 'running' state when the "
+    "server restarted; no active task to drive it forward"
+)
+_RECONCILED_WORKSPACES: set[Path] = set()
+
+
+def _job_dir(workspace: Path, job_id: str) -> Path:
+    return jobs_root(workspace) / job_id
+
+
+def _job_path(workspace: Path, job_id: str) -> Path:
+    return _job_dir(workspace, job_id) / "job.json"
+
+
+def _artifact_root(workspace: Path, job_id: str) -> Path:
+    return _job_dir(workspace, job_id) / "artifacts"
+
+
+def _is_chat_stream_job(job: Optional[Job]) -> bool:
+    return bool(
+        job
+        and job.skill == "chat"
+        and isinstance(job.params, dict)
+        and job.params.get("job_kind") == "chat_stream"
+    )
+
+
+def _reconcile_orphaned_jobs(workspace: Path) -> bool:
+    """Flip ``running`` jobs that have no active stub task to ``failed``.
+
+    Invariants:
+    - Never touches ``queued`` jobs — they recover through ``_ensure_stub_job``.
+    - Never touches terminal jobs (succeeded / failed / canceled).
+    - Skips jobs whose stub task is still alive on the current event loop.
+    Returns ``True`` only when the workspace was scanned without unexpected
+    reconcile errors. Callers should retry later when ``False`` is returned.
+    """
+    root = jobs_root(workspace)
+    if not root.is_dir():
+        return True
+    reconciled_cleanly = True
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        job = _read_job(workspace, entry.name)
+        if job is None or job.status != "running":
+            continue
+        task = _STUB_JOB_TASKS.get(entry.name)
+        if task is not None and not task.done():
+            continue
+        try:
+            artifact_root = _persist_failure_diagnostics(
+                workspace,
+                job.job_id,
+                stdout_text=_ORPHANED_JOB_LINE,
+            )
+            orphaned = job.model_copy(update={
+                "status": "failed",
+                "finished_at": utc_now_iso(),
+                "exit_code": 1,
+                "error": "server_restart_orphaned_job",
+                "artifact_root": artifact_root,
+            })
+            _write_job(workspace, orphaned)
+        except Exception:
+            reconciled_cleanly = False
+            logger.exception(
+                "Failed to reconcile orphaned remote job '%s' in workspace '%s'",
+                job.job_id,
+                workspace,
+            )
+    return reconciled_cleanly
+
+
+def _resolve_or_400() -> Path:
+    try:
+        workspace = resolve_workspace()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if workspace not in _RECONCILED_WORKSPACES:
+        if _reconcile_orphaned_jobs(workspace):
+            _RECONCILED_WORKSPACES.add(workspace)
+    return workspace
+
+
+def _read_job(workspace: Path, job_id: str) -> Optional[Job]:
+    path = _job_path(workspace, job_id)
+    if not path.is_file():
+        return None
+    try:
+        return Job.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _write_job(workspace: Path, job: Job) -> None:
+    """Atomically persist ``job.json``.
+
+    Writes to a sibling ``.tmp`` file then ``os.replace``-renames it
+    into place. The rename is atomic on POSIX, so concurrent readers
+    never observe a truncated file — they see either the pre-write
+    content or the full post-write content. A crash / SIGKILL during
+    the ``.tmp`` write leaves the target untouched; a crash between
+    write and rename also leaves the target untouched plus a stray
+    ``.tmp`` (benign — next write overwrites it).
+    """
+    path = _job_path(workspace, job.job_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    serialized = json.dumps(job.model_dump(), indent=2, sort_keys=True)
+    try:
+        tmp.write_text(serialized, encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        # Best-effort cleanup so repeated failures don't leave stale
+        # .tmp files. The target is intentionally NOT touched.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _write_text(path: Path, content: str) -> None:
+    """Atomically write ``content`` to ``path``.
+
+    Mirrors ``_write_job``'s temp-file + ``os.replace`` pattern so a
+    crash mid-write leaves the pre-existing target intact instead of a
+    truncated / half-written file. Used for the diagnostic artifacts
+    (``stdout.log``, ``diagnostics/stdout.log``, ``env_doctor.json``)
+    that the App's failure-diagnostic view depends on.
+
+    Not used for the live executor append path — ``SubprocessExecutor``
+    writes bytes straight into ``stdout.log`` so SSE log-tailing can
+    stream incrementally.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def append_job_stdout_line(workspace: Path, job_id: str, line: str) -> None:
+    trimmed = line.rstrip()
+    if not trimmed:
+        return
+    stdout_path = _job_dir(workspace, job_id) / "stdout.log"
+    stdout_path.parent.mkdir(parents=True, exist_ok=True)
+    with stdout_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{trimmed}\n")
+
+
+def _finalize_stdout(workspace: Path, job_id: str, stdout_text: str) -> None:
+    """Ensure ``stdout.log`` has content for diagnostics.
+
+    Preserve anything the executor streamed during run (so live-tailed
+    SSE output isn't wiped). Only fall back to ``stdout_text`` when the
+    executor left the file empty / missing — this is the instant-return
+    stub-executor path, e.g. ``LocalExecutor``.
+    """
+    stdout_path = _job_dir(workspace, job_id) / "stdout.log"
+    if stdout_path.is_file() and stdout_path.stat().st_size > 0:
+        return
+    if not stdout_text:
+        return
+    normalized = stdout_text if stdout_text.endswith("\n") else f"{stdout_text}\n"
+    _write_text(stdout_path, normalized)
+
+
+def _persist_failure_diagnostics(workspace: Path, job_id: str, *, stdout_text: str) -> str:
+    _finalize_stdout(workspace, job_id, stdout_text)
+    job_dir = _job_dir(workspace, job_id)
+    artifact_root = _artifact_root(workspace, job_id)
+    diagnostics_dir = artifact_root / "diagnostics"
+
+    stdout_path = job_dir / "stdout.log"
+    diagnostics_content = (
+        stdout_path.read_text(encoding="utf-8")
+        if stdout_path.is_file()
+        else ""
+    )
+    _write_text(diagnostics_dir / "stdout.log", diagnostics_content)
+
+    env_payload = build_env_doctor_report_payload(workspace_dir=str(workspace))
+    _write_text(
+        diagnostics_dir / "env_doctor.json",
+        json.dumps(env_payload.model_dump(), indent=2, sort_keys=True),
+    )
+    return str(artifact_root.resolve())
+
+
+def _sse_event(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+def _tail_new_lines(
+    log_path: Path,
+    bytes_read: int,
+    carry: str,
+) -> tuple[list[str], int, str]:
+    """Read new bytes from ``log_path`` since ``bytes_read`` offset.
+
+    Returns ``(complete_new_lines, new_offset, carry)`` where ``carry``
+    holds the trailing partial line (no newline yet) that must be
+    prepended to the next read. Only ``\\n``-terminated lines are
+    returned here; partial content is buffered until the executor flushes
+    a newline or the stream drains at terminal state.
+
+    File shrink / truncate is out of scope for MVP — executors only
+    append.
+    """
+    if not log_path.is_file():
+        return [], bytes_read, carry
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return [], bytes_read, carry
+    if size <= bytes_read:
+        return [], bytes_read, carry
+    try:
+        with log_path.open("rb") as fh:
+            fh.seek(bytes_read)
+            chunk = fh.read(size - bytes_read)
+    except OSError:
+        return [], bytes_read, carry
+    buffer = carry + chunk.decode("utf-8", errors="replace")
+    pieces = buffer.split("\n")
+    new_carry = pieces[-1]  # may be "" when buffer ends with \n
+    return pieces[:-1], size, new_carry
+
+
+def _log_event(job_id: str, line: str, *, event_id: int | None = None) -> str:
+    """Render a ``job_log`` SSE frame, optionally with an ``id:`` line.
+
+    The id carries the end-byte-offset of ``line`` inside ``stdout.log``
+    so clients can round-trip it back as ``Last-Event-ID`` on reconnect.
+    Each line gets a *distinct* id — a shared batch id would let a
+    client crash mid-batch silently drop later lines with the same id.
+    """
+    payload = {"job_id": job_id, "stream": "stdout", "line": line}
+    data = json.dumps(payload, ensure_ascii=False)
+    if event_id is None:
+        return f"event: job_log\ndata: {data}\n\n"
+    return f"id: {event_id}\nevent: job_log\ndata: {data}\n\n"
+
+
+def _status_event_name(status: JobStatus) -> str:
+    return {
+        "queued": "job_queued",
+        "running": "job_started",
+        "succeeded": "job_succeeded",
+        "failed": "job_failed",
+        "canceled": "job_canceled",
+    }[status]
+
+
+def _persist_success_stdout(workspace: Path, job_id: str, *, stdout_text: str) -> str:
+    _finalize_stdout(workspace, job_id, stdout_text)
+    artifact_root = _artifact_root(workspace, job_id)
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    return str(artifact_root.resolve())
+
+
+async def _run_job(workspace: Path, job_id: str) -> None:
+    """Drive a queued job through the active Executor to a terminal state.
+
+    Re-reads the job JSON between each transition so a ``cancel`` call
+    wins over an in-flight executor run.
+    """
+    try:
+        await asyncio.sleep(0.01)
+        job = _read_job(workspace, job_id)
+        if job is None or job.status != "queued":
+            return
+
+        running = job.model_copy(update={"status": "running", "started_at": utc_now_iso()})
+        _write_job(workspace, running)
+
+        # Yield so the SSE poll loop observes the 'running' transition
+        # before an instant-return executor (e.g. LocalExecutor stub) flips
+        # the job to its terminal state.
+        await asyncio.sleep(0.02)
+
+        ctx = JobContext(
+            job_id=job_id,
+            workspace=workspace,
+            skill=running.skill,
+            inputs=running.inputs,
+            params=running.params,
+            artifact_root=_artifact_root(workspace, job_id),
+            stdout_log=_job_dir(workspace, job_id) / "stdout.log",
+        )
+        outcome: JobOutcome = await _DEFAULT_EXECUTOR.run(ctx)
+
+        # Cancel may have landed while the executor was running. Don't
+        # clobber a terminal state that the cancel handler already wrote.
+        job = _read_job(workspace, job_id)
+        if job is None or job.status != "running":
+            return
+
+        if outcome.exit_code == 0:
+            artifact_root = _persist_success_stdout(
+                workspace, job_id, stdout_text=outcome.stdout_text,
+            )
+            final = job.model_copy(update={
+                "status": "succeeded",
+                "finished_at": utc_now_iso(),
+                "exit_code": outcome.exit_code,
+                "error": None,
+                "artifact_root": artifact_root,
+            })
+        else:
+            artifact_root = _persist_failure_diagnostics(
+                workspace,
+                job_id,
+                stdout_text=outcome.stdout_text or _EXECUTOR_NOT_IMPLEMENTED_LINE,
+            )
+            final = job.model_copy(update={
+                "status": "failed",
+                "finished_at": utc_now_iso(),
+                "exit_code": outcome.exit_code,
+                "error": outcome.error or "executor_not_implemented",
+                "artifact_root": artifact_root,
+            })
+        _write_job(workspace, final)
+    finally:
+        _STUB_JOB_TASKS.pop(job_id, None)
+
+
+def _ensure_stub_job(workspace: Path, job_id: str) -> None:
+    job = _read_job(workspace, job_id)
+    if _is_chat_stream_job(job):
+        return
+    task = _STUB_JOB_TASKS.get(job_id)
+    if task is not None and not task.done():
+        return
+    _STUB_JOB_TASKS[job_id] = asyncio.create_task(_run_job(workspace, job_id))
+
+
+def bind_chat_stream_job(workspace: Path, job_id: str, *, session_id: str = "") -> Job:
+    job = _read_job(workspace, job_id)
+    if job is None:
+        raise LookupError(f"job not found: {job_id}")
+    if not _is_chat_stream_job(job):
+        raise ValueError(f"job is not a chat_stream display job: {job_id}")
+    if session_id and job.session_id and job.session_id != session_id:
+        raise ValueError(
+            f"job session mismatch: expected {job.session_id!r}, got {session_id!r}"
+        )
+    if job.status == "queued":
+        running = job.model_copy(update={
+            "status": "running",
+            "started_at": job.started_at or utc_now_iso(),
+        })
+        _write_job(workspace, running)
+        return running
+    if job.status == "running":
+        return job
+    if job.status == "canceled":
+        return job
+    raise ValueError(f"job is already terminal: {job.status}")
+
+
+def finalize_chat_stream_job(
+    workspace: Path,
+    job_id: str,
+    *,
+    status: JobStatus,
+    error: str | None = None,
+) -> Job:
+    if status not in _TERMINAL_STATUSES:
+        raise ValueError(f"chat stream job must finalize to a terminal status, got {status}")
+
+    job = _read_job(workspace, job_id)
+    if job is None:
+        raise LookupError(f"job not found: {job_id}")
+    if not _is_chat_stream_job(job):
+        raise ValueError(f"job is not a chat_stream display job: {job_id}")
+    if job.status == "canceled" and status != "canceled":
+        return job
+    if job.status in _TERMINAL_STATUSES and job.status == status:
+        return job
+    if job.status in _TERMINAL_STATUSES and job.status != status:
+        return job
+
+    updates: dict[str, object | None] = {
+        "status": status,
+        "finished_at": utc_now_iso(),
+        "started_at": job.started_at or utc_now_iso(),
+    }
+    if status == "succeeded":
+        updates.update({
+            "exit_code": 0,
+            "error": None,
+            "artifact_root": _persist_success_stdout(workspace, job_id, stdout_text=""),
+        })
+    elif status == "failed":
+        message = error or "chat_stream_failed"
+        updates.update({
+            "exit_code": 1,
+            "error": message,
+            "artifact_root": _persist_failure_diagnostics(
+                workspace,
+                job_id,
+                stdout_text=message,
+            ),
+        })
+    else:
+        updates.update({"error": error or job.error})
+
+    final = job.model_copy(update=updates)
+    _write_job(workspace, final)
+    return final
+
+
+@router.post("/jobs", response_model=JobSubmitResponse)
+async def submit_job(req: JobSubmitRequest) -> JobSubmitResponse:
+    workspace = _resolve_or_400()
+    job = Job(
+        job_id=uuid.uuid4().hex,
+        session_id=req.session_id.strip(),
+        skill=req.skill,
+        status="queued",
+        workspace=str(workspace),
+        inputs=req.inputs,
+        params=req.params,
+        created_at=utc_now_iso(),
+    )
+    _write_job(workspace, job)
+    _ensure_stub_job(workspace, job.job_id)
+    return JobSubmitResponse(job_id=job.job_id, status=job.status)
+
+
+@router.get("/jobs", response_model=JobListResponse)
+async def list_jobs(
+    status: Optional[JobStatus] = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+) -> JobListResponse:
+    workspace = _resolve_or_400()
+    root = jobs_root(workspace)
+    rows: list[Job] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        job = _read_job(workspace, entry.name)
+        if job is None:
+            continue
+        if status and job.status != status:
+            continue
+        rows.append(job)
+    rows.sort(key=lambda j: j.created_at, reverse=True)
+    total = len(rows)
+    rows = rows[:limit]
+    return JobListResponse(jobs=rows, total=total)
+
+
+@router.get("/jobs/{job_id}", response_model=Job)
+async def get_job(job_id: str) -> Job:
+    workspace = _resolve_or_400()
+    job = _read_job(workspace, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    return job
+
+
+@router.post("/jobs/{job_id}/cancel", response_model=Job)
+async def cancel_job(job_id: str) -> Job:
+    workspace = _resolve_or_400()
+    job = _read_job(workspace, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    if job.status in ("succeeded", "failed", "canceled"):
+        return job
+    updated = job.model_copy(update={
+        "status": "canceled",
+        "finished_at": utc_now_iso(),
+    })
+    _write_job(workspace, updated)
+
+    # Interrupt the in-flight executor task so cooperative cancel paths
+    # run (``SubprocessExecutor`` → SIGTERM → SIGKILL). Without this, a
+    # long-running skill would keep burning CPU despite the status flip.
+    # ``task.cancel()`` on a completed task is a safe no-op.
+    task = _STUB_JOB_TASKS.get(job_id)
+    if task is not None:
+        task.cancel()
+    return updated
+
+
+@router.post("/jobs/{job_id}/retry", response_model=JobSubmitResponse)
+async def retry_job(job_id: str) -> JobSubmitResponse:
+    workspace = _resolve_or_400()
+    original = _read_job(workspace, job_id)
+    if original is None:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    if original.status not in _TERMINAL_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"can only retry a finished job; this one is {original.status}",
+        )
+    clone = Job(
+        job_id=uuid.uuid4().hex,
+        session_id=original.session_id,
+        skill=original.skill,
+        status="queued",
+        workspace=str(workspace),
+        inputs=original.inputs,
+        params=original.params,
+        created_at=utc_now_iso(),
+    )
+    _write_job(workspace, clone)
+    _ensure_stub_job(workspace, clone.job_id)
+    return JobSubmitResponse(job_id=clone.job_id, status=clone.status)
+
+
+def _parse_resume_cursor(last_event_id: Optional[str]) -> int:
+    """Parse ``Last-Event-ID`` into a byte offset.
+
+    Invalid / missing / negative values fall back to ``0`` (fresh stream)
+    so the worst case is the pre-resume duplication behaviour, never a
+    500.
+    """
+    if not last_event_id:
+        return 0
+    try:
+        value = int(last_event_id)
+    except ValueError:
+        return 0
+    return value if value > 0 else 0
+
+
+async def _job_event_stream(
+    workspace: Path, job_id: str, *, resume_bytes: int = 0
+) -> AsyncIterator[str]:
+    job = _read_job(workspace, job_id)
+    if job is None:
+        yield _sse_event("error", {"error": "job_not_found", "job_id": job_id})
+        return
+
+    if job.status == "queued":
+        _ensure_stub_job(workspace, job_id)
+
+    stdout_path = _job_dir(workspace, job_id) / "stdout.log"
+    bytes_read = resume_bytes
+    carry = ""
+    last_status: JobStatus | None = None
+
+    while True:
+        current = _read_job(workspace, job_id)
+        if current is None:
+            yield _sse_event("error", {"error": "job_not_found", "job_id": job_id})
+            return
+
+        # Drain any new stdout lines *before* a status-change event so the
+        # App gets context in the natural order (logs → final banner).
+        new_lines, new_bytes, carry = _tail_new_lines(
+            stdout_path, bytes_read, carry
+        )
+        cursor = bytes_read
+        for line in new_lines:
+            # +1 for the stripped trailing \n.
+            cursor += len(line.encode("utf-8")) + 1
+            yield _log_event(job_id, line, event_id=cursor)
+        bytes_read = new_bytes
+
+        if current.status != last_status:
+            yield _sse_event(_status_event_name(current.status), current.model_dump())
+            last_status = current.status
+
+        if current.status in _TERMINAL_STATUSES:
+            final_lines, new_bytes, carry = _tail_new_lines(
+                stdout_path, bytes_read, carry
+            )
+            cursor = bytes_read
+            for line in final_lines:
+                cursor += len(line.encode("utf-8")) + 1
+                yield _log_event(job_id, line, event_id=cursor)
+            bytes_read = new_bytes
+            # Flush an unterminated trailing line so the last executor
+            # output never gets silently dropped.
+            if carry:
+                cursor += len(carry.encode("utf-8"))
+                yield _log_event(job_id, carry, event_id=cursor)
+            yield _sse_event("done", {"job_id": job_id})
+            return
+
+        await asyncio.sleep(0.01)
+
+
+@router.get("/jobs/{job_id}/events")
+async def job_events(
+    job_id: str,
+    last_event_id: Optional[str] = Header(default=None, alias="Last-Event-ID"),
+) -> StreamingResponse:
+    workspace = _resolve_or_400()
+    resume_bytes = _parse_resume_cursor(last_event_id)
+    return StreamingResponse(
+        _job_event_stream(workspace, job_id, resume_bytes=resume_bytes),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/omicsclaw/remote/routers/sessions.py
+++ b/omicsclaw/remote/routers/sessions.py
@@ -1,0 +1,57 @@
+"""POST /sessions/{session_id}/resume — reattach to running jobs.
+
+When the App's tunnel drops or the window reopens, the session is asked
+"are any of your jobs still alive?". MVP-1 returns the list of active jobs
+owned by that session; deeper transcript replay belongs to the chat layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from omicsclaw.remote.schemas import Job, SessionResumeResponse
+from omicsclaw.remote.storage import jobs_root, resolve_workspace
+
+router = APIRouter(tags=["remote"])
+
+
+def _resolve_or_400() -> Path:
+    try:
+        return resolve_workspace()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _read_job(job_file: Path) -> Job | None:
+    if not job_file.is_file():
+        return None
+    try:
+        return Job.model_validate_json(job_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+@router.post("/sessions/{session_id}/resume", response_model=SessionResumeResponse)
+async def resume_session(session_id: str) -> SessionResumeResponse:
+    workspace = _resolve_or_400()
+    root = jobs_root(workspace)
+    active: list[str] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        job = _read_job(entry / "job.json")
+        if job is None:
+            continue
+        if job.session_id != session_id:
+            continue
+        if job.status in ("queued", "running"):
+            active.append(entry.name)
+    return SessionResumeResponse(
+        session_id=session_id,
+        resumed=True,
+        reason="" if active else "no_active_jobs",
+        active_job_ids=active,
+    )

--- a/omicsclaw/remote/schemas.py
+++ b/omicsclaw/remote/schemas.py
@@ -1,0 +1,145 @@
+"""Pydantic models for the remote control-plane contract.
+
+Every field name and JSON shape MUST stay in lockstep with the App side
+(``OmicsClaw-App`` ``src/lib/dataset-ref.ts`` / ``jobs-client.ts``).
+Treat this file as the single source of truth for the wire format.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# /connections/test  +  /env/doctor
+# ---------------------------------------------------------------------------
+
+
+class ConnectionTestResponse(BaseModel):
+    ok: bool
+    version: str
+    server_time: str  # ISO-8601 UTC
+    extras: dict[str, Any] = Field(default_factory=dict)
+
+
+class EnvDoctorCheck(BaseModel):
+    name: str
+    status: Literal["ok", "warn", "fail", "info"]
+    summary: str
+    details: list[str] = Field(default_factory=list)
+
+
+class EnvDoctorReport(BaseModel):
+    generated_at: str
+    workspace_dir: str
+    omicsclaw_dir: str
+    overall_status: Literal["ok", "warn", "fail"]
+    failure_count: int
+    warning_count: int
+    checks: list[EnvDoctorCheck]
+
+
+# ---------------------------------------------------------------------------
+# /datasets
+# ---------------------------------------------------------------------------
+
+
+DatasetStatus = Literal["local-only", "uploading", "synced", "stale"]
+
+
+class DatasetRef(BaseModel):
+    dataset_id: str
+    display_name: str
+    storage_uri: str           # file:///abs/path | ssh://host/abs/path
+    execution_target: str      # required: 'local' | 'remote:<profile_id>'
+    checksum: str              # sha256-of-first-64k + ":" + size_bytes
+    size_bytes: int
+    modified_at: str           # ISO-8601 UTC
+    status: DatasetStatus = "synced"
+
+
+class DatasetListResponse(BaseModel):
+    datasets: list[DatasetRef]
+    total: int
+    workspace: str
+
+
+class DatasetImportRemoteRequest(BaseModel):
+    remote_path: str           # absolute path on the server
+    display_name: str = ""
+    execution_target: str
+
+
+# ---------------------------------------------------------------------------
+# /jobs
+# ---------------------------------------------------------------------------
+
+
+JobStatus = Literal["queued", "running", "succeeded", "failed", "canceled"]
+
+
+class JobSubmitRequest(BaseModel):
+    workspace: str = ""
+    session_id: str = ""
+    skill: str
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class Job(BaseModel):
+    job_id: str
+    session_id: str = ""
+    skill: str
+    status: JobStatus
+    workspace: str
+    inputs: dict[str, Any]
+    params: dict[str, Any]
+    created_at: str
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    exit_code: Optional[int] = None
+    error: Optional[str] = None
+    artifact_root: Optional[str] = None
+
+
+class JobListResponse(BaseModel):
+    jobs: list[Job]
+    total: int
+
+
+class JobSubmitResponse(BaseModel):
+    job_id: str
+    status: JobStatus
+
+
+# ---------------------------------------------------------------------------
+# /artifacts
+# ---------------------------------------------------------------------------
+
+
+class Artifact(BaseModel):
+    artifact_id: str
+    job_id: str
+    relative_path: str
+    size_bytes: int
+    mime_type: str
+    created_at: str
+
+
+class ArtifactListResponse(BaseModel):
+    artifacts: list[Artifact]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# /sessions/:id/resume
+# ---------------------------------------------------------------------------
+
+
+class SessionResumeResponse(BaseModel):
+    session_id: str
+    resumed: bool
+    reason: str = ""
+    active_job_ids: list[str] = Field(default_factory=list)

--- a/omicsclaw/remote/storage.py
+++ b/omicsclaw/remote/storage.py
@@ -1,0 +1,89 @@
+"""Filesystem layout helpers for remote control-plane state.
+
+Workspace layout::
+
+    <workspace>/.omicsclaw/remote/
+        datasets/<dataset_id>/
+            <original_filename>
+            meta.json
+        jobs/<job_id>/
+            job.json
+            stdout.log
+            artifacts/<...>
+
+Single source of truth for path resolution so every router resolves the
+same workspace via :func:`resolve_workspace`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+REMOTE_SUBDIR = ".omicsclaw/remote"
+_CHECKSUM_HEAD_BYTES = 64 * 1024
+
+
+def resolve_workspace(explicit: str = "") -> Path:
+    """Resolve the active workspace, raising ``RuntimeError`` if unset.
+
+    Resolution order matches existing server.py helpers (see
+    ``_resolve_scoped_memory_workspace``): explicit arg > env > unset.
+    """
+    candidate = (explicit or "").strip() or os.environ.get("OMICSCLAW_WORKSPACE", "").strip()
+    if not candidate:
+        raise RuntimeError(
+            "OMICSCLAW_WORKSPACE is not set. Configure a workspace via PUT /workspace first."
+        )
+    path = Path(candidate).expanduser().resolve()
+    if not path.is_dir():
+        raise RuntimeError(f"workspace directory does not exist: {path}")
+    return path
+
+
+def remote_root(workspace: Path) -> Path:
+    root = workspace / REMOTE_SUBDIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def datasets_root(workspace: Path) -> Path:
+    root = remote_root(workspace) / "datasets"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def jobs_root(workspace: Path) -> Path:
+    root = remote_root(workspace) / "jobs"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def timestamp_iso(timestamp: float) -> str:
+    return datetime.fromtimestamp(timestamp, timezone.utc).isoformat()
+
+
+def path_modified_at_iso(path: Path) -> str:
+    return timestamp_iso(path.stat().st_mtime)
+
+
+def composite_checksum(path: Path) -> str:
+    """sha256 of the first 64 KiB plus ``":<size_bytes>"``.
+
+    Matches App ``src/lib/dataset-ref.ts`` so checksums round-trip.
+    Cheap on multi-GB ``.h5ad`` files; collisions are vanishingly rare for
+    deduplication purposes (UX-grade fingerprint, not cryptographic).
+    """
+    hasher = hashlib.sha256()
+    size = 0
+    with path.open("rb") as fh:
+        head = fh.read(_CHECKSUM_HEAD_BYTES)
+        hasher.update(head)
+        size = path.stat().st_size
+    return f"sha256-64k:{hasher.hexdigest()}:{size}"

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -984,6 +984,149 @@ async def test_chat_stream_emits_protocol_events_and_usage(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_updates_bound_remote_chat_job_lifecycle(monkeypatch, tmp_path: Path):
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.remote.schemas import Job
+    from omicsclaw.remote.storage import jobs_root, utc_now_iso
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+
+    job_dir = jobs_root(workspace) / "job-chat-1"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    queued = Job(
+        job_id="job-chat-1",
+        session_id="session-chat-1",
+        skill="chat",
+        status="queued",
+        workspace=str(workspace),
+        inputs={},
+        params={"job_kind": "chat_stream", "display_name": "chat turn"},
+        created_at=utc_now_iso(),
+    )
+    (job_dir / "job.json").write_text(queued.model_dump_json(), encoding="utf-8")
+
+    async def fake_llm_tool_loop(**kwargs):
+        await kwargs["on_tool_call"]("task_update", {"task_id": "t1", "status": "in_progress"})
+        await kwargs["on_tool_result"]("task_update", "updated")
+        await kwargs["on_stream_content"]("remote chat output")
+        return "remote chat output"
+
+    fake_core = SimpleNamespace(
+        init=lambda **kwargs: None,
+        llm_tool_loop=fake_llm_tool_loop,
+        LLM_PROVIDER_NAME="env",
+        OMICSCLAW_MODEL="gpt-test",
+        OUTPUT_DIR=ROOT / "output",
+        _skill_registry=lambda: SimpleNamespace(skills={}),
+        get_tool_executors=lambda: {"task_update": object()},
+        _accumulate_usage=lambda response_usage: {},
+        _get_token_price=lambda model: (0.0, 0.0),
+    )
+
+    monkeypatch.setattr(server, "_core", fake_core, raising=False)
+    monkeypatch.setattr(server, "_mcp_load_fn", None, raising=False)
+
+    response = await server.chat_stream(
+        server.ChatRequest(
+            session_id="session-chat-1",
+            content="hello",
+            workspace=str(workspace),
+            job_id="job-chat-1",
+        )
+    )
+    await _read_streaming_response(response)
+
+    final_job = Job.model_validate_json((job_dir / "job.json").read_text(encoding="utf-8"))
+    assert final_job.status == "succeeded"
+    assert final_job.started_at
+    assert final_job.finished_at
+    stdout_text = (job_dir / "stdout.log").read_text(encoding="utf-8")
+    assert "Starting task_update" in stdout_text
+    assert "Completed task_update" in stdout_text
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_rejects_bind_when_job_already_canceled(monkeypatch, tmp_path: Path):
+    """Regression: ``bind_chat_stream_job`` intentionally passes canceled jobs
+    through so the cancel handler can finalize them without clobbering state.
+    Before this guard, ``chat_stream`` discarded that return value and marched
+    on into the tool loop, executing a full chat turn whose job row was
+    permanently ``canceled`` — backend state and actual execution forked.
+    The handler must bail with 409 instead.
+    """
+    pytest.importorskip("fastapi")
+
+    from fastapi import HTTPException
+
+    from omicsclaw.app import server
+    from omicsclaw.remote.schemas import Job
+    from omicsclaw.remote.storage import jobs_root, utc_now_iso
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+
+    job_dir = jobs_root(workspace) / "job-chat-canceled"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    canceled = Job(
+        job_id="job-chat-canceled",
+        session_id="session-chat-canceled",
+        skill="chat",
+        status="canceled",
+        workspace=str(workspace),
+        inputs={},
+        params={"job_kind": "chat_stream", "display_name": "chat turn"},
+        created_at=utc_now_iso(),
+        finished_at=utc_now_iso(),
+    )
+    (job_dir / "job.json").write_text(canceled.model_dump_json(), encoding="utf-8")
+
+    tool_loop_ran = False
+
+    async def fake_llm_tool_loop(**kwargs):
+        nonlocal tool_loop_ran
+        tool_loop_ran = True
+        return ""
+
+    fake_core = SimpleNamespace(
+        init=lambda **kwargs: None,
+        llm_tool_loop=fake_llm_tool_loop,
+        LLM_PROVIDER_NAME="env",
+        OMICSCLAW_MODEL="gpt-test",
+        OUTPUT_DIR=ROOT / "output",
+        _skill_registry=lambda: SimpleNamespace(skills={}),
+        get_tool_executors=lambda: {},
+        _accumulate_usage=lambda response_usage: {},
+        _get_token_price=lambda model: (0.0, 0.0),
+    )
+
+    monkeypatch.setattr(server, "_core", fake_core, raising=False)
+    monkeypatch.setattr(server, "_mcp_load_fn", None, raising=False)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await server.chat_stream(
+            server.ChatRequest(
+                session_id="session-chat-canceled",
+                content="hello",
+                workspace=str(workspace),
+                job_id="job-chat-canceled",
+            )
+        )
+
+    assert excinfo.value.status_code == 409
+    assert "canceled" in str(excinfo.value.detail).lower()
+    assert not tool_loop_ran, "tool loop must not run for a pre-canceled job"
+
+    # Job row must remain canceled — the guard explicitly avoids clobbering.
+    final_job = Job.model_validate_json((job_dir / "job.json").read_text(encoding="utf-8"))
+    assert final_job.status == "canceled"
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_surfaces_provider_switch_failure(monkeypatch):
     """When provider switch fails, chat_stream must raise HTTPException instead
     of silently falling back to the previous provider. Without this the UI

--- a/tests/test_execution_default_executor.py
+++ b/tests/test_execution_default_executor.py
@@ -1,0 +1,129 @@
+"""Contract tests for the default ``SubprocessExecutor`` wiring used by /jobs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from omicsclaw.execution.executors import (
+    JobContext,
+    SubprocessExecutor,
+    build_default_executor,
+    default_command_factory,
+)
+
+
+def _make_ctx(
+    *,
+    tmp_path: Path,
+    skill: str = "bulkrna-qc",
+    inputs: dict | None = None,
+    params: dict | None = None,
+) -> JobContext:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    artifact_root = tmp_path / "artifacts"
+    stdout_log = tmp_path / "stdout.log"
+    return JobContext(
+        job_id="job-abc",
+        workspace=workspace,
+        skill=skill,
+        inputs=inputs or {},
+        params=params or {},
+        artifact_root=artifact_root,
+        stdout_log=stdout_log,
+    )
+
+
+def test_default_command_factory_invokes_omicsclaw_run(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path=tmp_path, skill="bulkrna-qc")
+    argv = default_command_factory(ctx)
+
+    assert argv[0] == sys.executable, "must use current interpreter, not shell PATH"
+    # Entry point must be an absolute, existing path.
+    entry = Path(argv[1])
+    assert entry.is_absolute()
+    assert entry.name == "omicsclaw.py"
+    assert entry.is_file()
+    # Positional args match the CLI contract: `run <skill>`.
+    assert argv[2] == "run"
+    assert argv[3] == "bulkrna-qc"
+
+
+def test_default_command_factory_sets_output_to_artifact_root(tmp_path: Path) -> None:
+    """Every skill uses ``--output <dir>`` as its standard CLI flag."""
+    ctx = _make_ctx(tmp_path=tmp_path)
+    argv = default_command_factory(ctx)
+    assert "--output" in argv
+    output_value = argv[argv.index("--output") + 1]
+    assert Path(output_value) == ctx.artifact_root
+
+
+def test_default_command_factory_passes_demo_flag_when_requested(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path=tmp_path, inputs={"demo": True})
+    argv = default_command_factory(ctx)
+    assert "--demo" in argv
+
+
+def test_default_command_factory_passes_input_path_when_provided(tmp_path: Path) -> None:
+    data_file = tmp_path / "dataset.h5ad"
+    data_file.write_bytes(b"")
+    ctx = _make_ctx(tmp_path=tmp_path, inputs={"input": str(data_file)})
+    argv = default_command_factory(ctx)
+    assert "--input" in argv
+    value = argv[argv.index("--input") + 1]
+    assert Path(value) == data_file
+
+
+def test_default_command_factory_prefers_path_key_as_alias_for_input(tmp_path: Path) -> None:
+    data_file = tmp_path / "dataset.h5ad"
+    data_file.write_bytes(b"")
+    ctx = _make_ctx(tmp_path=tmp_path, inputs={"path": str(data_file)})
+    argv = default_command_factory(ctx)
+    assert "--input" in argv
+    assert argv[argv.index("--input") + 1] == str(data_file)
+
+
+def test_default_command_factory_forwards_params_as_long_flags(tmp_path: Path) -> None:
+    ctx = _make_ctx(
+        tmp_path=tmp_path,
+        inputs={"demo": True},
+        params={"method": "harmony", "batch_key": "sample"},
+    )
+    argv = default_command_factory(ctx)
+    # Params become ``--method harmony --batch-key sample`` (snake→kebab).
+    assert "--method" in argv
+    assert argv[argv.index("--method") + 1] == "harmony"
+    assert "--batch-key" in argv
+    assert argv[argv.index("--batch-key") + 1] == "sample"
+
+
+def test_default_command_factory_omits_falsy_boolean_params(tmp_path: Path) -> None:
+    """``False`` params must NOT generate a flag; only ``True`` does."""
+    ctx = _make_ctx(tmp_path=tmp_path, params={"verbose": True, "dry_run": False})
+    argv = default_command_factory(ctx)
+    assert "--verbose" in argv
+    # Standalone flag: no value follows
+    idx = argv.index("--verbose")
+    # Next token must be another flag, or end of argv
+    assert idx + 1 == len(argv) or argv[idx + 1].startswith("--")
+    assert "--dry-run" not in argv
+
+
+def test_default_command_factory_ignores_none_param_values(tmp_path: Path) -> None:
+    ctx = _make_ctx(tmp_path=tmp_path, params={"method": None, "threshold": 0.5})
+    argv = default_command_factory(ctx)
+    assert "--method" not in argv
+    assert "--threshold" in argv
+    assert argv[argv.index("--threshold") + 1] == "0.5"
+
+
+def test_build_default_executor_returns_subprocess_executor() -> None:
+    executor = build_default_executor()
+    assert isinstance(executor, SubprocessExecutor)
+
+
+def test_jobs_router_default_executor_is_subprocess_executor() -> None:
+    from omicsclaw.remote.routers import jobs as jobs_module
+
+    assert isinstance(jobs_module._DEFAULT_EXECUTOR, SubprocessExecutor)

--- a/tests/test_execution_executors.py
+++ b/tests/test_execution_executors.py
@@ -1,0 +1,143 @@
+"""Executor abstraction scaffolding.
+
+``omicsclaw/execution/executors/`` provides the Executor Protocol and a
+baseline ``LocalExecutor`` that wraps today's ``executor_not_implemented``
+stub behavior. Keeping the same wire-level semantics lets us swap in a
+real in-process runner later without changing the App-facing contract.
+
+A matching Protocol makes SSH / Slurm executors a drop-in replacement once
+they land (plan §Non-Goals pins Slurm to Phase 9).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+def test_base_module_exports_protocol_and_dataclasses() -> None:
+    from omicsclaw.execution.executors import (
+        Executor,
+        JobContext,
+        JobOutcome,
+    )
+
+    assert inspect.isclass(JobContext)
+    assert inspect.isclass(JobOutcome)
+    assert hasattr(Executor, "run")
+
+
+def test_local_executor_returns_executor_not_implemented_outcome(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import (
+        JobContext,
+        JobOutcome,
+        LocalExecutor,
+    )
+
+    stdout_log = tmp_path / "stdout.log"
+    artifact_root = tmp_path / "artifacts"
+    ctx = JobContext(
+        job_id="job-1",
+        workspace=tmp_path,
+        skill="spatial-preprocess",
+        inputs={"dataset_id": "abc"},
+        params={},
+        artifact_root=artifact_root,
+        stdout_log=stdout_log,
+    )
+    outcome = asyncio.run(LocalExecutor().run(ctx))
+    assert isinstance(outcome, JobOutcome)
+    assert outcome.exit_code == 1
+    assert outcome.error == "executor_not_implemented"
+    assert outcome.stdout_text
+    assert "executor_not_implemented" in outcome.stdout_text
+
+
+def test_local_executor_supports_custom_implementations() -> None:
+    """LocalExecutor itself can be replaced by any Executor-compatible
+    callable. Smoke-check Protocol duck-typing so alternate executors
+    don't need to subclass anything."""
+    from omicsclaw.execution.executors import Executor, JobContext, JobOutcome
+
+    class FakeExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            return JobOutcome(
+                exit_code=0,
+                error=None,
+                stdout_text="custom-run",
+            )
+
+    # Structural — no runtime isinstance needed; this asserts the shape.
+    fake: Executor = FakeExecutor()  # type: ignore[assignment]
+    outcome = asyncio.run(fake.run(  # type: ignore[arg-type]
+        JobContext(
+            job_id="x",
+            workspace=Path("/tmp"),
+            skill="noop",
+            inputs={},
+            params={},
+            artifact_root=Path("/tmp/a"),
+            stdout_log=Path("/tmp/s.log"),
+        )
+    ))
+    assert outcome.exit_code == 0
+    assert outcome.stdout_text == "custom-run"
+
+
+def test_jobs_router_dispatches_via_executor(monkeypatch, tmp_path: Path) -> None:
+    """Swap the default executor and confirm a submitted job's terminal
+    state reflects the custom outcome — i.e. the router delegates to the
+    abstraction rather than hard-coding the stub behavior."""
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from omicsclaw.execution.executors import JobContext, JobOutcome
+    from omicsclaw.remote.app_integration import register_remote_routers
+    from omicsclaw.remote.routers import jobs as jobs_module
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+
+    class SuccessExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            return JobOutcome(
+                exit_code=0,
+                error=None,
+                stdout_text="custom-success-marker",
+            )
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", SuccessExecutor())
+
+    app = FastAPI()
+    register_remote_routers(app)
+    client = TestClient(app)
+
+    response = client.post("/jobs", json={"skill": "noop", "inputs": {}})
+    assert response.status_code == 200, response.text
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    assert "event: job_succeeded" in body
+    assert "event: job_failed" not in body
+
+    final = client.get(f"/jobs/{job_id}").json()
+    assert final["status"] == "succeeded"
+    assert final["exit_code"] == 0
+
+    stdout = (
+        workspace
+        / ".omicsclaw"
+        / "remote"
+        / "jobs"
+        / job_id
+        / "stdout.log"
+    ).read_text(encoding="utf-8")
+    assert "custom-success-marker" in stdout

--- a/tests/test_execution_subprocess_executor.py
+++ b/tests/test_execution_subprocess_executor.py
@@ -1,0 +1,206 @@
+"""``SubprocessExecutor`` — real-process runner for remote jobs.
+
+Spawns an OS subprocess, merges stdout + stderr, and streams the combined
+output into ``ctx.stdout_log`` so the Stage-4 SSE tail picks it up live.
+Cooperative cancellation terminates the process (SIGTERM, then SIGKILL on
+timeout) so a user's "Cancel" button cannot leak runaway skill runs.
+
+Opt-in: callers build a ``command_factory`` that maps a ``JobContext`` to
+an argv list. The factory is the seam where skill routing lives — this
+class owns process lifecycle only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _ctx(tmp_path: Path) -> "JobContext":
+    from omicsclaw.execution.executors import JobContext
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return JobContext(
+        job_id="job-1",
+        workspace=workspace,
+        skill="noop",
+        inputs={},
+        params={},
+        artifact_root=workspace / "artifacts",
+        stdout_log=workspace / "stdout.log",
+    )
+
+
+def test_subprocess_executor_captures_stdout(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+    executor = SubprocessExecutor(
+        command_factory=lambda c: [sys.executable, "-c", "print('hello-world')"]
+    )
+    outcome = asyncio.run(executor.run(ctx))
+    assert outcome.exit_code == 0
+    assert outcome.error is None
+    assert "hello-world" in ctx.stdout_log.read_text(encoding="utf-8")
+    assert "hello-world" in outcome.stdout_text
+
+
+def test_subprocess_executor_nonzero_exit_is_failure(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+    executor = SubprocessExecutor(
+        command_factory=lambda c: [sys.executable, "-c", "raise SystemExit(7)"]
+    )
+    outcome = asyncio.run(executor.run(ctx))
+    assert outcome.exit_code == 7
+    assert outcome.error is not None
+    assert "7" in outcome.error
+
+
+def test_subprocess_executor_merges_stderr_into_stdout_log(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+    executor = SubprocessExecutor(
+        command_factory=lambda c: [
+            sys.executable,
+            "-c",
+            "import sys; print('to-out'); print('to-err', file=sys.stderr)",
+        ]
+    )
+    outcome = asyncio.run(executor.run(ctx))
+    assert outcome.exit_code == 0
+    content = ctx.stdout_log.read_text(encoding="utf-8")
+    assert "to-out" in content
+    assert "to-err" in content
+
+
+def test_subprocess_executor_streams_lines_before_exit(tmp_path: Path) -> None:
+    """stdout.log must contain the first line long before the subprocess
+    returns — otherwise SSE log-tail stays silent for slow skills."""
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+
+    async def run_and_poll() -> tuple[bool, object]:
+        executor = SubprocessExecutor(
+            command_factory=lambda c: [
+                sys.executable,
+                "-u",  # unbuffered so the first line flushes immediately
+                "-c",
+                "import sys,time\nprint('first-flush',flush=True)\ntime.sleep(0.4)\nprint('second')\n",
+            ]
+        )
+        run_task = asyncio.create_task(executor.run(ctx))
+        observed_first = False
+        for _ in range(30):
+            await asyncio.sleep(0.05)
+            if ctx.stdout_log.is_file():
+                text = ctx.stdout_log.read_text(encoding="utf-8")
+                if "first-flush" in text and "second" not in text:
+                    observed_first = True
+                    break
+        outcome = await run_task
+        return observed_first, outcome
+
+    observed_first, outcome = asyncio.run(run_and_poll())
+    assert outcome.exit_code == 0
+    assert observed_first, "expected 'first-flush' to appear before process exit"
+
+
+def test_subprocess_executor_spawn_failure_yields_outcome(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+    executor = SubprocessExecutor(
+        command_factory=lambda c: ["/definitely/not/a/real/binary-9a8b7c"]
+    )
+    outcome = asyncio.run(executor.run(ctx))
+    assert outcome.exit_code != 0
+    assert outcome.error is not None
+    assert "spawn_failed" in outcome.error
+
+
+def test_subprocess_executor_command_factory_failure_yields_outcome(
+    tmp_path: Path,
+) -> None:
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    def boom(ctx):
+        raise RuntimeError("planned failure")
+
+    ctx = _ctx(tmp_path)
+    outcome = asyncio.run(SubprocessExecutor(command_factory=boom).run(ctx))
+    assert outcome.exit_code != 0
+    assert outcome.error is not None
+    assert "command_factory_failed" in outcome.error
+
+
+def test_subprocess_executor_cancel_terminates_process(tmp_path: Path) -> None:
+    """Cancelling the run task must kill the subprocess promptly; no
+    stranded skill run after the user clicks Cancel."""
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+
+    async def scenario() -> float:
+        executor = SubprocessExecutor(
+            command_factory=lambda c: [
+                sys.executable,
+                "-c",
+                "import time; time.sleep(30)",
+            ]
+        )
+        run_task = asyncio.create_task(executor.run(ctx))
+        await asyncio.sleep(0.2)  # give subprocess time to start
+        start = time.monotonic()
+        run_task.cancel()
+        try:
+            await run_task
+        except asyncio.CancelledError:
+            pass
+        return time.monotonic() - start
+
+    elapsed = asyncio.run(scenario())
+    assert elapsed < 6.0, f"cancel took too long: {elapsed:.2f}s"
+
+
+def test_subprocess_executor_factory_receives_job_context(tmp_path: Path) -> None:
+    from omicsclaw.execution.executors import JobContext, SubprocessExecutor
+
+    seen: list[JobContext] = []
+
+    def factory(ctx: JobContext) -> list[str]:
+        seen.append(ctx)
+        return [sys.executable, "-c", "pass"]
+
+    ctx = _ctx(tmp_path)
+    asyncio.run(SubprocessExecutor(command_factory=factory).run(ctx))
+    assert len(seen) == 1
+    assert seen[0].job_id == "job-1"
+    assert seen[0].workspace == ctx.workspace
+
+
+def test_subprocess_executor_appends_to_existing_stdout_log(tmp_path: Path) -> None:
+    """If another caller (e.g. an earlier phase) seeded stdout.log, the
+    executor must append rather than truncate so prior context survives."""
+    from omicsclaw.execution.executors import SubprocessExecutor
+
+    ctx = _ctx(tmp_path)
+    ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+    ctx.stdout_log.write_text("pre-existing\n", encoding="utf-8")
+
+    executor = SubprocessExecutor(
+        command_factory=lambda c: [sys.executable, "-c", "print('after')"]
+    )
+    asyncio.run(executor.run(ctx))
+    content = ctx.stdout_log.read_text(encoding="utf-8")
+    assert "pre-existing" in content
+    assert "after" in content

--- a/tests/test_remote_artifacts_range.py
+++ b/tests/test_remote_artifacts_range.py
@@ -1,0 +1,113 @@
+"""``GET /artifacts/:id/download`` Range header support.
+
+Plan §API contract: "产物下载（支持 Range）". Large artifacts (e.g. a
+500 MB ``.h5ad``) must be resumable — both for flaky tunnels and for
+App-side browsers that issue Range by default when seeking a video /
+large file preview.
+
+FastAPI's ``FileResponse`` handles Range automatically, but "works by
+accident" is a regression waiting to happen. These tests pin the
+contract so swapping the response type later cannot silently break it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.remote.app_integration import register_remote_routers
+
+
+@pytest.fixture()
+def client_with_artifact(monkeypatch, tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+
+    # Seed a fixed-content artifact of known size.
+    job_id = "range-subject"
+    artifact_dir = workspace / ".omicsclaw" / "remote" / "jobs" / job_id / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    payload = bytes(range(256)) * 4  # 1024 bytes, each byte value known
+    (artifact_dir / "data.bin").write_bytes(payload)
+
+    app = FastAPI()
+    register_remote_routers(app)
+    client = TestClient(app)
+    return client, job_id, payload
+
+
+def _artifact_id(job_id: str, rel: str = "data.bin") -> str:
+    return f"{job_id}:{rel}"
+
+
+def test_download_without_range_returns_full_content(client_with_artifact) -> None:
+    client, job_id, payload = client_with_artifact
+    response = client.get(f"/artifacts/{_artifact_id(job_id)}/download")
+    assert response.status_code == 200
+    assert response.content == payload
+
+
+def test_download_with_range_returns_206_partial(client_with_artifact) -> None:
+    client, job_id, payload = client_with_artifact
+    response = client.get(
+        f"/artifacts/{_artifact_id(job_id)}/download",
+        headers={"Range": "bytes=100-199"},
+    )
+    assert response.status_code == 206, response.text
+    assert response.content == payload[100:200]
+    assert len(response.content) == 100
+
+
+def test_download_with_range_sets_content_range_header(
+    client_with_artifact,
+) -> None:
+    client, job_id, _ = client_with_artifact
+    response = client.get(
+        f"/artifacts/{_artifact_id(job_id)}/download",
+        headers={"Range": "bytes=0-9"},
+    )
+    assert response.status_code == 206
+    content_range = response.headers.get("content-range", "")
+    assert content_range.startswith("bytes 0-9/"), content_range
+
+
+def test_download_with_open_ended_range(client_with_artifact) -> None:
+    """``Range: bytes=N-`` means "from byte N to end"."""
+    client, job_id, payload = client_with_artifact
+    response = client.get(
+        f"/artifacts/{_artifact_id(job_id)}/download",
+        headers={"Range": "bytes=1000-"},
+    )
+    assert response.status_code == 206
+    assert response.content == payload[1000:]
+
+
+def test_download_with_suffix_range(client_with_artifact) -> None:
+    """``Range: bytes=-N`` means "last N bytes"."""
+    client, job_id, payload = client_with_artifact
+    response = client.get(
+        f"/artifacts/{_artifact_id(job_id)}/download",
+        headers={"Range": "bytes=-50"},
+    )
+    assert response.status_code == 206
+    assert response.content == payload[-50:]
+
+
+def test_download_advertises_accept_ranges_bytes(client_with_artifact) -> None:
+    """Clients inspect ``Accept-Ranges`` to decide whether resume is
+    even an option. Must be ``bytes`` (or present at all)."""
+    client, job_id, _ = client_with_artifact
+    response = client.get(f"/artifacts/{_artifact_id(job_id)}/download")
+    # Starlette's FileResponse includes this on 200s.
+    accept_ranges = response.headers.get("accept-ranges", "")
+    assert accept_ranges.lower() == "bytes", (
+        f"expected Accept-Ranges: bytes, got {accept_ranges!r}"
+    )

--- a/tests/test_remote_cancel_propagation.py
+++ b/tests/test_remote_cancel_propagation.py
@@ -1,0 +1,181 @@
+"""``POST /jobs/{id}/cancel`` must interrupt the in-flight executor.
+
+Before Stage 6 the cancel endpoint only flipped ``job.json`` to
+``canceled``; the asyncio task driving the executor (and any subprocess
+beneath it) kept running to completion. This file pins the real
+requirement at the unit level: ``cancel_job`` must call
+``asyncio.Task.cancel()`` on the registered task so ``CancelledError``
+reaches the executor's ``await`` point and e.g. ``SubprocessExecutor``'s
+SIGTERM path runs.
+
+Tests drive the handler directly via ``asyncio.run`` rather than through
+``TestClient``. The TestClient's underlying httpx Client is explicitly
+not thread-safe, so cross-thread SSE+cancel scenarios serialize on the
+connection pool — a cancel sent from a side thread stays queued behind
+the streaming read until the stream naturally closes, making it
+impossible to observe real cancel propagation through that code path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from omicsclaw.remote.routers import jobs as jobs_module
+from omicsclaw.remote.schemas import Job
+
+
+def _seed_running_job(workspace: Path, job_id: str) -> None:
+    job_dir = workspace / ".omicsclaw" / "remote" / "jobs" / job_id
+    job_dir.mkdir(parents=True)
+    job = Job(
+        job_id=job_id,
+        session_id="",
+        skill="slow",
+        status="running",
+        workspace=str(workspace),
+        inputs={},
+        params={},
+        created_at="2025-01-01T00:00:00+00:00",
+        started_at="2025-01-01T00:00:01+00:00",
+    )
+    (job_dir / "job.json").write_text(
+        json.dumps(job.model_dump()),
+        encoding="utf-8",
+    )
+
+
+def _prepare_workspace(monkeypatch, tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    # Avoid reconciler flipping our seeded running job.
+    jobs_module._RECONCILED_WORKSPACES.add(workspace.resolve())
+    return workspace
+
+
+def test_cancel_job_calls_task_cancel_on_registered_task(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The one-line fix: cancel_job must call ``task.cancel()`` so a
+    running executor observes ``CancelledError`` instead of running to
+    its natural (30 s) completion.
+
+    Verification uses passive observation (``task.done()`` after a short
+    yield) rather than ``asyncio.wait_for`` — wait_for cancels the task
+    itself on timeout, which would mask the exact bug we're testing.
+    """
+    workspace = _prepare_workspace(monkeypatch, tmp_path)
+    job_id = "cancel-subject"
+    _seed_running_job(workspace, job_id)
+
+    async def scenario() -> tuple[bool, bool]:
+        async def long_lived() -> None:
+            await asyncio.sleep(30.0)
+
+        task = asyncio.create_task(long_lived())
+        jobs_module._STUB_JOB_TASKS[job_id] = task
+        try:
+            await asyncio.sleep(0.05)  # park the task inside sleep
+            assert not task.done(), "precondition: task should still be sleeping"
+
+            result = await jobs_module.cancel_job(job_id)
+            assert result.status == "canceled"
+
+            # Yield a few times so any scheduled cancellation can land.
+            for _ in range(5):
+                await asyncio.sleep(0.05)
+                if task.done():
+                    break
+
+            return task.done(), task.cancelled()
+        finally:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            jobs_module._STUB_JOB_TASKS.pop(job_id, None)
+
+    done, cancelled = asyncio.run(scenario())
+    assert done, (
+        "task still running 0.25 s after cancel_job — cancel_job did not "
+        "call task.cancel() (task is still in its 30 s sleep)"
+    )
+    assert cancelled, "task.done() but task.cancelled() is False"
+
+
+def test_cancel_job_idempotent_second_call_is_noop(
+    monkeypatch, tmp_path: Path
+) -> None:
+    workspace = _prepare_workspace(monkeypatch, tmp_path)
+    job_id = "idempotent-subject"
+    _seed_running_job(workspace, job_id)
+
+    async def scenario() -> None:
+        async def immediate() -> None:
+            return None
+
+        task = asyncio.create_task(immediate())
+        await task
+        jobs_module._STUB_JOB_TASKS[job_id] = task
+        try:
+            first = await jobs_module.cancel_job(job_id)
+            second = await jobs_module.cancel_job(job_id)
+            assert first.status == "canceled"
+            assert second.status == "canceled"
+        finally:
+            jobs_module._STUB_JOB_TASKS.pop(job_id, None)
+
+    asyncio.run(scenario())
+
+
+def test_cancel_job_without_registered_task_still_flips_status(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Cancel must not require a live task in the registry — running jobs
+    restored from disk (or ones whose task already finished) should still
+    receive a clean status flip."""
+    workspace = _prepare_workspace(monkeypatch, tmp_path)
+    job_id = "no-task-subject"
+    _seed_running_job(workspace, job_id)
+
+    async def scenario() -> str:
+        assert job_id not in jobs_module._STUB_JOB_TASKS
+        result = await jobs_module.cancel_job(job_id)
+        return result.status
+
+    assert asyncio.run(scenario()) == "canceled"
+
+
+def test_cancel_job_does_not_raise_when_task_is_already_done(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """``asyncio.Task.cancel()`` on a completed task returns False but
+    must not raise — regression guard for a common footgun."""
+    workspace = _prepare_workspace(monkeypatch, tmp_path)
+    job_id = "already-done-subject"
+    _seed_running_job(workspace, job_id)
+
+    async def scenario() -> str:
+        async def already_done() -> None:
+            return None
+
+        task = asyncio.create_task(already_done())
+        await task
+        assert task.done()
+        jobs_module._STUB_JOB_TASKS[job_id] = task
+        try:
+            result = await jobs_module.cancel_job(job_id)
+            return result.status
+        finally:
+            jobs_module._STUB_JOB_TASKS.pop(job_id, None)
+
+    assert asyncio.run(scenario()) == "canceled"

--- a/tests/test_remote_datasets_delete.py
+++ b/tests/test_remote_datasets_delete.py
@@ -1,0 +1,152 @@
+"""``DELETE /datasets/{dataset_id}`` — remove a registered dataset.
+
+Semantics:
+- ``upload``-type datasets: the file lives inside the dataset dir, so
+  ``shutil.rmtree(dataset_dir)`` removes both the file and ``meta.json``.
+- ``import-remote``-type datasets: ``storage_uri`` points to a path
+  outside the workspace; the dataset dir only holds ``meta.json``. The
+  same rmtree just unregisters it — **the source file MUST NOT be
+  touched**, since deleting a user-provided path is a data-loss risk
+  the backend cannot recover from.
+
+Also verifies path-sandboxing on ``dataset_id`` and standard 404/204
+HTTP semantics.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.remote.app_integration import register_remote_routers
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+def _upload_demo(
+    client: TestClient, *, name: str = "demo.h5ad", payload: bytes | None = None
+) -> str:
+    if payload is None:
+        payload = name.encode("utf-8") * 16  # vary content per name to dodge
+                                             # checksum dedup from _upload_dataset
+    response = client.post(
+        "/datasets/upload",
+        files={"file": (name, io.BytesIO(payload), "application/octet-stream")},
+        data={"execution_target": "local"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["dataset_id"]
+
+
+def _import_remote(client: TestClient, src: Path) -> str:
+    response = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": str(src),
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["dataset_id"]
+
+
+def test_delete_upload_dataset_removes_file_and_meta(
+    client: TestClient, tmp_path: Path
+) -> None:
+    dataset_id = _upload_demo(client)
+    workspace = tmp_path / "workspace"
+    dataset_dir = (
+        workspace / ".omicsclaw" / "remote" / "datasets" / dataset_id
+    )
+    assert dataset_dir.is_dir()
+
+    response = client.delete(f"/datasets/{dataset_id}")
+    assert response.status_code == 204
+
+    assert not dataset_dir.exists()
+    listing = client.get("/datasets").json()
+    assert all(d["dataset_id"] != dataset_id for d in listing["datasets"])
+
+
+def test_delete_import_remote_dataset_preserves_source_file(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """CRITICAL: unregistering an imported path must not delete the
+    user's source file. Tests put the source OUTSIDE the workspace so a
+    naive ``shutil.rmtree`` on storage_uri would be caught."""
+    source = tmp_path / "outside" / "big-cohort.h5ad"
+    source.parent.mkdir()
+    source.write_bytes(b"precious" * 128)
+
+    dataset_id = _import_remote(client, source)
+
+    response = client.delete(f"/datasets/{dataset_id}")
+    assert response.status_code == 204
+
+    # Source must still exist — removing the meta dir is fine, deleting
+    # the referenced source is a data-loss bug.
+    assert source.is_file(), (
+        "DELETE /datasets/:id removed the user's source file — data loss"
+    )
+    assert source.read_bytes() == b"precious" * 128
+
+
+def test_delete_unknown_dataset_returns_404(client: TestClient) -> None:
+    response = client.delete("/datasets/not-a-real-id-xyz")
+    assert response.status_code == 404
+
+
+def test_delete_rejects_unsafe_dataset_id(client: TestClient) -> None:
+    """Path-traversal attempts and absolute paths must never reach
+    ``shutil.rmtree``.
+
+    ``.`` / ``..`` get canonicalized by httpx into ``/datasets`` or
+    ``/datasets/``, which the router resolves to the GET endpoint →
+    405 Method Not Allowed. That's a correct rejection at the routing
+    layer; anything in {400, 404, 405} means the dangerous id never hit
+    the handler.
+    """
+    for bad in ("../etc/passwd", "foo/bar", "..", "."):
+        response = client.delete(f"/datasets/{bad}")
+        assert response.status_code in (400, 404, 405), (
+            f"unsafe id {bad!r} accepted as {response.status_code}"
+        )
+
+
+def test_delete_is_idempotent_second_call_is_404(client: TestClient) -> None:
+    dataset_id = _upload_demo(client, name="once.h5ad")
+    first = client.delete(f"/datasets/{dataset_id}")
+    assert first.status_code == 204
+    second = client.delete(f"/datasets/{dataset_id}")
+    assert second.status_code == 404
+
+
+def test_delete_does_not_disturb_siblings(
+    client: TestClient, tmp_path: Path
+) -> None:
+    keep_id = _upload_demo(client, name="keep.h5ad")
+    drop_id = _upload_demo(client, name="drop.h5ad")
+
+    response = client.delete(f"/datasets/{drop_id}")
+    assert response.status_code == 204
+
+    listing = client.get("/datasets").json()
+    remaining_ids = {d["dataset_id"] for d in listing["datasets"]}
+    assert keep_id in remaining_ids
+    assert drop_id not in remaining_ids

--- a/tests/test_remote_jobs_atomic_write.py
+++ b/tests/test_remote_jobs_atomic_write.py
@@ -1,0 +1,174 @@
+"""Atomic ``job.json`` writes.
+
+``_write_job`` used to call ``Path.write_text`` directly, which under the
+hood is ``open(O_TRUNC) → write → close``. A crash / OOM-kill between the
+truncate and the final write leaves ``job.json`` empty or partially
+written; ``_read_job`` then returns ``None`` and the job status is
+lost *permanently* — the orphan reconciler can't recover it because it
+relies on reading the very file that was corrupted.
+
+Fix: write to a sibling ``.tmp`` file, then ``os.replace``. The rename
+is atomic on POSIX, so any concurrent reader always sees either the old
+complete content or the new complete content — never a truncated file.
+
+Tests simulate the crash by patching the temp write to raise mid-flight
+and assert the target file still deserializes to the pre-write state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from omicsclaw.remote.routers import jobs as jobs_module
+from omicsclaw.remote.schemas import Job
+
+
+def _make_job(*, job_id: str, status: str = "running", error: str | None = None) -> Job:
+    return Job(
+        job_id=job_id,
+        session_id="",
+        skill="spatial-preprocess",
+        status=status,
+        workspace="/tmp/placeholder",
+        inputs={},
+        params={},
+        created_at="2025-01-01T00:00:00+00:00",
+        started_at="2025-01-01T00:00:01+00:00",
+        error=error,
+    )
+
+
+def test_write_job_crash_between_truncate_and_write_preserves_old_content(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """RED: a naive ``path.write_text`` writer truncates the target
+    before writing the new content; a crash in between leaves an empty
+    file and ``_read_job`` returns ``None``.
+
+    GREEN: an atomic writer uses a ``.tmp`` sibling + ``os.replace``,
+    so sabotaging the final rename still leaves the target with its
+    pre-write content."""
+    workspace = tmp_path / "workspace"
+    job_id = "atomic-subject"
+
+    jobs_module._write_job(workspace, _make_job(job_id=job_id, status="running"))
+    path_before = jobs_module._job_path(workspace, job_id)
+    assert path_before.is_file()
+
+    real_write_text = Path.write_text
+    real_replace = Path.replace
+
+    def crash_direct_target_write(self: Path, *args, **kwargs):
+        # Non-atomic path: writer goes straight at the target. Simulate
+        # the kernel-level sequence of open(O_TRUNC) → crash-before-write.
+        if self == path_before:
+            with open(self, "wb"):
+                pass  # truncate to zero
+            raise RuntimeError("simulated crash after truncate")
+        return real_write_text(self, *args, **kwargs)
+
+    def crash_replace_into_target(self: Path, target):
+        # Atomic path: .tmp sibling was written, but the rename fails
+        # (simulating e.g. SIGKILL between write and rename). Target
+        # must remain untouched — because ``os.replace`` is atomic and
+        # hadn't landed.
+        if Path(target) == path_before:
+            raise OSError("simulated crash mid-rename")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "write_text", crash_direct_target_write)
+    monkeypatch.setattr(Path, "replace", crash_replace_into_target)
+
+    try:
+        jobs_module._write_job(
+            workspace, _make_job(job_id=job_id, status="failed", error="x")
+        )
+    except Exception:
+        pass
+
+    monkeypatch.setattr(Path, "write_text", real_write_text)
+    monkeypatch.setattr(Path, "replace", real_replace)
+
+    preserved = jobs_module._read_job(workspace, job_id)
+    assert preserved is not None, (
+        "target job.json was truncated — non-atomic writer corrupted state"
+    )
+    assert preserved.status == "running"
+
+
+def test_write_job_failure_in_temp_leaves_target_untouched(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """If the temp write itself errors, the original target must remain
+    the pre-write version, not the partial new content."""
+    workspace = tmp_path / "workspace"
+    job_id = "atomic-2"
+    jobs_module._write_job(workspace, _make_job(job_id=job_id, status="queued"))
+
+    target = jobs_module._job_path(workspace, job_id)
+    pre_content = target.read_text(encoding="utf-8")
+
+    real_write_text = Path.write_text
+
+    def fail_on_temp(self: Path, *args, **kwargs):
+        if self.name.endswith(".tmp"):
+            # Partially write then crash.
+            real_write_text(self, "{incomplete", *args[1:], **kwargs)
+            raise OSError("simulated disk-full")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_on_temp)
+
+    try:
+        jobs_module._write_job(
+            workspace, _make_job(job_id=job_id, status="running")
+        )
+    except OSError:
+        pass
+
+    monkeypatch.setattr(Path, "write_text", real_write_text)
+
+    assert target.read_text(encoding="utf-8") == pre_content
+
+
+def test_write_job_completes_cleans_up_stray_tmp_files(
+    tmp_path: Path,
+) -> None:
+    """After a successful write, no ``.tmp`` sibling should linger next
+    to the target (either it renamed into place, or nothing was left)."""
+    workspace = tmp_path / "workspace"
+    job_id = "atomic-3"
+    jobs_module._write_job(
+        workspace, _make_job(job_id=job_id, status="queued")
+    )
+
+    target = jobs_module._job_path(workspace, job_id)
+    tmp_candidates = list(target.parent.glob("*.tmp"))
+    assert tmp_candidates == [], f"stray temp files: {tmp_candidates}"
+
+
+def test_write_job_roundtrips_content_unchanged(tmp_path: Path) -> None:
+    """Sanity: the atomic write must produce a file the reader can parse
+    — atomic semantics must not break the content format."""
+    workspace = tmp_path / "workspace"
+    job = _make_job(job_id="atomic-rt", status="succeeded")
+    jobs_module._write_job(workspace, job)
+
+    roundtripped = jobs_module._read_job(workspace, "atomic-rt")
+    assert roundtripped is not None
+    assert roundtripped.model_dump() == job.model_dump()
+
+
+def test_write_job_overwrites_same_id_idempotently(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    jid = "atomic-overwrite"
+    jobs_module._write_job(workspace, _make_job(job_id=jid, status="queued"))
+    jobs_module._write_job(workspace, _make_job(job_id=jid, status="running"))
+    jobs_module._write_job(workspace, _make_job(job_id=jid, status="succeeded"))
+
+    final = jobs_module._read_job(workspace, jid)
+    assert final is not None
+    assert final.status == "succeeded"

--- a/tests/test_remote_jobs_reconcile.py
+++ b/tests/test_remote_jobs_reconcile.py
@@ -1,0 +1,214 @@
+"""Server-restart reconcile for orphaned ``running`` jobs.
+
+Scenario: the backend writes a job JSON with status ``running`` and an
+asyncio stub task that drives it to terminal state. If the process restarts
+while the job is running, the JSON stays at ``running`` but no task is
+driving it — the App would see "running forever". On first touch of a
+workspace, the router must mark such orphans as ``failed`` with a specific
+error code and persist diagnostic artifacts so the App can surface the
+reason.
+
+Newly submitted jobs (no prior stub task yet) must NOT be touched by the
+reconciler: they are legitimately queued/running on the current process.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.remote.app_integration import register_remote_routers
+from omicsclaw.remote.routers import jobs as jobs_module
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+def _seed_pre_existing_job(workspace: Path, job_id: str, status: str) -> Path:
+    """Plant a job JSON on disk as if it predated the current process."""
+    job_dir = workspace / ".omicsclaw" / "remote" / "jobs" / job_id
+    job_dir.mkdir(parents=True)
+    payload = {
+        "job_id": job_id,
+        "session_id": "",
+        "skill": "spatial-preprocess",
+        "status": status,
+        "workspace": str(workspace),
+        "inputs": {},
+        "params": {},
+        "created_at": "2025-01-01T00:00:00+00:00",
+        "started_at": "2025-01-01T00:00:01+00:00" if status == "running" else None,
+        "finished_at": None,
+        "exit_code": None,
+        "error": None,
+        "artifact_root": None,
+    }
+    (job_dir / "job.json").write_text(json.dumps(payload), encoding="utf-8")
+    return job_dir
+
+
+def test_orphaned_running_job_marked_failed_on_first_touch(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "orphan-1", status="running")
+
+    response = client.get("/jobs/orphan-1")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["error"] == "server_restart_orphaned_job"
+    assert body["exit_code"] == 1
+    assert body["finished_at"] is not None
+    assert body["artifact_root"] is not None
+
+
+def test_orphan_reconcile_persists_diagnostic_artifacts(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "orphan-2", status="running")
+
+    # Trigger reconcile.
+    client.get("/jobs/orphan-2")
+
+    artifacts = client.get("/artifacts", params={"job_id": "orphan-2"}).json()
+    paths = {artifact["relative_path"] for artifact in artifacts["artifacts"]}
+    assert "diagnostics/stdout.log" in paths
+    assert "diagnostics/env_doctor.json" in paths
+
+
+def test_queued_pre_existing_job_is_not_reconciled(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Queued jobs auto-recover via _ensure_stub_job; the reconciler must
+    never flip them to failed."""
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "queued-1", status="queued")
+
+    response = client.get("/jobs/queued-1")
+    assert response.status_code == 200
+    assert response.json()["status"] == "queued"
+    assert response.json().get("error") is None
+
+
+def test_new_submitted_job_not_touched_by_reconcile(client: TestClient) -> None:
+    """Submitting a fresh job must not be reconciled as orphaned — its
+    stub task is alive on the current process."""
+    response = client.post(
+        "/jobs", json={"skill": "spatial-preprocess", "inputs": {}}
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    immediate = client.get(f"/jobs/{job_id}").json()
+    # Must not have been prematurely failed with the orphan reason.
+    assert immediate.get("error") != "server_restart_orphaned_job"
+
+
+def test_terminal_jobs_not_reconciled(client: TestClient, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "already-done", status="succeeded")
+
+    response = client.get("/jobs/already-done")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "succeeded"
+    assert body.get("error") is None
+
+
+def test_list_jobs_also_reconciles_orphans(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "orphan-list", status="running")
+
+    listed = client.get("/jobs").json()
+    orphan = next(j for j in listed["jobs"] if j["job_id"] == "orphan-list")
+    assert orphan["status"] == "failed"
+    assert orphan["error"] == "server_restart_orphaned_job"
+
+
+def test_orphan_reconcile_retries_workspace_after_transient_failure(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_pre_existing_job(workspace, "orphan-retry", status="running")
+    jobs_module._RECONCILED_WORKSPACES.clear()
+
+    original = jobs_module._persist_failure_diagnostics
+    attempts = {"count": 0}
+
+    def flaky_persist(workspace: Path, job_id: str, *, stdout_text: str) -> str:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise OSError("disk full")
+        return original(workspace, job_id, stdout_text=stdout_text)
+
+    monkeypatch.setattr(jobs_module, "_persist_failure_diagnostics", flaky_persist)
+
+    first = client.get("/jobs/orphan-retry")
+    assert first.status_code == 200
+    assert first.json()["status"] == "running"
+
+    second = client.get("/jobs/orphan-retry")
+    assert second.status_code == 200
+    assert second.json()["status"] == "failed"
+    assert second.json()["error"] == "server_restart_orphaned_job"
+    assert attempts["count"] == 2
+
+
+def test_orphan_reconcile_continues_after_single_job_failure(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    bad_dir = _seed_pre_existing_job(workspace, "bad-job", status="running")
+    good_dir = _seed_pre_existing_job(workspace, "good-job", status="running")
+    jobs_module._RECONCILED_WORKSPACES.clear()
+
+    jobs_dir = workspace / ".omicsclaw" / "remote" / "jobs"
+    original_iterdir = Path.iterdir
+
+    def ordered_iterdir(self: Path):
+        if self == jobs_dir:
+            return iter([bad_dir, good_dir])
+        return original_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", ordered_iterdir)
+
+    original = jobs_module._persist_failure_diagnostics
+
+    def flaky_persist(workspace: Path, job_id: str, *, stdout_text: str) -> str:
+        if job_id == "bad-job":
+            raise OSError("diagnostics write failed")
+        return original(workspace, job_id, stdout_text=stdout_text)
+
+    monkeypatch.setattr(jobs_module, "_persist_failure_diagnostics", flaky_persist)
+
+    response = client.get("/jobs")
+    assert response.status_code == 200
+
+    rows = {job["job_id"]: job for job in response.json()["jobs"]}
+    assert rows["bad-job"]["status"] == "running"
+    assert rows["bad-job"]["error"] is None
+    assert rows["good-job"]["status"] == "failed"
+    assert rows["good-job"]["error"] == "server_restart_orphaned_job"

--- a/tests/test_remote_routes_auth.py
+++ b/tests/test_remote_routes_auth.py
@@ -1,0 +1,105 @@
+"""Bearer token auth for remote control-plane routers.
+
+When ``OMICSCLAW_REMOTE_AUTH_TOKEN`` is set, every request to remote routers
+must carry ``Authorization: Bearer <token>``. When the env var is unset the
+routers stay open so local development / single-user SSH-tunnel setups keep
+working unchanged (MVP-1 default in the plan — tunnel is the first layer,
+token is the second).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.remote.app_integration import register_remote_routers
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+def _make_client(workspace: Path, monkeypatch) -> TestClient:
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+def test_no_auth_required_when_token_env_unset(monkeypatch, workspace: Path) -> None:
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    client = _make_client(workspace, monkeypatch)
+    assert client.post("/connections/test").status_code == 200
+
+
+def test_auth_required_returns_401_without_header(monkeypatch, workspace: Path) -> None:
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "s3cret-token")
+    client = _make_client(workspace, monkeypatch)
+    response = client.post("/connections/test")
+    assert response.status_code == 401
+
+
+def test_auth_rejects_wrong_token(monkeypatch, workspace: Path) -> None:
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "s3cret-token")
+    client = _make_client(workspace, monkeypatch)
+    response = client.post(
+        "/connections/test",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status_code == 401
+
+
+def test_auth_rejects_non_bearer_scheme(monkeypatch, workspace: Path) -> None:
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "s3cret-token")
+    client = _make_client(workspace, monkeypatch)
+    response = client.post(
+        "/connections/test",
+        headers={"Authorization": "Basic s3cret-token"},
+    )
+    assert response.status_code == 401
+
+
+def test_auth_accepts_correct_bearer(monkeypatch, workspace: Path) -> None:
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "s3cret-token")
+    client = _make_client(workspace, monkeypatch)
+    response = client.post(
+        "/connections/test",
+        headers={"Authorization": "Bearer s3cret-token"},
+    )
+    assert response.status_code == 200
+
+
+def test_auth_applies_to_all_remote_routers(monkeypatch, workspace: Path) -> None:
+    """Every router shares the same dependency — no back-door endpoints."""
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "s3cret-token")
+    client = _make_client(workspace, monkeypatch)
+    unauthorized_endpoints = [
+        ("POST", "/connections/test"),
+        ("GET", "/env/doctor"),
+        ("GET", "/datasets"),
+        ("GET", "/jobs"),
+        ("GET", "/artifacts?job_id=anything"),
+        ("POST", "/sessions/foo/resume"),
+    ]
+    for method, path in unauthorized_endpoints:
+        response = client.request(method, path)
+        assert response.status_code == 401, f"{method} {path} should require auth"
+
+
+def test_auth_whitespace_and_empty_token_env_not_enforced(
+    monkeypatch, workspace: Path
+) -> None:
+    """Empty / whitespace-only token env is treated as unset (safer default)."""
+    monkeypatch.setenv("OMICSCLAW_REMOTE_AUTH_TOKEN", "   ")
+    client = _make_client(workspace, monkeypatch)
+    response = client.post("/connections/test")
+    assert response.status_code == 200

--- a/tests/test_remote_routes_contract.py
+++ b/tests/test_remote_routes_contract.py
@@ -1,0 +1,563 @@
+"""Contract tests for ``omicsclaw/remote/`` routers.
+
+Validates the JSON shape that ``OmicsClaw-App`` (Stage 0/1 already shipped)
+relies on. These tests pin the wire format; behavioural changes that affect
+the App must update both sides.
+
+Test pattern follows ``tests/test_app_server.py``: build an ad-hoc FastAPI
+instance and ``include_router`` directly to skip the heavy lifespan.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.execution.executors import LocalExecutor
+from omicsclaw.remote.app_integration import register_remote_routers
+from omicsclaw.remote.routers import jobs as jobs_module
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    # Contract tests pin wire format, not executor behavior. Keep the
+    # cheap instant-return stub so every submitted job deterministically
+    # ends in ``failed`` with ``executor_not_implemented`` — the real
+    # default (``SubprocessExecutor``) is covered separately.
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", LocalExecutor())
+
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# /connections/test  +  /env/doctor
+# ---------------------------------------------------------------------------
+
+
+def test_connections_test_returns_version_and_extras(client: TestClient) -> None:
+    response = client.post("/connections/test")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert isinstance(body["version"], str) and body["version"]
+    assert "server_time" in body
+    extras = body["extras"]
+    assert "gpu" in extras and "available" in extras["gpu"]
+    assert "disk_free_bytes" in extras
+
+
+def test_env_doctor_returns_doctor_report_shape(client: TestClient) -> None:
+    response = client.get("/env/doctor")
+    assert response.status_code == 200
+    body = response.json()
+    for field in ("generated_at", "workspace_dir", "omicsclaw_dir",
+                  "overall_status", "failure_count", "warning_count", "checks"):
+        assert field in body, f"missing field: {field}"
+    assert body["overall_status"] in {"ok", "warn", "fail"}
+    assert isinstance(body["checks"], list)
+    if body["checks"]:
+        check = body["checks"][0]
+        assert {"name", "status", "summary", "details"} <= set(check.keys())
+
+
+# ---------------------------------------------------------------------------
+# /datasets
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_upload_persists_and_lists(client: TestClient) -> None:
+    payload = b"H5AD-fake-content" * 64
+    response = client.post(
+        "/datasets/upload",
+        files={"file": ("demo.h5ad", io.BytesIO(payload), "application/octet-stream")},
+        data={"display_name": "Demo dataset", "execution_target": "local"},
+    )
+    assert response.status_code == 200, response.text
+    ref = response.json()
+    assert ref["display_name"] == "Demo dataset"
+    assert ref["execution_target"] == "local"
+    assert ref["size_bytes"] == len(payload)
+    assert ref["checksum"].startswith("sha256-64k:")
+    assert ref["status"] == "synced"
+    dataset_id = ref["dataset_id"]
+
+    listed = client.get("/datasets")
+    assert listed.status_code == 200
+    body = listed.json()
+    assert body["total"] >= 1
+    assert any(d["dataset_id"] == dataset_id for d in body["datasets"])
+
+
+def test_import_remote_rejects_relative_path(client: TestClient) -> None:
+    response = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": "relative/file.h5ad",
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_import_remote_registers_existing_file(client: TestClient, tmp_path: Path) -> None:
+    src = tmp_path / "remote_input.h5ad"
+    src.write_bytes(b"x" * 1024)
+    response = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": str(src),
+            "display_name": "from-scp",
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["display_name"] == "from-scp"
+    assert body["size_bytes"] == 1024
+    assert body["storage_uri"].startswith("file://")
+    assert body["execution_target"] == "remote:profile-a"
+
+
+def test_dataset_upload_requires_execution_target(client: TestClient) -> None:
+    response = client.post(
+        "/datasets/upload",
+        files={"file": ("demo.h5ad", io.BytesIO(b"x" * 16), "application/octet-stream")},
+    )
+    assert response.status_code == 422
+
+
+def test_import_remote_requires_execution_target(client: TestClient, tmp_path: Path) -> None:
+    src = tmp_path / "remote_required.h5ad"
+    src.write_bytes(b"x" * 16)
+    response = client.post(
+        "/datasets/import-remote",
+        json={"remote_path": str(src)},
+    )
+    assert response.status_code == 422
+
+
+def test_dataset_upload_same_payload_does_not_cross_execution_target_boundaries(
+    client: TestClient,
+) -> None:
+    payload = b"same-content" * 64
+    first = client.post(
+        "/datasets/upload",
+        files={"file": ("same.h5ad", io.BytesIO(payload), "application/octet-stream")},
+        data={"execution_target": "remote:profile-a"},
+    )
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/datasets/upload",
+        files={"file": ("same.h5ad", io.BytesIO(payload), "application/octet-stream")},
+        data={"execution_target": "remote:profile-b"},
+    )
+    assert second.status_code == 200, second.text
+
+    first_body = first.json()
+    second_body = second.json()
+    assert first_body["checksum"] == second_body["checksum"]
+    assert first_body["dataset_id"] != second_body["dataset_id"]
+    assert first_body["execution_target"] == "remote:profile-a"
+    assert second_body["execution_target"] == "remote:profile-b"
+
+    listed = client.get("/datasets")
+    assert listed.status_code == 200
+    body = listed.json()
+    assert body["total"] == 2
+    assert {dataset["execution_target"] for dataset in body["datasets"]} == {
+        "remote:profile-a",
+        "remote:profile-b",
+    }
+
+
+def test_list_datasets_marks_missing_storage_as_stale(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "remote_missing.h5ad"
+    src.write_bytes(b"x" * 16)
+    imported = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": str(src),
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert imported.status_code == 200, imported.text
+    dataset_id = imported.json()["dataset_id"]
+
+    src.unlink()
+
+    listed = client.get("/datasets")
+    assert listed.status_code == 200
+    body = listed.json()
+    stale = next(dataset for dataset in body["datasets"] if dataset["dataset_id"] == dataset_id)
+    assert stale["status"] == "stale"
+
+
+def test_import_remote_does_not_deduplicate_against_stale_dataset(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    original = tmp_path / "remote_original.h5ad"
+    original.write_bytes(b"same-content" * 16)
+    first = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": str(original),
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+
+    original.unlink()
+    listed = client.get("/datasets")
+    assert listed.status_code == 200
+    stale = next(
+        dataset
+        for dataset in listed.json()["datasets"]
+        if dataset["dataset_id"] == first_body["dataset_id"]
+    )
+    assert stale["status"] == "stale"
+
+    replacement = tmp_path / "remote_replacement.h5ad"
+    replacement.write_bytes(b"same-content" * 16)
+    second = client.post(
+        "/datasets/import-remote",
+        json={
+            "remote_path": str(replacement),
+            "execution_target": "remote:profile-a",
+        },
+    )
+    assert second.status_code == 200, second.text
+    second_body = second.json()
+    assert second_body["dataset_id"] != first_body["dataset_id"]
+    assert second_body["status"] == "synced"
+    assert second_body["storage_uri"] == replacement.resolve().as_uri()
+
+
+# ---------------------------------------------------------------------------
+# /jobs
+# ---------------------------------------------------------------------------
+
+
+def _submit_job(
+    client: TestClient,
+    skill: str = "spatial-preprocess",
+    session_id: str = "",
+) -> str:
+    payload = {"skill": skill, "inputs": {"dataset_id": "abc"}}
+    if session_id:
+        payload["session_id"] = session_id
+    response = client.post("/jobs", json=payload)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], str) and body["job_id"]
+    return body["job_id"]
+
+
+def test_job_submit_list_get_round_trip(client: TestClient) -> None:
+    job_id = _submit_job(client)
+
+    detail = client.get(f"/jobs/{job_id}").json()
+    assert detail["job_id"] == job_id
+    assert detail["status"] == "queued"
+    assert detail["skill"] == "spatial-preprocess"
+    assert detail["inputs"] == {"dataset_id": "abc"}
+
+    listed = client.get("/jobs", params={"status": "queued"}).json()
+    assert any(j["job_id"] == job_id for j in listed["jobs"])
+
+
+def test_job_submit_uses_resolved_workspace_not_client_claim(client: TestClient) -> None:
+    import os
+
+    response = client.post(
+        "/jobs",
+        json={"skill": "spatial-preprocess", "workspace": "/tmp/not-the-real-workspace"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    detail = client.get(f"/jobs/{body['job_id']}")
+    assert detail.status_code == 200
+    assert detail.json()["workspace"] == os.environ["OMICSCLAW_WORKSPACE"]
+
+
+def test_chat_display_job_submission_stays_queued_until_chat_stream_binds_it(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/jobs",
+        json={
+            "skill": "chat",
+            "session_id": "sess-chat",
+            "params": {"job_kind": "chat_stream", "display_name": "chat turn"},
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "queued"
+
+    detail = client.get(f"/jobs/{body['job_id']}")
+    assert detail.status_code == 200
+    assert detail.json()["status"] == "queued"
+
+
+def test_job_cancel_marks_canceled(client: TestClient) -> None:
+    job_id = _submit_job(client)
+    response = client.post(f"/jobs/{job_id}/cancel")
+    assert response.status_code == 200
+    assert response.json()["status"] == "canceled"
+    # Idempotent — second cancel does not flip status.
+    again = client.post(f"/jobs/{job_id}/cancel")
+    assert again.json()["status"] == "canceled"
+
+
+def test_job_retry_creates_new_job(client: TestClient) -> None:
+    original = _submit_job(client)
+    # Drive to terminal state first — retry only works on finished jobs.
+    client.post(f"/jobs/{original}/cancel")
+    response = client.post(f"/jobs/{original}/retry")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["job_id"] != original
+
+
+def test_job_retry_rejects_active_job(client: TestClient) -> None:
+    queued = _submit_job(client)
+    response = client.post(f"/jobs/{queued}/retry")
+    assert response.status_code == 400
+    assert "terminal" in response.json()["detail"].lower() or "finished" in response.json()["detail"].lower()
+
+
+def test_job_events_streams_lifecycle(client: TestClient) -> None:
+    job_id = _submit_job(client)
+    with client.stream("GET", f"/jobs/{job_id}/events") as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        body = "".join(response.iter_text())
+    # Required SSE event names — App's EventSource subscribes to these.
+    for marker in ("event: job_queued", "event: job_started",
+                   "event: job_log", "event: job_failed", "event: done"):
+        assert marker in body, f"missing SSE marker: {marker}"
+
+
+def test_job_events_do_not_rewrite_canceled_job(client: TestClient) -> None:
+    job_id = _submit_job(client)
+    canceled = client.post(f"/jobs/{job_id}/cancel")
+    assert canceled.status_code == 200
+    assert canceled.json()["status"] == "canceled"
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+
+    assert "event: job_canceled" in body
+    assert "event: job_started" not in body
+    assert "event: job_failed" not in body
+
+    final = client.get(f"/jobs/{job_id}")
+    assert final.status_code == 200
+    assert final.json()["status"] == "canceled"
+
+
+def test_jobs_total_reports_matches_before_limit(client: TestClient) -> None:
+    _submit_job(client, skill="skill-a")
+    _submit_job(client, skill="skill-b")
+    _submit_job(client, skill="skill-c")
+
+    response = client.get("/jobs", params={"limit": 1})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["jobs"]) == 1
+    assert body["total"] == 3
+
+
+# ---------------------------------------------------------------------------
+# /artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_artifacts_list_empty_when_no_outputs(client: TestClient) -> None:
+    response = client.get("/artifacts", params={"job_id": "nonexistent"})
+    assert response.status_code == 200
+    assert response.json() == {"artifacts": [], "total": 0}
+
+
+def test_artifacts_list_picks_up_files(client: TestClient) -> None:
+    import os
+
+    ws = Path(os.environ["OMICSCLAW_WORKSPACE"])
+    job_id = "job_with_output"
+    artifact_dir = ws / ".omicsclaw" / "remote" / "jobs" / job_id / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "report.md").write_text("# hi\n")
+
+    response = client.get("/artifacts", params={"job_id": job_id})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    artifact = body["artifacts"][0]
+    assert artifact["relative_path"] == "report.md"
+    assert artifact["mime_type"].startswith("text/")
+
+    download = client.get(f"/artifacts/{artifact['artifact_id']}/download")
+    assert download.status_code == 200
+    assert download.text == "# hi\n"
+
+
+def test_artifacts_created_at_is_stable_across_list_calls(client: TestClient) -> None:
+    import os
+    import time
+
+    ws = Path(os.environ["OMICSCLAW_WORKSPACE"])
+    job_id = "job_stable_artifact_time"
+    artifact_dir = ws / ".omicsclaw" / "remote" / "jobs" / job_id / "artifacts"
+    artifact_dir.mkdir(parents=True)
+    report = artifact_dir / "report.md"
+    report.write_text("# hi\n")
+
+    first = client.get("/artifacts", params={"job_id": job_id})
+    assert first.status_code == 200
+    created_at_1 = first.json()["artifacts"][0]["created_at"]
+
+    time.sleep(0.01)
+
+    second = client.get("/artifacts", params={"job_id": job_id})
+    assert second.status_code == 200
+    created_at_2 = second.json()["artifacts"][0]["created_at"]
+    assert created_at_1 == created_at_2
+
+
+def test_artifacts_reject_unsafe_job_id_query(client: TestClient) -> None:
+    response = client.get("/artifacts", params={"job_id": "../../../../outside"})
+    assert response.status_code == 400
+
+
+def test_artifact_download_rejects_unsafe_job_id_in_artifact_id(client: TestClient) -> None:
+    response = client.get("/artifacts/..%2F..%2F..%2F..%2Foutside:secret.txt/download")
+    assert response.status_code == 400
+
+
+def test_failed_job_persists_diagnostic_artifacts(client: TestClient) -> None:
+    import os
+
+    job_id = _submit_job(client, session_id="sess-diagnostics")
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as response:
+        assert response.status_code == 200
+        body = "".join(response.iter_text())
+
+    assert "event: job_failed" in body
+
+    detail = client.get(f"/jobs/{job_id}")
+    assert detail.status_code == 200
+    job = detail.json()
+    assert job["status"] == "failed"
+    assert isinstance(job["artifact_root"], str) and job["artifact_root"]
+
+    ws = Path(os.environ["OMICSCLAW_WORKSPACE"])
+    job_dir = ws / ".omicsclaw" / "remote" / "jobs" / job_id
+    stdout_path = job_dir / "stdout.log"
+    assert stdout_path.is_file()
+    stdout_text = stdout_path.read_text(encoding="utf-8")
+    assert "executor_not_implemented" in stdout_text
+
+    listed = client.get("/artifacts", params={"job_id": job_id})
+    assert listed.status_code == 200
+    artifacts = {artifact["relative_path"]: artifact for artifact in listed.json()["artifacts"]}
+    assert "diagnostics/env_doctor.json" in artifacts
+    assert "diagnostics/stdout.log" in artifacts
+
+    env_doctor = client.get(
+        f"/artifacts/{artifacts['diagnostics/env_doctor.json']['artifact_id']}/download"
+    )
+    assert env_doctor.status_code == 200
+    env_payload = env_doctor.json()
+    assert "overall_status" in env_payload
+    assert "checks" in env_payload
+
+    stdout_download = client.get(
+        f"/artifacts/{artifacts['diagnostics/stdout.log']['artifact_id']}/download"
+    )
+    assert stdout_download.status_code == 200
+    assert "executor_not_implemented" in stdout_download.text
+
+
+# ---------------------------------------------------------------------------
+# /sessions
+# ---------------------------------------------------------------------------
+
+
+def test_session_resume_returns_active_jobs(client: TestClient) -> None:
+    queued = _submit_job(client, session_id="sess-xyz")
+    response = client.post("/sessions/sess-xyz/resume")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["session_id"] == "sess-xyz"
+    assert body["resumed"] is True
+    assert queued in body["active_job_ids"]
+
+
+def test_session_resume_filters_active_jobs_by_session_id(client: TestClient) -> None:
+    session_a = client.post(
+        "/jobs",
+        json={"skill": "spatial-preprocess", "session_id": "sess-a"},
+    )
+    assert session_a.status_code == 200
+    job_a = session_a.json()["job_id"]
+
+    session_b = client.post(
+        "/jobs",
+        json={"skill": "spatial-preprocess", "session_id": "sess-b"},
+    )
+    assert session_b.status_code == 200
+    job_b = session_b.json()["job_id"]
+
+    resumed = client.post("/sessions/sess-a/resume")
+    assert resumed.status_code == 200
+    body = resumed.json()
+    assert job_a in body["active_job_ids"]
+    assert job_b not in body["active_job_ids"]
+
+
+def test_dataset_upload_deduplicates_same_payload(client: TestClient) -> None:
+    payload = b"same-content" * 64
+    first = client.post(
+        "/datasets/upload",
+        files={"file": ("same.h5ad", io.BytesIO(payload), "application/octet-stream")},
+        data={"execution_target": "local"},
+    )
+    assert first.status_code == 200, first.text
+    second = client.post(
+        "/datasets/upload",
+        files={"file": ("same.h5ad", io.BytesIO(payload), "application/octet-stream")},
+        data={"execution_target": "local"},
+    )
+    assert second.status_code == 200, second.text
+
+    first_body = first.json()
+    second_body = second.json()
+    assert first_body["checksum"] == second_body["checksum"]
+    assert first_body["dataset_id"] == second_body["dataset_id"]
+
+    listed = client.get("/datasets")
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1

--- a/tests/test_remote_sse_log_tail.py
+++ b/tests/test_remote_sse_log_tail.py
@@ -1,0 +1,264 @@
+"""Real-time SSE log tailing from ``<job>/stdout.log``.
+
+Contract: whenever the active Executor writes a ``\\n``-terminated line to
+``ctx.stdout_log``, the SSE stream must emit a corresponding ``job_log``
+event (stream=``stdout``) *before* the eventual terminal status event.
+
+Key invariants:
+- Lines written in separate flushes must surface as separate events
+  (no batching across the whole run).
+- No line is emitted twice, even if the SSE loop polls the file many times.
+- A pre-existing ``stdout.log`` (e.g. session resume) is drained on the
+  first subscription.
+- Unterminated trailing content is flushed only at terminal state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+from typing import List
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.execution.executors import JobContext, JobOutcome
+from omicsclaw.remote.app_integration import register_remote_routers
+from omicsclaw.remote.routers import jobs as jobs_module
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+def _parse_sse(body: str) -> List[dict]:
+    """Return [{event, data}] in stream order."""
+    events: list[dict] = []
+    for block in body.split("\n\n"):
+        if not block.strip():
+            continue
+        match = re.search(r"^event:\s*(\S+)", block, re.MULTILINE)
+        data_match = re.search(r"^data:\s*(.*)$", block, re.MULTILINE)
+        if not match or not data_match:
+            continue
+        try:
+            data = json.loads(data_match.group(1))
+        except json.JSONDecodeError:
+            data = data_match.group(1)
+        events.append({"event": match.group(1), "data": data})
+    return events
+
+
+def test_sse_tails_progressive_lines_as_separate_events(
+    monkeypatch, client: TestClient, tmp_path: Path
+) -> None:
+    """Executor writes 3 newline-terminated lines with pauses in between →
+    SSE emits 3 distinct ``job_log`` events, not one batched event."""
+
+    class ProgressiveExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            for line in ("step-1-done\n", "step-2-done\n", "step-3-done\n"):
+                await asyncio.sleep(0.05)
+                with ctx.stdout_log.open("ab") as fh:
+                    fh.write(line.encode("utf-8"))
+            return JobOutcome(exit_code=0, error=None, stdout_text="")
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", ProgressiveExecutor())
+
+    response = client.post("/jobs", json={"skill": "noop"})
+    assert response.status_code == 200, response.text
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    events = _parse_sse(body)
+    log_lines = [
+        e["data"]["line"]
+        for e in events
+        if e["event"] == "job_log" and isinstance(e["data"], dict)
+    ]
+    assert "step-1-done" in log_lines
+    assert "step-2-done" in log_lines
+    assert "step-3-done" in log_lines
+
+
+def test_sse_log_events_use_stdout_stream(
+    monkeypatch, client: TestClient
+) -> None:
+    class OneLineExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            ctx.stdout_log.write_text("single-line\n", encoding="utf-8")
+            return JobOutcome(exit_code=0, error=None, stdout_text="")
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", OneLineExecutor())
+
+    response = client.post("/jobs", json={"skill": "noop"})
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    log_events = [e for e in _parse_sse(body) if e["event"] == "job_log"]
+    assert log_events, "expected at least one job_log event"
+    assert log_events[0]["data"]["stream"] == "stdout"
+
+
+def test_sse_does_not_duplicate_log_lines_across_polls(
+    monkeypatch, client: TestClient
+) -> None:
+    """File tailing must track position; a line written once must never
+    appear in two separate job_log events."""
+
+    class SlowExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            with ctx.stdout_log.open("ab") as fh:
+                fh.write(b"only-once\n")
+            # Sleep long enough that the SSE poll loop runs many times
+            # after the write, giving duplicate emissions a chance to happen.
+            await asyncio.sleep(0.2)
+            return JobOutcome(exit_code=0, error=None, stdout_text="")
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", SlowExecutor())
+    response = client.post("/jobs", json={"skill": "noop"})
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    only_once_events = [
+        e
+        for e in _parse_sse(body)
+        if e["event"] == "job_log"
+        and isinstance(e["data"], dict)
+        and e["data"].get("line") == "only-once"
+    ]
+    assert len(only_once_events) == 1, (
+        f"expected exactly one emission; got {len(only_once_events)}"
+    )
+
+
+def test_sse_resumes_pre_existing_stdout_log(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Subscribing to a job whose stdout.log already has content drains
+    that content as job_log events — the session-resume guarantee."""
+    workspace = tmp_path / "workspace"
+    job_id = "resumed-job"
+    job_dir = workspace / ".omicsclaw" / "remote" / "jobs" / job_id
+    job_dir.mkdir(parents=True)
+    (job_dir / "stdout.log").write_text(
+        "pre-existing-line-1\npre-existing-line-2\n", encoding="utf-8"
+    )
+    (job_dir / "job.json").write_text(
+        json.dumps({
+            "job_id": job_id,
+            "session_id": "",
+            "skill": "noop",
+            "status": "succeeded",
+            "workspace": str(workspace),
+            "inputs": {},
+            "params": {},
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "started_at": "2025-01-01T00:00:01+00:00",
+            "finished_at": "2025-01-01T00:00:02+00:00",
+            "exit_code": 0,
+            "error": None,
+            "artifact_root": str(job_dir / "artifacts"),
+        }),
+        encoding="utf-8",
+    )
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    log_lines = [
+        e["data"]["line"]
+        for e in _parse_sse(body)
+        if e["event"] == "job_log" and isinstance(e["data"], dict)
+    ]
+    assert "pre-existing-line-1" in log_lines
+    assert "pre-existing-line-2" in log_lines
+
+
+def test_sse_flushes_unterminated_trailing_line_at_done(
+    monkeypatch, client: TestClient
+) -> None:
+    """A final ``\\n``-less chunk must be flushed as a job_log event when
+    the job reaches terminal state — otherwise the last executor output
+    gets silently dropped."""
+
+    class NoTrailingNewlineExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            ctx.stdout_log.write_text("trailing-no-newline", encoding="utf-8")
+            return JobOutcome(exit_code=0, error=None, stdout_text="")
+
+    monkeypatch.setattr(
+        jobs_module, "_DEFAULT_EXECUTOR", NoTrailingNewlineExecutor()
+    )
+    response = client.post("/jobs", json={"skill": "noop"})
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    log_lines = [
+        e["data"]["line"]
+        for e in _parse_sse(body)
+        if e["event"] == "job_log" and isinstance(e["data"], dict)
+    ]
+    assert "trailing-no-newline" in log_lines
+
+
+def test_sse_log_events_appear_before_terminal_status(
+    monkeypatch, client: TestClient
+) -> None:
+    """User expects log context first, then the final status — reversing
+    the order makes the UI awkward (banner arrives before logs)."""
+
+    class LoggedExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            ctx.stdout_log.write_text(
+                "context-line-a\ncontext-line-b\n", encoding="utf-8"
+            )
+            return JobOutcome(exit_code=0, error=None, stdout_text="")
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", LoggedExecutor())
+    response = client.post("/jobs", json={"skill": "noop"})
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    events = _parse_sse(body)
+    names = [e["event"] for e in events]
+    terminal_index = names.index("job_succeeded")
+    log_positions = [
+        i
+        for i, e in enumerate(events)
+        if e["event"] == "job_log"
+        and isinstance(e["data"], dict)
+        and e["data"].get("line", "").startswith("context-line")
+    ]
+    assert log_positions, "expected log events"
+    assert max(log_positions) < terminal_index, (
+        "all context log events should be emitted before job_succeeded"
+    )

--- a/tests/test_remote_sse_resume.py
+++ b/tests/test_remote_sse_resume.py
@@ -1,0 +1,277 @@
+"""SSE ``Last-Event-ID`` resume cursor.
+
+Plan §关键风险2: "SSE 断链自动重订阅；``/jobs/:id/events?resume=1`` 从最后
+cursor 续流". When the tunnel hiccups or the App tab is backgrounded, the
+browser's EventSource automatically reconnects with the ``Last-Event-ID``
+header set to the last seen event id. The server must resume the log
+tail at that byte offset so the user doesn't see duplicate output.
+
+Invariants tested:
+- ``job_log`` events carry an ``id:`` line equal to the end-byte-offset
+  of the line in ``stdout.log``.
+- Each line has a DIFFERENT id — otherwise a client crash between two
+  lines in the same poll batch would lose one.
+- Reconnecting with ``Last-Event-ID: N`` skips log bytes <= N.
+- Invalid / non-numeric headers fall back to a fresh subscribe
+  (byte 0) so the worst case is the existing duplication behaviour.
+- Status events stay id-less — the SSE spec says the client keeps its
+  previous Last-Event-ID, which is the correct cursor for log resume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omicsclaw.execution.executors import JobContext, JobOutcome
+from omicsclaw.remote.app_integration import register_remote_routers
+from omicsclaw.remote.routers import jobs as jobs_module
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path: Path) -> TestClient:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+    monkeypatch.delenv("OMICSCLAW_REMOTE_AUTH_TOKEN", raising=False)
+    app = FastAPI()
+    register_remote_routers(app)
+    return TestClient(app)
+
+
+def _parse_sse(body: str) -> List[dict]:
+    events: list[dict] = []
+    for block in body.split("\n\n"):
+        if not block.strip():
+            continue
+        ev = re.search(r"^event:\s*(\S+)", block, re.MULTILINE)
+        dm = re.search(r"^data:\s*(.*)$", block, re.MULTILINE)
+        idm = re.search(r"^id:\s*(\S+)", block, re.MULTILINE)
+        if not ev or not dm:
+            continue
+        try:
+            data = json.loads(dm.group(1))
+        except json.JSONDecodeError:
+            data = dm.group(1)
+        event_id = idm.group(1) if idm else None
+        events.append({"event": ev.group(1), "data": data, "id": event_id})
+    return events
+
+
+def _log_events(events: List[dict]) -> List[Tuple[str, str]]:
+    return [
+        (e["id"], e["data"]["line"])
+        for e in events
+        if e["event"] == "job_log" and isinstance(e["data"], dict)
+    ]
+
+
+def _seed_completed_job_with_log(
+    workspace: Path,
+    job_id: str,
+    log_text: str,
+    status: str = "succeeded",
+) -> None:
+    """Plant a terminal job whose stdout.log already contains ``log_text``.
+
+    This lets resume tests exercise the cursor purely from the SSE side
+    — no racing against a live executor.
+    """
+    job_dir = workspace / ".omicsclaw" / "remote" / "jobs" / job_id
+    job_dir.mkdir(parents=True)
+    (job_dir / "stdout.log").write_text(log_text, encoding="utf-8")
+    (job_dir / "job.json").write_text(
+        json.dumps({
+            "job_id": job_id,
+            "session_id": "",
+            "skill": "noop",
+            "status": status,
+            "workspace": str(workspace),
+            "inputs": {},
+            "params": {},
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "started_at": "2025-01-01T00:00:01+00:00",
+            "finished_at": "2025-01-01T00:00:02+00:00",
+            "exit_code": 0 if status == "succeeded" else 1,
+            "error": None,
+            "artifact_root": str(job_dir / "artifacts"),
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_log_events_carry_monotonic_ids_at_line_boundaries(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "id-check", "alpha\nbeta\ngamma\n"
+    )
+
+    with client.stream("GET", "/jobs/id-check/events") as stream:
+        body = "".join(stream.iter_text())
+
+    log_rows = _log_events(_parse_sse(body))
+    assert [line for _id, line in log_rows] == ["alpha", "beta", "gamma"]
+    ids = [int(event_id) for event_id, _ in log_rows]
+    assert ids == sorted(set(ids)), "ids must be strictly monotonic"
+    # "alpha\n" is 6 bytes → first id = 6; "beta\n" is 5 → 11; "gamma\n" 6 → 17
+    assert ids == [6, 11, 17]
+
+
+def test_resume_with_last_event_id_skips_seen_log_lines(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "resume-mid", "alpha\nbeta\ngamma\n"
+    )
+
+    # Simulate the client having already received through "beta" (id=11).
+    with client.stream(
+        "GET",
+        "/jobs/resume-mid/events",
+        headers={"Last-Event-ID": "11"},
+    ) as stream:
+        body = "".join(stream.iter_text())
+
+    log_rows = _log_events(_parse_sse(body))
+    lines = [line for _id, line in log_rows]
+    assert "alpha" not in lines
+    assert "beta" not in lines
+    assert "gamma" in lines
+
+
+def test_resume_past_end_of_log_emits_no_log_events(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "resume-end", "one\ntwo\n"
+    )
+
+    # Cursor beyond EOF: nothing left to stream.
+    with client.stream(
+        "GET",
+        "/jobs/resume-end/events",
+        headers={"Last-Event-ID": "9999"},
+    ) as stream:
+        body = "".join(stream.iter_text())
+
+    events = _parse_sse(body)
+    assert _log_events(events) == []
+    # Status + done must still fire so the App can reconcile state.
+    assert any(e["event"] == "job_succeeded" for e in events)
+    assert any(e["event"] == "done" for e in events)
+
+
+def test_resume_with_invalid_header_falls_back_to_fresh(
+    client: TestClient, tmp_path: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "resume-bad", "hello\nworld\n"
+    )
+
+    for bad in ("not-a-number", "", "-5", "1.5"):
+        with client.stream(
+            "GET",
+            "/jobs/resume-bad/events",
+            headers={"Last-Event-ID": bad},
+        ) as stream:
+            body = "".join(stream.iter_text())
+        lines = [line for _id, line in _log_events(_parse_sse(body))]
+        assert "hello" in lines, f"invalid header {bad!r} must yield fresh stream"
+        assert "world" in lines
+
+
+def test_status_events_do_not_carry_id(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """SSE spec: absent ``id:`` lets the client keep its previous id —
+    we want log-line cursors, not status cursors, to drive resume."""
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "status-ids", "just-one-line\n"
+    )
+
+    with client.stream("GET", "/jobs/status-ids/events") as stream:
+        body = "".join(stream.iter_text())
+
+    for e in _parse_sse(body):
+        if e["event"] in ("job_queued", "job_started", "job_succeeded",
+                          "job_failed", "job_canceled", "done"):
+            assert e["id"] is None, (
+                f"status event {e['event']} must not carry id"
+            )
+
+
+def test_resume_preserves_status_event_for_current_state(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Reconnecting clients still need to see the current status so
+    their UI updates — don't suppress status events just because the
+    cursor is already past all logs."""
+    workspace = tmp_path / "workspace"
+    _seed_completed_job_with_log(
+        workspace, "resume-status", "line\n", status="failed"
+    )
+
+    with client.stream(
+        "GET",
+        "/jobs/resume-status/events",
+        headers={"Last-Event-ID": "9999"},
+    ) as stream:
+        body = "".join(stream.iter_text())
+
+    names = [e["event"] for e in _parse_sse(body)]
+    assert "job_failed" in names
+
+
+def test_live_run_ids_roundtrip_and_resume_mid_stream(
+    monkeypatch, client: TestClient, tmp_path: Path
+) -> None:
+    """Full live scenario: run an executor that writes known lines,
+    capture the ids on the first subscribe, then reconnect with the
+    second line's id as Last-Event-ID and verify the third line comes
+    through without the first two."""
+
+    class LinesExecutor:
+        async def run(self, ctx: JobContext) -> JobOutcome:
+            ctx.stdout_log.parent.mkdir(parents=True, exist_ok=True)
+            for line in ("aaa\n", "bbb\n", "ccc\n"):
+                await asyncio.sleep(0.05)
+                with ctx.stdout_log.open("ab") as fh:
+                    fh.write(line.encode("utf-8"))
+            return JobOutcome(exit_code=0, stdout_text="")
+
+    monkeypatch.setattr(jobs_module, "_DEFAULT_EXECUTOR", LinesExecutor())
+    response = client.post("/jobs", json={"skill": "noop"})
+    job_id = response.json()["job_id"]
+
+    with client.stream("GET", f"/jobs/{job_id}/events") as stream:
+        body = "".join(stream.iter_text())
+
+    log_rows = _log_events(_parse_sse(body))
+    assert [line for _id, line in log_rows] == ["aaa", "bbb", "ccc"]
+    _bbb_id, _ = log_rows[1]
+
+    # Second subscribe with the second line's id as the cursor.
+    with client.stream(
+        "GET",
+        f"/jobs/{job_id}/events",
+        headers={"Last-Event-ID": _bbb_id},
+    ) as stream:
+        body2 = "".join(stream.iter_text())
+    resumed = [line for _id, line in _log_events(_parse_sse(body2))]
+    assert resumed == ["ccc"]

--- a/tests/test_remote_write_text_atomic.py
+++ b/tests/test_remote_write_text_atomic.py
@@ -1,0 +1,176 @@
+"""Atomic writes for diagnostic artifacts.
+
+Stage 7 made ``_write_job`` atomic for ``job.json``. This file extends
+the same guarantee to the diagnostic artifacts written through
+``_write_text``:
+
+- ``stdout.log`` (when the executor didn't stream — e.g. LocalExecutor
+  stub — and ``_finalize_stdout`` seeds it)
+- ``diagnostics/stdout.log`` (failure diagnostic snapshot)
+- ``diagnostics/env_doctor.json`` (env probe snapshot attached to
+  failed jobs)
+
+A crash mid-write leaves a truncated file — the App's failure-diagnostic
+flow then shows an empty stdout or a JSON parse error. The fix is the
+same temp-file + rename pattern used for ``job.json``.
+
+Non-goal: making executor-driven ``stdout.log`` writes atomic.
+``SubprocessExecutor`` appends byte-by-byte by design so the SSE tail
+can stream live. Atomicity at append-time would defeat that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omicsclaw.remote.routers import jobs as jobs_module
+
+
+def test_write_text_failure_preserves_existing_target(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """RED: naive ``write_text`` on target = truncate-then-crash →
+    empty target. GREEN: atomic writer writes to ``.tmp`` then
+    ``replace``; sabotaging the replace keeps the target at its
+    pre-write content."""
+    target = tmp_path / "dir" / "file.log"
+    target.parent.mkdir()
+    target.write_text("previous-content\n", encoding="utf-8")
+
+    real_write_text = Path.write_text
+    real_replace = Path.replace
+
+    def crash_on_direct_target(self: Path, *args, **kwargs):
+        if self == target:
+            with open(self, "wb"):
+                pass
+            raise RuntimeError("crash after truncate")
+        return real_write_text(self, *args, **kwargs)
+
+    def crash_on_target_rename(self: Path, target_path):
+        if Path(target_path) == target:
+            raise OSError("simulated crash mid-rename")
+        return real_replace(self, target_path)
+
+    monkeypatch.setattr(Path, "write_text", crash_on_direct_target)
+    monkeypatch.setattr(Path, "replace", crash_on_target_rename)
+    try:
+        jobs_module._write_text(target, "new-content\n")
+    except Exception:
+        pass
+    monkeypatch.setattr(Path, "write_text", real_write_text)
+    monkeypatch.setattr(Path, "replace", real_replace)
+
+    assert target.is_file()
+    assert target.read_text(encoding="utf-8") == "previous-content\n", (
+        "target was truncated — _write_text is not atomic"
+    )
+
+
+def test_write_text_crash_in_tmp_leaves_target_untouched(
+    monkeypatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "diagnostics" / "env_doctor.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"prior":true}', encoding="utf-8")
+    pre = target.read_text(encoding="utf-8")
+
+    real_write_text = Path.write_text
+
+    def crash_in_tmp(self: Path, *args, **kwargs):
+        if self.name.endswith(".tmp"):
+            # Partially write the tmp, then fail — simulates disk-full.
+            real_write_text(self, "{partial", *args[1:], **kwargs)
+            raise OSError("simulated disk full")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", crash_in_tmp)
+    try:
+        jobs_module._write_text(target, '{"now":true}')
+    except OSError:
+        pass
+    monkeypatch.setattr(Path, "write_text", real_write_text)
+
+    assert target.read_text(encoding="utf-8") == pre
+
+
+def test_write_text_success_leaves_no_stray_tmp(tmp_path: Path) -> None:
+    target = tmp_path / "report.log"
+    jobs_module._write_text(target, "done\n")
+    assert target.read_text(encoding="utf-8") == "done\n"
+    stray = list(target.parent.glob("*.tmp"))
+    assert stray == [], f"stray tmp files remain: {stray}"
+
+
+def test_write_text_creates_parent_dirs(tmp_path: Path) -> None:
+    target = tmp_path / "deep" / "nested" / "place" / "x.log"
+    jobs_module._write_text(target, "ok\n")
+    assert target.is_file()
+    assert target.read_text(encoding="utf-8") == "ok\n"
+
+
+def test_write_text_roundtrip_unchanged(tmp_path: Path) -> None:
+    target = tmp_path / "plain.txt"
+    payload = "line1\nline2\n中文\n"
+    jobs_module._write_text(target, payload)
+    assert target.read_text(encoding="utf-8") == payload
+
+
+def test_failure_diagnostics_env_doctor_json_is_atomic(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """End-to-end sanity: ``_persist_failure_diagnostics`` writes
+    ``env_doctor.json`` through ``_write_text``; a crash during that
+    write must not leave a corrupted JSON artifact for the App to
+    render as ``parse error``."""
+    workspace = tmp_path / "workspace"
+    monkeypatch.setenv("OMICSCLAW_WORKSPACE", str(workspace))
+
+    job_id = "diag-atomic"
+    # First-run: seed good diagnostics by running the real call.
+    jobs_module._persist_failure_diagnostics(
+        workspace, job_id, stdout_text="first run\n"
+    )
+    env_path = (
+        workspace / ".omicsclaw" / "remote" / "jobs" / job_id
+        / "artifacts" / "diagnostics" / "env_doctor.json"
+    )
+    assert env_path.is_file()
+    first_bytes = env_path.read_bytes()
+    assert first_bytes, "first diagnostics write should produce content"
+
+    # Second-run with a simulated crash during the env_doctor.json
+    # write. Under a non-atomic writer the target gets truncated; under
+    # the atomic writer, failing the ``replace`` preserves the prior
+    # content verbatim.
+    real_write_text = Path.write_text
+    real_replace = Path.replace
+
+    def crash_on_env_doctor(self: Path, *args, **kwargs):
+        if self == env_path:
+            with open(self, "wb"):
+                pass
+            raise RuntimeError("crash during env_doctor write")
+        return real_write_text(self, *args, **kwargs)
+
+    def crash_env_doctor_rename(self: Path, target_path):
+        if Path(target_path) == env_path:
+            raise OSError("simulated crash during env_doctor rename")
+        return real_replace(self, target_path)
+
+    monkeypatch.setattr(Path, "write_text", crash_on_env_doctor)
+    monkeypatch.setattr(Path, "replace", crash_env_doctor_rename)
+    try:
+        jobs_module._persist_failure_diagnostics(
+            workspace, job_id, stdout_text="second run\n"
+        )
+    except Exception:
+        pass
+    monkeypatch.setattr(Path, "write_text", real_write_text)
+    monkeypatch.setattr(Path, "replace", real_replace)
+
+    assert env_path.read_bytes() == first_bytes, (
+        "env_doctor.json was corrupted by mid-write crash"
+    )


### PR DESCRIPTION
## Summary

Adds the remote-execution surface that lets the Desktop App thin-client
run jobs against a backend reached over SSH / direct URL, plus the
docs and folder-picker endpoint that ship alongside it.

- **`feat(remote)` (28db12a)** — Executor abstraction (local + subprocess), remote job/dataset/artifact endpoints, and the integration tests that pin the wire contract with the App (SSE resume, artifact ranges, atomic writes, auth, cancel propagation, jobs reconcile, dataset delete, routes contract).
- **`docs(remote)` (90d3787, e505df2)** — Streamline README, refresh `docs/remote-connection-guide.md`, align with App v0.1.3+ unified Runtimes page (four RuntimeKinds, actual ConnectionProfile fields, dynamic SSH tunnel port, `/health` → `/env/doctor` bearer-token validation).
- **`feat(app-server)` (3f1db1e)** — `GET /files/browse` endpoint so the App's `<FolderPicker/>` can pick a workspace directory that lives on the *backend* filesystem when the two hosts differ. Response shape matches the App's local route field-for-field; bearer-auth-gated, read-only.

## Test plan

- [ ] `pytest tests/test_execution_*.py tests/test_remote_*.py tests/test_app_server.py`
- [ ] Manual: point Desktop App at a remote-SSH Runtime, pick a workspace folder via `<FolderPicker/>`, run a job, verify SSE log tail + artifact download.
- [ ] Manual: verify `GET /files/browse?path=<absolute>` rejects unauthenticated requests and returns `{current, parent, directories}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote control-plane API for executing jobs and managing datasets on remote servers
  * Implemented real-time job event streaming with Server-Sent Events and session resumption capabilities
  * Added health checks and environment diagnostics for remote connectivity validation
  * Added directory browsing endpoint for navigating workspace files

* **Documentation**
  * Added remote connection guide covering setup, configuration, and troubleshooting
  * Added implementation plan documenting the remote integration roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->