### PR TITLE
refactor(memory) PR #3a: MemoryEngine writes + namespace-aware indexer

### DIFF
--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -200,6 +200,7 @@ class DatabaseManager:
                         text("""
                             CREATE VIRTUAL TABLE IF NOT EXISTS search_documents_fts
                             USING fts5(
+                                namespace,
                                 domain,
                                 path,
                                 node_uuid,

--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -136,6 +136,11 @@ class DatabaseManager:
                 if not is_initialized:
                     await conn.run_sync(Base.metadata.create_all)
 
+            # Run any pending schema migrations after the base schema exists.
+            # Imported lazily to avoid a circular import at module load time.
+            from omicsclaw.memory.migrations import run_pending
+            await run_pending(self)
+
             # Ensure the root node exists (all edges reference it as parent)
             await self._ensure_root_node()
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -273,16 +273,98 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
         For ``core://*`` and ``preference://*`` URIs where the version
         chain is the audit trail. The old Memory keeps ``deprecated=True``
         and ``migrated_to=new_memory_id``; only the newest is active.
+        First write returns ``old_memory_id=None``.
         """
-        raise NotImplementedError("Task 3a.3")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is None:
+                # No existing path: this is a first write — same shape as upsert
+                # but routed through the versioned helper for return-type symmetry.
+                new_memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+                old_memory_id: Optional[int] = None
+            else:
+                old_memory_id, new_memory_id, node_uuid = (
+                    await self._upsert_versioned_chain(
+                        s, existing_path, content, priority, disclosure
+                    )
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return VersionedMemoryRef(
+            old_memory_id=old_memory_id,
+            new_memory_id=new_memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    async def _upsert_versioned_chain(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[Optional[int], int, str]:
+        """Insert a new active Memory and deprecate the previous active one.
+
+        Returns ``(old_memory_id, new_memory_id, node_uuid)``. ``old_memory_id``
+        is ``None`` only when no active Memory existed (orphan path), which
+        we recover from by treating the new write as the chain's first link.
+        """
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+        node_uuid = edge.child_uuid
+
+        old = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == node_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        new_memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(new_memory)
+        await s.flush()
+
+        old_id: Optional[int] = None
+        if old is not None:
+            old.deprecated = True
+            old.migrated_to = new_memory.id
+            old_id = old.id
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return old_id, new_memory.id, node_uuid
 
     async def patch_edge_metadata(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -1,0 +1,165 @@
+# pyright: reportArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
+
+"""MemoryEngine — namespace-aware hot path for memory writes and reads.
+
+This module is the "engine room" of the OmicsClaw memory architecture.
+It owns the canonical CRUD verbs over Node/Memory/Edge/Path and is the
+only layer that touches those tables directly.
+
+Above it sits ``MemoryClient`` (strategy: which namespace, version vs.
+overwrite); below it sits the ORM. The legacy ``GraphService`` is
+unaffected during PR #3a — see ``docs/2026-05-09-memory-refactor-plan.md``
+for the full migration path.
+
+Verbs landed in this PR (PR #3a):
+    - upsert(uri, content, namespace, ...)
+    - upsert_versioned(uri, content, namespace, ...)
+    - patch_edge_metadata(uri, namespace, ...)
+
+Verbs reserved for PR #3b:
+    - recall(uri, namespace, ...)
+    - search(query, namespace, ...)
+    - list_children(uri, namespace)
+    - get_subtree(uri, namespace, ...)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import select
+
+from .models import Edge, Memory, Node, Path
+from .uri import MemoryURI
+
+if TYPE_CHECKING:
+    from .database import DatabaseManager
+    from .search import SearchIndexer
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRef:
+    """Pointer to a single materialized memory at one (namespace, uri)."""
+
+    memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class VersionedMemoryRef:
+    """Result of a version-creating upsert.
+
+    ``old_memory_id`` is ``None`` on the first write (no chain yet).
+    """
+
+    old_memory_id: Optional[int]
+    new_memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+class MemoryEngine:
+    """Namespace-aware CRUD over the memory graph.
+
+    Constructed once per process and reused. Holds no per-namespace state —
+    every verb takes ``namespace`` as a required argument.
+    """
+
+    def __init__(self, db: "DatabaseManager", search: "SearchIndexer") -> None:
+        self._db = db
+        self._search = search
+
+    # ------------------------------------------------------------------
+    # Write verbs (PR #3a)
+    # ------------------------------------------------------------------
+
+    async def upsert(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> MemoryRef:
+        """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
+
+        Re-calling with the same (uri, namespace) UPDATEs the existing
+        Memory row's content in place — no deprecation chain, no new
+        Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
+        where history is not interesting.
+        """
+        raise NotImplementedError("Task 3a.2")
+
+    async def upsert_versioned(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> VersionedMemoryRef:
+        """Versioned upsert: deprecate the old Memory, insert a new one.
+
+        For ``core://*`` and ``preference://*`` URIs where the version
+        chain is the audit trail. The old Memory keeps ``deprecated=True``
+        and ``migrated_to=new_memory_id``; only the newest is active.
+        """
+        raise NotImplementedError("Task 3a.3")
+
+    async def patch_edge_metadata(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        priority: Optional[int] = None,
+        disclosure: Optional[str] = None,
+    ) -> None:
+        """Update Edge metadata (priority, disclosure) without touching Memory.
+
+        At least one of ``priority``/``disclosure`` must be provided.
+        """
+        raise NotImplementedError("Task 3a.4")
+
+    # ------------------------------------------------------------------
+    # Read verbs (PR #3b)
+    # ------------------------------------------------------------------
+
+    async def recall(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        fallback_to_shared: bool = True,
+    ) -> Optional[Any]:
+        raise NotImplementedError("PR #3b")
+
+    async def search(
+        self,
+        query: str,
+        *,
+        namespace: str,
+        domain: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        raise NotImplementedError("PR #3b")
+
+    async def list_children(
+        self, uri: str | MemoryURI, *, namespace: str
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")
+
+    async def get_subtree(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        limit: int = 100,
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -25,18 +25,21 @@ Verbs reserved for PR #3b:
 
 from __future__ import annotations
 
+import uuid as uuidlib
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Edge, Memory, Node, Path
+from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
+
+_UNSET: Any = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,8 +87,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -93,8 +96,176 @@ class MemoryEngine:
         Memory row's content in place — no deprecation chain, no new
         Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
         where history is not interesting.
+
+        ``priority`` and ``disclosure`` use a sentinel so an update call
+        without them preserves the existing edge's metadata; pass an
+        explicit ``None`` (or any value) to overwrite.
         """
-        raise NotImplementedError("Task 3a.2")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is not None:
+                memory_id, node_uuid = await self._upsert_existing(
+                    s, existing_path, content, priority, disclosure
+                )
+            else:
+                memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return MemoryRef(
+            memory_id=memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers (kept private — tests should drive only via verbs)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _fetch_path(
+        s: AsyncSession, namespace: str, parsed: MemoryURI
+    ) -> Optional[Path]:
+        return (
+            await s.execute(
+                select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def _upsert_existing(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+
+        memory = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == edge.child_uuid,
+                    Memory.deprecated == False,  # noqa: E712 — SQLAlchemy column comparison
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        if memory is None:
+            # Edge exists but has no active memory — create one and attach.
+            memory = Memory(
+                node_uuid=edge.child_uuid, content=content, deprecated=False
+            )
+            s.add(memory)
+            await s.flush()
+        else:
+            memory.content = content
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return memory.id, edge.child_uuid
+
+    async def _upsert_create(
+        self,
+        s: AsyncSession,
+        parsed: MemoryURI,
+        namespace: str,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
+
+        node_uuid = str(uuidlib.uuid4())
+        s.add(Node(uuid=node_uuid))
+        await s.flush()
+
+        memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(memory)
+        await s.flush()
+
+        edge_name = parsed.path.rsplit("/", 1)[-1] if "/" in parsed.path else parsed.path
+        edge = Edge(
+            parent_uuid=parent_uuid,
+            child_uuid=node_uuid,
+            name=edge_name,
+            priority=0 if priority is _UNSET else priority,
+            disclosure=None if disclosure is _UNSET else disclosure,
+        )
+        s.add(edge)
+        await s.flush()
+
+        s.add(
+            Path(
+                namespace=namespace,
+                domain=parsed.domain,
+                path=parsed.path,
+                edge_id=edge.id,
+            )
+        )
+        await s.flush()
+
+        return memory.id, node_uuid
+
+    @staticmethod
+    async def _resolve_parent_node_uuid(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> str:
+        """Resolve the parent node UUID for a new path, with shared fallback.
+
+        Top-level URIs (``core://agent``, ``analysis://sc-de``) attach to
+        ROOT. Nested URIs require the parent path to exist either in the
+        current namespace or in ``__shared__``. Falling back to shared lets
+        a per-user write attach under a globally-known structural parent.
+        """
+        parent_uri = parsed.parent()
+        if parent_uri is None or parent_uri.is_root:
+            return ROOT_NODE_UUID
+
+        for ns in (namespace, "__shared__"):
+            parent_path = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == ns,
+                        Path.domain == parent_uri.domain,
+                        Path.path == parent_uri.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if parent_path is None:
+                continue
+            parent_edge = await s.get(Edge, parent_path.edge_id)
+            if parent_edge is not None:
+                return parent_edge.child_uuid
+
+        raise ValueError(
+            f"Parent path {parent_uri} does not exist in namespace "
+            f"{namespace!r} or '__shared__' — create the parent first."
+        )
 
     async def upsert_versioned(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -371,14 +371,45 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Optional[int] = None,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 
-        At least one of ``priority``/``disclosure`` must be provided.
+        At least one of ``priority``/``disclosure`` must be provided. Pass
+        an explicit ``None`` to clear ``disclosure``. Memory rows and the
+        version chain are untouched; the search_documents row is refreshed
+        because priority and disclosure feed into search_terms.
         """
-        raise NotImplementedError("Task 3a.4")
+        if priority is _UNSET and disclosure is _UNSET:
+            raise ValueError(
+                "patch_edge_metadata requires at least one of priority "
+                "or disclosure to be set."
+            )
+
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            path_row = await self._fetch_path(s, namespace, parsed)
+            if path_row is None:
+                raise LookupError(
+                    f"Path for {parsed} in namespace {namespace!r} not found."
+                )
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                raise RuntimeError(
+                    f"Path {namespace}/{parsed} references a missing edge "
+                    f"— graph corruption."
+                )
+
+            if priority is not _UNSET:
+                edge.priority = priority
+            if disclosure is not _UNSET:
+                edge.disclosure = disclosure
+
+            await self._search.refresh_search_documents_for_node(
+                edge.child_uuid, session=s
+            )
 
     # ------------------------------------------------------------------
     # Read verbs (PR #3b)

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import uuid as uuidlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +39,31 @@ if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
 
-_UNSET: Any = object()
+
+class _UnsetType:
+    """Sentinel class for "argument was not supplied".
+
+    Lets ``priority: int | None | _UnsetType`` distinguish
+    "preserve the current value" (sentinel) from
+    "set the value to None" (explicit None). A regular ``None`` default
+    can't tell those apart.
+    """
+
+    _instance: Optional["_UnsetType"] = None
+
+    def __new__(cls) -> "_UnsetType":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "_UNSET"
+
+
+_UNSET: _UnsetType = _UnsetType()
+
+PriorityArg = Union[int, _UnsetType]
+DisclosureArg = Union[Optional[str], _UnsetType]
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,8 +111,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -150,8 +174,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         edge = await s.get(Edge, path_row.edge_id)
         if edge is None:
@@ -173,14 +197,20 @@ class MemoryEngine:
         ).scalar_one_or_none()
 
         if memory is None:
-            # Edge exists but has no active memory — create one and attach.
-            memory = Memory(
-                node_uuid=edge.child_uuid, content=content, deprecated=False
+            # Edge exists but no active memory: a deprecated chain might
+            # exist with no successor (a crash window in upsert_versioned,
+            # or a direct DB poke). We deliberately do NOT silently
+            # fabricate a fresh active memory — that would disconnect a
+            # deprecated tail from any successor and lose audit lineage.
+            # Surface the corruption so callers can route to ReviewLog.
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"has no active memory but the edge persists; refusing to "
+                f"silently rebuild. Inspect the deprecated chain for node "
+                f"{edge.child_uuid} and resolve via ReviewLog before retrying."
             )
-            s.add(memory)
-            await s.flush()
-        else:
-            memory.content = content
+
+        memory.content = content
 
         if priority is not _UNSET:
             edge.priority = priority
@@ -195,8 +225,8 @@ class MemoryEngine:
         parsed: MemoryURI,
         namespace: str,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
 
@@ -273,8 +303,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
@@ -320,8 +350,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[Optional[int], int, str]:
         """Insert a new active Memory and deprecate the previous active one.
 
@@ -371,8 +401,8 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 

--- a/omicsclaw/memory/migrations/001_namespace.py
+++ b/omicsclaw/memory/migrations/001_namespace.py
@@ -1,0 +1,167 @@
+"""001_namespace: Add namespace partition to paths, search_documents, glossary_keywords.
+
+Idempotent — checks for the namespace column on ``paths`` before doing any
+work. Backfills namespace from the ``disclosure`` field of session and memory
+records (best-effort; rows without parseable disclosure stay at ``__shared__``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+VERSION = "001_namespace"
+DESCRIPTION = "Add namespace partition to paths, search_documents, glossary_keywords"
+
+# Disclosure formats produced by compat.py:
+#   "Memory from session <platform>:<user_id>:<session_uuid>"
+#   "Session for user <user_id> on <platform>"
+_DISCLOSURE_MEMORY_RE = re.compile(r"Memory from session (\S+?):(\S+?):")
+_DISCLOSURE_SESSION_RE = re.compile(r"Session for user (\S+) on (\S+)")
+
+
+async def _column_exists(s, table: str, column: str) -> bool:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.all())
+
+
+def _parse_disclosure_namespace(disclosure: str | None) -> str | None:
+    """Extract ``f"{platform}/{user_id}"`` from a disclosure string, if possible."""
+    if not disclosure:
+        return None
+    m = _DISCLOSURE_MEMORY_RE.search(disclosure)
+    if m:
+        platform, user_id = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    m = _DISCLOSURE_SESSION_RE.search(disclosure)
+    if m:
+        user_id, platform = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    return None
+
+
+async def _backfill_namespace_from_disclosure(s) -> None:
+    """Update ``namespace`` on paths + search_documents based on disclosure data."""
+    result = await s.execute(
+        sa.text(
+            "SELECT domain, path, disclosure FROM search_documents "
+            "WHERE disclosure IS NOT NULL"
+        )
+    )
+    for domain, path, disclosure in result.all():
+        ns = _parse_disclosure_namespace(disclosure)
+        if not ns:
+            continue
+        await s.execute(
+            sa.text(
+                "UPDATE paths SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "UPDATE search_documents SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+
+
+async def apply(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        # Idempotent guard — column already added means migration has been applied.
+        if await _column_exists(s, "paths", "namespace"):
+            return
+
+        # 1. Rebuild paths with composite PK (namespace, domain, path)
+        await s.execute(sa.text("""
+            CREATE TABLE paths_new (
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO paths_new (namespace, domain, path, edge_id, created_at)
+            SELECT '__shared__', domain, path, edge_id, created_at FROM paths
+        """))
+        await s.execute(sa.text("DROP TABLE paths"))
+        await s.execute(sa.text("ALTER TABLE paths_new RENAME TO paths"))
+
+        # 2. Rebuild search_documents with composite PK
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents_new (
+                namespace    VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_new
+                (namespace, domain, path, node_uuid, memory_id, uri,
+                 content, disclosure, search_terms, priority, updated_at)
+            SELECT '__shared__', domain, path, node_uuid, memory_id, uri,
+                   content, disclosure, search_terms, priority, updated_at
+            FROM search_documents
+        """))
+        await s.execute(sa.text("DROP TABLE search_documents"))
+        await s.execute(sa.text("ALTER TABLE search_documents_new RENAME TO search_documents"))
+
+        # 3. Rebuild glossary_keywords with namespace + new UNIQUE constraint
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords_new (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                created_at DATETIME,
+                UNIQUE (namespace, keyword, node_uuid)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO glossary_keywords_new (id, keyword, node_uuid, namespace, created_at)
+            SELECT id, keyword, node_uuid, '__shared__', created_at FROM glossary_keywords
+        """))
+        await s.execute(sa.text("DROP TABLE glossary_keywords"))
+        await s.execute(sa.text("ALTER TABLE glossary_keywords_new RENAME TO glossary_keywords"))
+
+        # 4. Best-effort namespace backfill from disclosure metadata
+        await _backfill_namespace_from_disclosure(s)
+
+        # 5. Rebuild FTS5 virtual table with namespace column, repopulate from search_documents
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents_fts"))
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                namespace, domain, path, node_uuid, uri, content,
+                disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_fts (
+                rowid, namespace, domain, path, node_uuid, uri,
+                content, disclosure, search_terms
+            )
+            SELECT rowid, namespace, domain, path, node_uuid, uri,
+                   content, disclosure, search_terms
+            FROM search_documents
+        """))

--- a/omicsclaw/memory/migrations/__init__.py
+++ b/omicsclaw/memory/migrations/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight migrations framework for OmicsClaw memory schema.
+
+Each migration is a module exposing module-level ``VERSION`` (str),
+``DESCRIPTION`` (str), and ``async def apply(db: DatabaseManager) -> None``.
+The runner discovers them, applies pending ones in version-sorted order,
+and records applications in the ``_schema_version`` table.
+"""
+
+from omicsclaw.memory.migrations.runner import run_pending
+
+__all__ = ["run_pending"]

--- a/omicsclaw/memory/migrations/runner.py
+++ b/omicsclaw/memory/migrations/runner.py
@@ -1,0 +1,93 @@
+"""Lightweight migrations runner — see omicsclaw/memory/migrations/__init__.py."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Iterable, Protocol
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+_DEFAULT_MIGRATIONS_PACKAGE = "omicsclaw.memory.migrations"
+
+
+class Migration(Protocol):
+    VERSION: str
+    DESCRIPTION: str
+
+    async def apply(self, db: "DatabaseManager") -> None: ...
+
+
+_SCHEMA_VERSION_DDL = sa.text(
+    "CREATE TABLE IF NOT EXISTS _schema_version ("
+    "  version TEXT PRIMARY KEY,"
+    "  applied_at TEXT NOT NULL"
+    ")"
+)
+
+
+async def _ensure_schema_version_table(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        await s.execute(_SCHEMA_VERSION_DDL)
+
+
+async def _get_applied_versions(db: "DatabaseManager") -> set[str]:
+    async with db.session() as s:
+        result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+        return {row[0] for row in result.all()}
+
+
+async def _record_applied(db: "DatabaseManager", version: str) -> None:
+    async with db.session() as s:
+        await s.execute(
+            sa.text(
+                "INSERT INTO _schema_version (version, applied_at) "
+                "VALUES (:v, :t)"
+            ),
+            {"v": version, "t": datetime.now(timezone.utc).isoformat()},
+        )
+
+
+def _discover_migrations(package: str = _DEFAULT_MIGRATIONS_PACKAGE) -> list[Migration]:
+    """Import every NNN_*.py module in ``package`` and return them as migrations."""
+    pkg = importlib.import_module(package)
+    found: list[Migration] = []
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if not info.name[:1].isdigit():
+            continue
+        mod = importlib.import_module(f"{package}.{info.name}")
+        if all(hasattr(mod, attr) for attr in ("VERSION", "DESCRIPTION", "apply")):
+            found.append(mod)  # type: ignore[arg-type]
+    return found
+
+
+async def run_pending(
+    db: "DatabaseManager",
+    *,
+    migrations: Iterable[Migration] | None = None,
+) -> list[str]:
+    """Apply pending migrations in version-sorted order. Returns versions applied.
+
+    If ``migrations`` is None, discovers them from
+    ``omicsclaw.memory.migrations`` (numbered modules: ``001_*.py``).
+    """
+    if migrations is None:
+        migrations = _discover_migrations()
+
+    await _ensure_schema_version_table(db)
+    applied = await _get_applied_versions(db)
+
+    pending = [m for m in migrations if m.VERSION not in applied]
+    pending.sort(key=lambda m: m.VERSION)
+
+    versions_applied: list[str] = []
+    for m in pending:
+        await m.apply(db)
+        await _record_applied(db, m.VERSION)
+        versions_applied.append(m.VERSION)
+
+    return versions_applied

--- a/omicsclaw/memory/models.py
+++ b/omicsclaw/memory/models.py
@@ -142,14 +142,20 @@ class Edge(Base):
 
 
 class Path(Base):
-    """Materialized URI cache: (domain, path_string) → edge.
+    """Materialized URI cache: (namespace, domain, path_string) → edge.
 
     The source of truth for tree structure is the edges table.
-    Paths are a routing convenience for URI resolution.
+    Paths are a routing convenience for URI resolution. ``namespace``
+    partitions identical (domain, path) URIs across surfaces/users.
+    Default ``__shared__`` keeps legacy callers (GraphService) writing into
+    the same partition they always have.
     """
 
     __tablename__ = "paths"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     edge_id = Column(Integer, ForeignKey("edges.id"), nullable=True)
@@ -159,10 +165,11 @@ class Path(Base):
 
 
 class GlossaryKeyword(Base):
-    """Glossary keyword-to-node binding.
+    """Glossary keyword-to-node binding, partitioned by namespace.
 
     When a keyword appears in a memory's content, the frontend highlights
-    the keyword and links it to the associated node.
+    the keyword and links it to the associated node. Each namespace owns
+    its own keyword set; ``__shared__`` keywords are visible to all.
     """
 
     __tablename__ = "glossary_keywords"
@@ -174,20 +181,32 @@ class GlossaryKeyword(Base):
         ForeignKey("nodes.uuid", ondelete="CASCADE"),
         nullable=False,
     )
+    namespace = Column(
+        String(128), nullable=False, default="__shared__"
+    )
     created_at = Column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (
-        UniqueConstraint("keyword", "node_uuid", name="uq_glossary_keyword_node"),
+        UniqueConstraint(
+            "namespace", "keyword", "node_uuid", name="uq_glossary_keyword_node"
+        ),
     )
 
     node = relationship("Node")
 
 
 class SearchDocument(Base):
-    """Derived search row for one reachable path of an active node."""
+    """Derived search row for one reachable path of an active node.
+
+    Composite PK ``(namespace, domain, path)`` matches Path's so the indexer
+    can refresh exactly one row per write target.
+    """
 
     __tablename__ = "search_documents"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     node_uuid = Column(

--- a/omicsclaw/memory/namespace_policy.py
+++ b/omicsclaw/memory/namespace_policy.py
@@ -1,0 +1,51 @@
+"""Namespace + version policy — see docs/CONTEXT.md.
+
+Two independent classifications of a Memory URI:
+
+  resolve_namespace(uri, current=N)
+    → "__shared__" if uri matches a SHARED_PREFIXES entry, else N
+
+  should_version(uri)
+    → True if uri matches a VERSIONED_PREFIXES entry, else False
+
+Prefix semantics for both tables (`(domain, prefix)` tuples):
+  - empty prefix matches the whole domain (e.g., all of preference://*)
+  - non-empty prefix matches exact path OR "<prefix>/..." sub-paths
+  - "kh" does NOT match "khaki" — matching is by path-segment, not raw startswith
+"""
+
+from omicsclaw.memory.uri import MemoryURI
+
+SHARED = "__shared__"
+
+SHARED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "kh"),
+    ("core", "my_user_default"),
+)
+
+VERSIONED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "my_user"),
+    ("preference", ""),
+)
+
+
+def _matches_prefix(uri: MemoryURI, domain: str, prefix: str) -> bool:
+    if uri.domain != domain:
+        return False
+    if prefix == "":
+        return True
+    return uri.path == prefix or uri.path.startswith(prefix + "/")
+
+
+def _matches_any(uri: MemoryURI, prefixes: tuple[tuple[str, str], ...]) -> bool:
+    return any(_matches_prefix(uri, d, p) for d, p in prefixes)
+
+
+def resolve_namespace(uri: MemoryURI, *, current: str) -> str:
+    return SHARED if _matches_any(uri, SHARED_PREFIXES) else current
+
+
+def should_version(uri: MemoryURI) -> bool:
+    return _matches_any(uri, VERSIONED_PREFIXES)

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -105,11 +105,13 @@ class SearchIndexer:
 
         path_rows = (
             await session.execute(
-                select(Path.domain, Path.path, Edge.priority, Edge.disclosure)
+                select(
+                    Path.namespace, Path.domain, Path.path, Edge.priority, Edge.disclosure
+                )
                 .select_from(Path)
                 .join(Edge, Path.edge_id == Edge.id)
                 .where(Edge.child_uuid == node_uuid)
-                .order_by(Path.domain, Path.path)
+                .order_by(Path.namespace, Path.domain, Path.path)
             )
         ).all()
         if not path_rows:
@@ -127,6 +129,7 @@ class SearchIndexer:
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
+                    "namespace": row.namespace,
                     "domain": row.domain,
                     "path": row.path,
                     "node_uuid": node_uuid,
@@ -182,9 +185,9 @@ class SearchIndexer:
                     text(
                         """
                         INSERT INTO search_documents_fts (
-                            domain, path, node_uuid, uri, content, disclosure, search_terms
+                            namespace, domain, path, node_uuid, uri, content, disclosure, search_terms
                         ) VALUES (
-                            :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
+                            :namespace, :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
                         )
                         """
                     ),

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -466,11 +466,17 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
-                    bm25(search_documents_fts, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
+                    -- 8 bm25 weights, one per FTS column in declaration order:
+                    -- namespace, domain, path, node_uuid, uri, content,
+                    -- disclosure, search_terms. namespace gets 0.0 because
+                    -- the JOIN already filters it; domain/node_uuid stay 0.0
+                    -- so they don't influence ranking.
+                    bm25(search_documents_fts, 0.0, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
                 FROM search_documents AS sd
                 JOIN search_documents_fts
-                  ON search_documents_fts.domain = sd.domain
-                 AND search_documents_fts.path = sd.path
+                  ON search_documents_fts.namespace = sd.namespace
+                 AND search_documents_fts.domain    = sd.domain
+                 AND search_documents_fts.path      = sd.path
                 WHERE search_documents_fts MATCH :match_query
                   {domain_clause}
                 ORDER BY score ASC, sd.priority ASC, length(sd.path) ASC

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -21,9 +21,12 @@ from .models import (
     escape_like_literal,
 )
 from .search_terms import build_document_search_terms, expand_query_terms
+from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
+
+SHARED_NAMESPACE = "__shared__"
 
 
 class SearchIndexer:
@@ -117,15 +120,29 @@ class SearchIndexer:
         if not path_rows:
             return []
 
-        keyword_rows = await session.execute(
-            select(GlossaryKeyword.keyword)
-            .where(GlossaryKeyword.node_uuid == node_uuid)
-            .order_by(GlossaryKeyword.keyword)
-        )
-        glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+        # Glossary keywords are partitioned by namespace; for each search
+        # row we include only keywords visible from its namespace, i.e. the
+        # row's own namespace plus the global ``__shared__`` namespace.
+        keyword_rows = (
+            await session.execute(
+                select(GlossaryKeyword.keyword, GlossaryKeyword.namespace)
+                .where(GlossaryKeyword.node_uuid == node_uuid)
+                .order_by(GlossaryKeyword.namespace, GlossaryKeyword.keyword)
+            )
+        ).all()
+        keyword_by_ns: Dict[str, List[str]] = {}
+        for kw, ns in keyword_rows:
+            if not kw:
+                continue
+            keyword_by_ns.setdefault(ns, []).append(kw)
 
         documents = []
+        shared_keywords = keyword_by_ns.get(SHARED_NAMESPACE, [])
         for row in path_rows:
+            visible = list(keyword_by_ns.get(row.namespace, []))
+            if row.namespace != SHARED_NAMESPACE:
+                visible.extend(shared_keywords)
+            glossary_text = " ".join(visible)
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
@@ -199,11 +216,114 @@ class SearchIndexer:
     async def refresh_search_documents_for_node(
         self, node_uuid: str, session: Optional[AsyncSession] = None
     ) -> None:
-        """Rebuild derived search rows for one node."""
+        """Rebuild derived search rows for one node (all namespaces).
+
+        Used when a node's content or structural metadata changed and every
+        path pointing at it needs to be reindexed.
+        """
         async with self._optional_session(session) as session:
             documents = await self._build_search_documents_for_node(session, node_uuid)
             await self._delete_search_documents_for_node(session, node_uuid)
             await self._insert_search_documents(session, documents)
+
+    async def refresh_search_documents_for(
+        self,
+        namespace: str,
+        uri: str | MemoryURI,
+        session: Optional[AsyncSession] = None,
+    ) -> None:
+        """Surgically rebuild ONE search row at (namespace, domain, path).
+
+        Useful when a write touches only a single (namespace, uri) and we
+        don't want to disturb sibling rows for the same node in other
+        namespaces. No-op if the path doesn't exist or has no active memory.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._optional_session(session) as s:
+            path_row = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == namespace,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if path_row is None:
+                return
+
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                return
+
+            memory = (
+                await s.execute(
+                    select(Memory)
+                    .where(
+                        Memory.node_uuid == edge.child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    )
+                    .order_by(Memory.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if memory is None:
+                return
+
+            keyword_rows = (
+                await s.execute(
+                    select(GlossaryKeyword.keyword)
+                    .where(
+                        GlossaryKeyword.node_uuid == edge.child_uuid,
+                        GlossaryKeyword.namespace.in_(
+                            [namespace, SHARED_NAMESPACE]
+                        ),
+                    )
+                    .order_by(GlossaryKeyword.keyword)
+                )
+            ).all()
+            glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+
+            uri_str = f"{parsed.domain}://{parsed.path}"
+            doc = {
+                "namespace": namespace,
+                "domain": parsed.domain,
+                "path": parsed.path,
+                "node_uuid": edge.child_uuid,
+                "memory_id": memory.id,
+                "uri": uri_str,
+                "content": memory.content,
+                "disclosure": edge.disclosure,
+                "search_terms": build_document_search_terms(
+                    parsed.path,
+                    uri_str,
+                    memory.content,
+                    edge.disclosure,
+                    glossary_text,
+                ),
+                "priority": edge.priority,
+            }
+
+            if self.db_type == "sqlite":
+                try:
+                    await s.execute(
+                        text(
+                            "DELETE FROM search_documents_fts "
+                            "WHERE namespace = :ns AND domain = :d AND path = :p"
+                        ),
+                        {"ns": namespace, "d": parsed.domain, "p": parsed.path},
+                    )
+                except Exception:
+                    pass
+            await s.execute(
+                delete(SearchDocument).where(
+                    SearchDocument.namespace == namespace,
+                    SearchDocument.domain == parsed.domain,
+                    SearchDocument.path == parsed.path,
+                )
+            )
+            await self._insert_search_documents(s, [doc])
 
     async def get_node_uuids_for_prefix(
         self, session: AsyncSession, domain: str, base_path: str

--- a/omicsclaw/memory/uri.py
+++ b/omicsclaw/memory/uri.py
@@ -1,0 +1,61 @@
+"""MemoryURI value object — see docs/CONTEXT.md → "Memory URI"."""
+
+from dataclasses import dataclass
+
+DEFAULT_DOMAIN = "core"
+SCHEME_SEPARATOR = "://"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryURI:
+    """Stable identifier for a memory location, independent of row id.
+
+    Invariants (enforced in ``__post_init__``):
+      - ``domain`` is non-empty, contains no ``://``, no control chars
+      - ``path`` contains no ``://`` (slashes are fine; they delimit segments)
+
+    Construct via ``parse(raw)`` for ``"domain://path"`` strings, or
+    via ``root(domain)`` for the root URI of a domain.
+    """
+
+    domain: str
+    path: str
+
+    def __post_init__(self) -> None:
+        if not self.domain:
+            raise ValueError("MemoryURI domain must be non-empty")
+        if SCHEME_SEPARATOR in self.domain:
+            raise ValueError(f"MemoryURI domain must not contain '://': {self.domain!r}")
+        if any(ord(c) < 0x20 for c in self.domain):
+            raise ValueError(f"MemoryURI domain must not contain control characters: {self.domain!r}")
+        if SCHEME_SEPARATOR in self.path:
+            raise ValueError(f"MemoryURI path must not contain '://': {self.path!r}")
+
+    @classmethod
+    def parse(cls, raw: str) -> "MemoryURI":
+        if SCHEME_SEPARATOR in raw:
+            domain, path = raw.split(SCHEME_SEPARATOR, 1)
+        else:
+            domain, path = DEFAULT_DOMAIN, raw
+        return cls(domain=domain, path=path)
+
+    @classmethod
+    def root(cls, domain: str = DEFAULT_DOMAIN) -> "MemoryURI":
+        return cls(domain=domain, path="")
+
+    def __str__(self) -> str:
+        return f"{self.domain}{SCHEME_SEPARATOR}{self.path}"
+
+    @property
+    def is_root(self) -> bool:
+        return self.path == ""
+
+    def child(self, name: str) -> "MemoryURI":
+        new_path = f"{self.path}/{name}" if self.path else name
+        return MemoryURI(domain=self.domain, path=new_path)
+
+    def parent(self) -> "MemoryURI | None":
+        if self.is_root:
+            return None
+        head, _, _ = self.path.rpartition("/")
+        return MemoryURI(domain=self.domain, path=head)

--- a/scripts/migrate_dry_run.py
+++ b/scripts/migrate_dry_run.py
@@ -1,0 +1,154 @@
+"""Dry-run for OmicsClaw memory schema migrations.
+
+Copies a memory.db to a temp location and runs all pending migrations against
+the copy, printing a diff (table row counts before/after, namespace
+distribution after, count of disclosures we couldn't parse). Exit code 0
+only if the migration ran cleanly and row counts are preserved.
+
+The original memory.db is never touched.
+
+Usage:
+
+    python scripts/migrate_dry_run.py
+        # Defaults to ~/.config/omicsclaw/memory.db
+
+    python scripts/migrate_dry_run.py --db-path /path/to/memory.db
+
+Recommended workflow before deploying a new migration:
+
+    1. cp ~/.config/omicsclaw/memory.db ~/.config/omicsclaw/memory.db.pre-NNN.bak
+    2. python scripts/migrate_dry_run.py
+    3. Inspect output; rollback recipe is `cp memory.db.pre-NNN.bak memory.db`
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import sqlalchemy as sa
+
+
+_TABLES = ("nodes", "memories", "edges", "paths", "search_documents", "glossary_keywords")
+
+
+async def _row_counts(db) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    async with db.session() as s:
+        for table in _TABLES:
+            try:
+                result = await s.execute(sa.text(f"SELECT COUNT(*) FROM {table}"))
+                counts[table] = result.scalar_one()
+            except Exception as e:
+                counts[table] = -1  # table missing in this state
+    return counts
+
+
+async def _namespace_distribution(db) -> dict[str, int]:
+    """After migration, count rows per namespace across paths."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT namespace, COUNT(*) FROM paths GROUP BY namespace ORDER BY 2 DESC"
+            )
+        )
+        return {row[0]: row[1] for row in result.all()}
+
+
+async def _unparseable_disclosures(db) -> int:
+    """Count search_documents rows that have a non-empty disclosure but
+    still ended up in __shared__ (likely unparseable)."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM search_documents "
+                "WHERE namespace = '__shared__' "
+                "AND disclosure IS NOT NULL "
+                "AND TRIM(disclosure) <> ''"
+            )
+        )
+        return result.scalar_one()
+
+
+async def main_async(db_path: Path) -> int:
+    if not db_path.exists():
+        print(f"ERROR: source DB not found at {db_path}", file=sys.stderr)
+        return 2
+
+    # Copy to a temp file so the original is untouched
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        copy_path = Path(tmp.name)
+    shutil.copy2(db_path, copy_path)
+    print(f"Copied {db_path} -> {copy_path}")
+    print(f"Source size:  {db_path.stat().st_size:,} bytes")
+
+    # Defer DatabaseManager import so the script remains usable even with a
+    # partial install; if memory deps are missing it will surface here.
+    from omicsclaw.memory.database import DatabaseManager
+
+    url = f"sqlite+aiosqlite:///{copy_path}"
+    db = DatabaseManager(url)
+    try:
+        before = await _row_counts(db)
+        print(f"\nRow counts BEFORE migration:")
+        for tbl, n in before.items():
+            print(f"  {tbl:24s} {n:>8d}")
+
+        # init_db runs all pending migrations via the runner
+        await db.init_db()
+
+        after = await _row_counts(db)
+        print(f"\nRow counts AFTER migration:")
+        for tbl, n in after.items():
+            change = "" if before[tbl] == after[tbl] else f"  ← was {before[tbl]}"
+            print(f"  {tbl:24s} {n:>8d}{change}")
+
+        ns_dist = await _namespace_distribution(db)
+        print(f"\nNamespace distribution (paths) after migration:")
+        for ns, n in ns_dist.items():
+            print(f"  {ns:32s} {n:>8d}")
+
+        unparseable = await _unparseable_disclosures(db)
+        print(f"\nUnparseable disclosures: {unparseable}")
+
+        # Assertions
+        ok = True
+        for tbl in _TABLES:
+            if before[tbl] >= 0 and before[tbl] != after[tbl]:
+                print(
+                    f"\n❌ Row count changed for {tbl}: {before[tbl]} -> {after[tbl]}",
+                    file=sys.stderr,
+                )
+                ok = False
+
+        if ok:
+            print("\n✅ Migration applied cleanly. Row counts preserved.")
+            return 0
+        return 1
+    finally:
+        await db.close()
+        try:
+            copy_path.unlink()
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    default = Path.home() / ".config" / "omicsclaw" / "memory.db"
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=default,
+        help=f"Path to source memory.db (default: {default})",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args.db_path))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/memory/test_init_db_runs_migrations.py
+++ b/tests/memory/test_init_db_runs_migrations.py
@@ -1,0 +1,45 @@
+"""Tests that DatabaseManager.init_db() invokes the migrations runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        # Capture version count after first init
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            count_after_first = result.scalar_one()
+
+        # Second init must not raise and must not re-apply anything
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            assert result.scalar_one() == count_after_first
+    finally:
+        await db.close()

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -331,6 +331,22 @@ async def test_upsert_versioned_chain_can_have_3_links(engine):
 
 
 @pytest.mark.asyncio
+async def test_upsert_refuses_to_silently_rebuild_orphan_path(engine):
+    """If the active memory has been deactivated leaving a deprecated tail
+    behind, upsert (overwrite) must raise rather than silently fabricate
+    a new active memory — that would break the chain's audit lineage."""
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True  # simulated corruption: active row lost
+
+    with pytest.raises(RuntimeError, match="no active memory"):
+        await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+
+@pytest.mark.asyncio
 async def test_upsert_versioned_returns_namespace_isolated(engine):
     eng, db = engine
 

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -233,3 +233,111 @@ async def test_upsert_accepts_memory_uri_object(engine):
         namespace="tg/userA",
     )
     assert ref.uri == "core://agent"
+
+
+# ----------------------------------------------------------------------
+# upsert_versioned (deprecation chain mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_first_write_no_chain(engine):
+    eng, db = engine
+
+    ref = await eng.upsert_versioned(
+        "core://agent", "v1", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, VersionedMemoryRef)
+    assert ref.old_memory_id is None
+    assert ref.new_memory_id > 0
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.new_memory_id)
+        assert memory.deprecated is False
+        assert memory.migrated_to is None
+        assert memory.content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_creates_chain_on_second_write(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    assert second.old_memory_id == first.new_memory_id
+    assert second.new_memory_id != first.new_memory_id
+    assert second.node_uuid == first.node_uuid
+
+    async with db.session() as s:
+        old = await s.get(Memory, first.new_memory_id)
+        new = await s.get(Memory, second.new_memory_id)
+
+        assert old.deprecated is True
+        assert old.migrated_to == second.new_memory_id
+
+        assert new.deprecated is False
+        assert new.migrated_to is None
+        assert new.content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_old_search_doc_replaced(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalars().all()
+        # Exactly one search_documents row at (namespace, domain, path) — the
+        # composite PK guarantees that, but we also assert it points at the
+        # new memory_id, not the deprecated one.
+        assert len(rows) == 1
+        assert rows[0].memory_id == second.new_memory_id
+        assert rows[0].content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_chain_can_have_3_links(engine):
+    eng, db = engine
+
+    r1 = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    r2 = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+    r3 = await eng.upsert_versioned("core://agent", "v3", namespace="tg/userA")
+
+    async with db.session() as s:
+        m1 = await s.get(Memory, r1.new_memory_id)
+        m2 = await s.get(Memory, r2.new_memory_id)
+        m3 = await s.get(Memory, r3.new_memory_id)
+
+        assert m1.deprecated is True and m1.migrated_to == r2.new_memory_id
+        assert m2.deprecated is True and m2.migrated_to == r3.new_memory_id
+        assert m3.deprecated is False and m3.migrated_to is None
+
+        # All three memories share the same node_uuid (the conceptual entity).
+        assert m1.node_uuid == m2.node_uuid == m3.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_returns_namespace_isolated(engine):
+    eng, db = engine
+
+    a = await eng.upsert_versioned("core://agent", "for A", namespace="tg/userA")
+    b = await eng.upsert_versioned("core://agent", "for B", namespace="tg/userB")
+
+    # Different namespaces → independent chains, independent nodes.
+    assert a.node_uuid != b.node_uuid
+    assert a.old_memory_id is None
+    assert b.old_memory_id is None  # B's first write also has no chain

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -341,3 +341,146 @@ async def test_upsert_versioned_returns_namespace_isolated(engine):
     assert a.node_uuid != b.node_uuid
     assert a.old_memory_id is None
     assert b.old_memory_id is None  # B's first write also has no chain
+
+
+# ----------------------------------------------------------------------
+# patch_edge_metadata
+# ----------------------------------------------------------------------
+
+
+async def _get_edge_for(eng, uri: str, namespace: str):
+    """Helper: load the edge backing (namespace, uri)."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    parsed = MemoryURI.parse(uri)
+    async with eng._db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one()
+        return await s.get(Edge, path_row.edge_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_priority(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=9
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 9
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_disclosure(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", disclosure="hidden from search"
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.disclosure == "hidden from search"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_both(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent",
+        namespace="tg/userA",
+        priority=3,
+        disclosure="why this exists",
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 3
+    assert edge.disclosure == "why this exists"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_does_not_touch_memory(engine):
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        before = (await s.get(Memory, ref.memory_id)).content
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=1
+    )
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        # Same content; same row id (no new memory created).
+        assert memory.content == before
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == ref.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_refreshes_search_doc(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=7
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.priority == 7
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_namespace_isolated(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "A", namespace="tg/userA", priority=1)
+    await eng.upsert("core://agent", "B", namespace="tg/userB", priority=1)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=99
+    )
+
+    edge_a = await _get_edge_for(eng, "core://agent", "tg/userA")
+    edge_b = await _get_edge_for(eng, "core://agent", "tg/userB")
+    assert edge_a.priority == 99
+    assert edge_b.priority == 1  # B unchanged
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_raises_if_path_missing(engine):
+    eng, _ = engine
+    with pytest.raises(LookupError, match="not found"):
+        await eng.patch_edge_metadata(
+            "core://nonexistent", namespace="tg/userA", priority=1
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_requires_at_least_one_field(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "x", namespace="tg/userA")
+    with pytest.raises(ValueError, match="at least one"):
+        await eng.patch_edge_metadata("core://agent", namespace="tg/userA")

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -1,0 +1,235 @@
+"""Tests for MemoryEngine — namespace-aware hot-path writes.
+
+PR #3a covers the three write verbs (upsert, upsert_versioned,
+patch_edge_metadata). Read verbs are reserved for PR #3b.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine, MemoryRef, VersionedMemoryRef
+from omicsclaw.memory.models import Edge, Memory, Path, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# upsert (overwrite mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_path_and_memory(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "you are a helpful agent", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, MemoryRef)
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+    assert ref.memory_id > 0
+    assert ref.node_uuid
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert path_row.edge_id is not None
+
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.child_uuid == ref.node_uuid
+        assert edge.name == "agent"
+
+        memory = await s.get(Memory, ref.memory_id)
+        assert memory.content == "you are a helpful agent"
+        assert memory.deprecated is False
+        assert memory.node_uuid == ref.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_idempotent_same_namespace_updates_content(engine):
+    eng, db = engine
+
+    first = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+    # Same memory row — overwrite mode does NOT create a new Memory.
+    assert first.memory_id == second.memory_id
+    assert first.node_uuid == second.node_uuid
+
+    async with db.session() as s:
+        memory = await s.get(Memory, second.memory_id)
+        assert memory.content == "v2"
+
+        # Exactly one Memory row total for this node.
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == second.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_different_namespace_creates_separate_path(engine):
+    eng, db = engine
+
+    a = await eng.upsert("core://agent", "voice for A", namespace="tg/userA")
+    b = await eng.upsert("core://agent", "voice for B", namespace="tg/userB")
+
+    # Independent paths, independent nodes/memories.
+    assert a.namespace != b.namespace
+    assert a.node_uuid != b.node_uuid
+    assert a.memory_id != b.memory_id
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "core", Path.path == "agent"
+                )
+            )
+        ).scalars().all()
+        namespaces = sorted(r.namespace for r in rows)
+        assert namespaces == ["tg/userA", "tg/userB"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_refreshes_search_document(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "search me", namespace="tg/userA", priority=5
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.content == "search me"
+        assert sd.memory_id == ref.memory_id
+        assert sd.node_uuid == ref.node_uuid
+        assert sd.uri == "core://agent"
+        assert sd.priority == 5
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_requires_parent(engine):
+    eng, _ = engine
+
+    with pytest.raises(ValueError, match="Parent path"):
+        await eng.upsert(
+            "analysis://sc-de/run_42",
+            "results",
+            namespace="tg/userA",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_works_when_parent_exists(engine):
+    eng, db = engine
+
+    parent = await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    child = await eng.upsert(
+        "analysis://sc-de/run_42", "results", namespace="tg/userA"
+    )
+
+    assert child.node_uuid != parent.node_uuid
+
+    async with db.session() as s:
+        edge = (
+            await s.execute(
+                sa.select(Edge).where(Edge.child_uuid == child.node_uuid)
+            )
+        ).scalar_one()
+        assert edge.parent_uuid == parent.node_uuid
+        assert edge.name == "run_42"
+
+
+@pytest.mark.asyncio
+async def test_upsert_priority_and_disclosure_on_create(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent",
+        "content",
+        namespace="tg/userA",
+        priority=7,
+        disclosure="user-set",
+    )
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 7
+        assert edge.disclosure == "user-set"
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_clobber_priority_when_omitted_on_update(engine):
+    """Re-calling upsert without priority should preserve the edge's priority."""
+    eng, db = engine
+
+    await eng.upsert("core://agent", "v1", namespace="tg/userA", priority=42)
+    await eng.upsert("core://agent", "v2", namespace="tg/userA")  # priority omitted
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 42
+
+
+@pytest.mark.asyncio
+async def test_upsert_accepts_memory_uri_object(engine):
+    """upsert should accept either a string or a MemoryURI."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    eng, db = engine
+    ref = await eng.upsert(
+        MemoryURI(domain="core", path="agent"),
+        "content",
+        namespace="tg/userA",
+    )
+    assert ref.uri == "core://agent"

--- a/tests/memory/test_memory_uri.py
+++ b/tests/memory/test_memory_uri.py
@@ -1,0 +1,113 @@
+"""Tests for MemoryURI value object.
+
+See docs/CONTEXT.md → "Memory URI" for the contract this exercises.
+"""
+
+import pytest
+
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_parse_basic_uri():
+    uri = MemoryURI.parse("core://agent")
+    assert uri.domain == "core"
+    assert uri.path == "agent"
+
+
+def test_str_canonical_form():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    assert str(uri) == "dataset://pbmc.h5ad"
+
+
+def test_is_root_property():
+    assert MemoryURI(domain="core", path="").is_root is True
+    assert MemoryURI(domain="core", path="agent").is_root is False
+
+
+def test_child_appends_name_with_slash():
+    parent = MemoryURI(domain="analysis", path="sc-de")
+    assert parent.child("run_42") == MemoryURI(domain="analysis", path="sc-de/run_42")
+
+
+def test_child_of_root_has_no_leading_slash():
+    root = MemoryURI(domain="core", path="")
+    assert root.child("agent") == MemoryURI(domain="core", path="agent")
+
+
+def test_parent_strips_last_segment():
+    uri = MemoryURI(domain="analysis", path="sc-de/run_42")
+    assert uri.parent() == MemoryURI(domain="analysis", path="sc-de")
+
+
+def test_parent_of_single_segment_returns_root():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    parent = uri.parent()
+    assert parent == MemoryURI(domain="dataset", path="")
+    assert parent.is_root
+
+
+def test_parent_of_root_returns_none():
+    root = MemoryURI(domain="core", path="")
+    assert root.parent() is None
+
+
+def test_parse_without_scheme_defaults_to_core():
+    uri = MemoryURI.parse("agent")
+    assert uri == MemoryURI(domain="core", path="agent")
+
+
+def test_parse_root_uri_with_empty_path():
+    uri = MemoryURI.parse("core://")
+    assert uri == MemoryURI(domain="core", path="")
+    assert uri.is_root
+
+
+def test_root_classmethod_creates_root_uri():
+    assert MemoryURI.root("dataset") == MemoryURI(domain="dataset", path="")
+    assert MemoryURI.root() == MemoryURI(domain="core", path="")
+    assert MemoryURI.root("dataset").is_root
+
+
+def test_parse_str_roundtrip():
+    for raw in (
+        "core://agent",
+        "dataset://pbmc.h5ad",
+        "analysis://sc-de/run_42",
+        "core://",
+    ):
+        assert str(MemoryURI.parse(raw)) == raw, f"roundtrip failed for {raw!r}"
+
+
+def test_uri_is_hashable_and_equal_by_value():
+    a = MemoryURI(domain="core", path="agent")
+    b = MemoryURI(domain="core", path="agent")
+    c = MemoryURI(domain="core", path="other")
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+    assert len({a, b, c}) == 2  # set deduplicates a/b
+
+
+def test_empty_domain_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="", path="agent")
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI.parse("://agent")
+
+
+def test_domain_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="core://nope", path="agent")
+
+
+def test_path_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI(domain="core", path="x://y")
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI.parse("core://x://y")
+
+
+@pytest.mark.parametrize("bad_char", ["\n", "\t", "\x00", "\r"])
+def test_domain_with_control_chars_rejected(bad_char):
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain=f"core{bad_char}", path="agent")

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -14,9 +14,56 @@ def _load_001():
 
 
 async def _build_legacy_schema(db: DatabaseManager) -> None:
-    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    """Create the pre-001 schema explicitly (no namespace column).
+
+    The current ORM models already include ``namespace``, so we can't simply
+    call ``Base.metadata.create_all`` and expect a legacy result. Instead:
+
+    1. ``create_all`` to set up unrelated tables (nodes, memories, edges).
+    2. Drop the three namespace-bearing tables and recreate them with the
+       pre-001 schema using raw SQL so the migration has real legacy rows
+       to act on.
+    """
     async with db.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    async with db.session() as s:
+        await s.execute(sa.text("DROP TABLE IF EXISTS paths"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS glossary_keywords"))
+        await s.execute(sa.text("""
+            CREATE TABLE paths (
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents (
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                created_at DATETIME,
+                UNIQUE (keyword, node_uuid)
+            )
+        """))
 
 
 async def _pk_columns_in_order(s, table: str) -> list[str]:

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -1,0 +1,421 @@
+"""Tests for migration 001_namespace — schema rebuild + disclosure backfill."""
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.models import Base
+
+
+def _load_001():
+    return importlib.import_module("omicsclaw.memory.migrations.001_namespace")
+
+
+async def _build_legacy_schema(db: DatabaseManager) -> None:
+    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    async with db.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def _pk_columns_in_order(s, table: str) -> list[str]:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    rows = [(row[1], row[5]) for row in result.all() if row[5] > 0]
+    rows.sort(key=lambda x: x[1])
+    return [name for name, _ in rows]
+
+
+@pytest.mark.asyncio
+async def test_001_adds_namespace_column_to_paths(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_paths_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "paths") == ["namespace", "domain", "path"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_search_documents_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "search_documents") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+            result = await s.execute(sa.text("PRAGMA table_info(search_documents)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+        await mig.apply(db)  # second invocation must not raise or duplicate work
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert cols.count("namespace") == 1
+            assert await _pk_columns_in_order(s, "paths") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_idempotent_does_not_reset_post_migration_namespaces(tmp_path):
+    """Re-running 001 must preserve any namespace edits already applied."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a single legacy path
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('n1')"))
+            await s.execute(
+                sa.text(
+                    "INSERT INTO edges (id, parent_uuid, child_uuid, name) "
+                    "VALUES (1, 'n1', 'n1', 'test')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO paths (domain, path, edge_id) "
+                    "VALUES ('core', 'foo', 1)"
+                )
+            )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Caller updates namespace after migration
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "UPDATE paths SET namespace='tg/userA' "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+
+        # Re-running the migration must NOT reset that namespace
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+async def _build_legacy_schema_with_fts(db: DatabaseManager) -> None:
+    """Legacy schema + the legacy FTS5 virtual table (no namespace col)."""
+    await _build_legacy_schema(db)
+    async with db.session() as s:
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                domain, path, node_uuid, uri, content, disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+
+
+@pytest.mark.asyncio
+async def test_001_rebuilds_fts5_with_namespace_column(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            # If namespace is a column on the FTS table, this query parses.
+            await s.execute(sa.text("SELECT namespace FROM search_documents_fts LIMIT 0"))
+    finally:
+        await db.close()
+
+
+async def _seed_path_with_disclosure(
+    db: DatabaseManager,
+    *,
+    domain: str,
+    path: str,
+    disclosure: str,
+) -> None:
+    """Seed nodes/edges/paths/memories/search_documents for one path row."""
+    async with db.session() as s:
+        await s.execute(sa.text("INSERT OR IGNORE INTO nodes (uuid) VALUES ('n1')"))
+        await s.execute(
+            sa.text(
+                "INSERT OR IGNORE INTO edges (id, parent_uuid, child_uuid, name) "
+                "VALUES (1, 'n1', 'n1', 'seed')"
+            )
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO paths (domain, path, edge_id) "
+                "VALUES (:d, :p, 1)"
+            ),
+            {"d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO memories (node_uuid, content) "
+                "VALUES ('n1', 'test-content')"
+            )
+        )
+        result = await s.execute(sa.text("SELECT last_insert_rowid()"))
+        memory_id = result.scalar_one()
+        await s.execute(
+            sa.text(
+                "INSERT INTO search_documents "
+                "(domain, path, node_uuid, memory_id, uri, content, "
+                "disclosure, search_terms, priority) "
+                "VALUES (:d, :p, 'n1', :mid, :uri, 'test-content', :disc, :st, 0)"
+            ),
+            {
+                "d": domain,
+                "p": path,
+                "mid": memory_id,
+                "uri": f"{domain}://{path}",
+                "disc": disclosure,
+                "st": path,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_memory_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="sc-de/run42",
+            disclosure="Memory from session app:userA:abcdef",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM search_documents "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_session_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="session",
+            path="abc123",
+            disclosure="Session for user userA on tg",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='session' AND path='abc123'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_falls_back_to_shared_when_disclosure_unparseable(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="orphan",
+            disclosure="some garbage that doesn't match",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='orphan'"
+                )
+            )
+            assert result.scalar_one() == "__shared__"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_preserves_row_counts(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        for i in range(5):
+            await _seed_path_with_disclosure(
+                db,
+                domain="analysis",
+                path=f"run_{i}",
+                disclosure=f"Memory from session app:user{i}:s{i}",
+            )
+
+        async def counts(s):
+            return {
+                tbl: (
+                    await s.execute(sa.text(f"SELECT COUNT(*) FROM {tbl}"))
+                ).scalar_one()
+                for tbl in ("paths", "search_documents", "memories", "nodes", "edges")
+            }
+
+        async with db.session() as s:
+            before = await counts(s)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            after = await counts(s)
+
+        assert before == after
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_discovered_and_run_via_init_db(tmp_path):
+    """End-to-end: init_db on a fresh DB applies 001 via discovery."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            # paths has namespace column post-migration
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+
+            # 001 was recorded by the runner
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert "001_namespace" in {row[0] for row in result.all()}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_glossary_keywords_has_namespace_in_unique_constraint(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a node so glossary FK is valid
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('node-1')"))
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Same (keyword, node_uuid) but different namespace — both must succeed
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns1')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns2')"
+                )
+            )
+            result = await s.execute(
+                sa.text("SELECT COUNT(*) FROM glossary_keywords")
+            )
+            assert result.scalar_one() == 2
+
+        # Duplicate (namespace, keyword, node_uuid) — must fail
+        with pytest.raises(Exception):
+            async with db.session() as s:
+                await s.execute(
+                    sa.text(
+                        "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                        "VALUES ('foo', 'node-1', 'ns1')"
+                    )
+                )
+    finally:
+        await db.close()

--- a/tests/memory/test_migration_runner.py
+++ b/tests/memory/test_migration_runner.py
@@ -1,0 +1,151 @@
+"""Tests for the lightweight migrations framework runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.migrations.runner import run_pending
+
+
+@pytest.mark.asyncio
+async def test_run_pending_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await run_pending(db, migrations=[])
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_migration_and_records_version(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_calls: list[DatabaseManager] = []
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            apply_calls.append(d)
+
+    try:
+        versions = await run_pending(db, migrations=[Mig()])
+        assert versions == ["001_test"]
+        assert apply_calls == [db]
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001_test"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_skips_already_applied(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_count = 0
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            nonlocal apply_count
+            apply_count += 1
+
+    try:
+        v1 = await run_pending(db, migrations=[Mig()])
+        v2 = await run_pending(db, migrations=[Mig()])
+        assert v1 == ["001_test"]
+        assert v2 == []
+        assert apply_count == 1  # idempotent
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_in_version_sorted_order(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    order_seen: list[str] = []
+
+    def make_mig(v: str):
+        class M:
+            VERSION = v
+            DESCRIPTION = f"m{v}"
+
+            async def apply(self, d: DatabaseManager) -> None:
+                order_seen.append(v)
+        return M()
+
+    try:
+        # Caller passes in reversed order — runner must sort
+        versions = await run_pending(
+            db, migrations=[make_mig("003"), make_mig("001"), make_mig("002")]
+        )
+        assert versions == ["001", "002", "003"]
+        assert order_seen == ["001", "002", "003"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_migration_is_not_recorded(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+
+    class GoodMig:
+        VERSION = "001"
+        DESCRIPTION = "good"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            pass
+
+    class BadMig:
+        VERSION = "002"
+        DESCRIPTION = "bad"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            raise RuntimeError("boom")
+
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await run_pending(db, migrations=[GoodMig(), BadMig()])
+
+        # 001 succeeded → recorded; 002 raised → NOT recorded
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001"}
+    finally:
+        await db.close()
+
+
+def test_discover_migrations_imports_numbered_modules(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / "fake_mig_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "001_alpha.py").write_text(
+        "VERSION = '001_alpha'\nDESCRIPTION = 'a'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    (pkg_dir / "002_beta.py").write_text(
+        "VERSION = '002_beta'\nDESCRIPTION = 'b'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    # non-numbered modules in the package should be ignored
+    (pkg_dir / "helper.py").write_text("# not a migration\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    from omicsclaw.memory.migrations.runner import _discover_migrations
+    found = _discover_migrations("fake_mig_pkg")
+
+    versions = sorted(m.VERSION for m in found)
+    assert versions == ["001_alpha", "002_beta"]

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,0 +1,104 @@
+"""Tests for namespace_policy — see docs/CONTEXT.md namespace ownership table."""
+
+import pytest
+
+from omicsclaw.memory.namespace_policy import resolve_namespace, should_version
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_resolve_namespace_returns_shared_for_core_agent():
+    uri = MemoryURI.parse("core://agent")
+    assert resolve_namespace(uri, current="tg/A") == "__shared__"
+
+
+def test_resolve_namespace_returns_current_for_per_namespace_uri():
+    assert resolve_namespace(MemoryURI.parse("dataset://pbmc.h5ad"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("analysis://run_42"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("project://current"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_kh_prefix_is_shared():
+    # core://kh and any sub-path under it are shared
+    assert resolve_namespace(MemoryURI.parse("core://kh"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/qc_threshold"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/sc/marker"), current="X") == "__shared__"
+
+
+def test_resolve_namespace_false_prefix_does_not_match():
+    # 'kh' must not match 'khaki' (path-segment matching, not raw startswith)
+    assert resolve_namespace(MemoryURI.parse("core://khaki"), current="X") == "X"
+    assert resolve_namespace(MemoryURI.parse("core://agent_alt"), current="X") == "X"
+
+
+def test_resolve_namespace_my_user_is_per_namespace():
+    # core://my_user is per-user, not shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_my_user_default_is_shared():
+    # core://my_user_default is the fallback template, shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user_default"), current="tg/A") == "__shared__"
+
+
+def test_should_version_core_agent_true():
+    assert should_version(MemoryURI.parse("core://agent")) is True
+
+
+def test_should_version_false_for_non_versioned_domains():
+    assert should_version(MemoryURI.parse("dataset://pbmc.h5ad")) is False
+    assert should_version(MemoryURI.parse("analysis://sc-de/run_42")) is False
+    assert should_version(MemoryURI.parse("session://abc123")) is False
+    assert should_version(MemoryURI.parse("insight://cluster/3")) is False
+    assert should_version(MemoryURI.parse("project://current")) is False
+
+
+def test_should_version_core_my_user_true():
+    # core://my_user is per-namespace (Q3) but versioned (Q5) — both rules independent
+    assert should_version(MemoryURI.parse("core://my_user")) is True
+
+
+def test_should_version_all_preferences_true():
+    # whole `preference://` domain is versioned
+    assert should_version(MemoryURI.parse("preference://qc/cutoff")) is True
+    assert should_version(MemoryURI.parse("preference://global/theme")) is True
+    assert should_version(MemoryURI.parse("preference://anything_at_all")) is True
+
+
+def test_should_version_kh_and_my_user_default_false():
+    # core://kh is shared but NOT versioned (static system content)
+    assert should_version(MemoryURI.parse("core://kh")) is False
+    assert should_version(MemoryURI.parse("core://kh/qc_threshold")) is False
+    # core://my_user_default is the static fallback template, NOT versioned
+    assert should_version(MemoryURI.parse("core://my_user_default")) is False
+
+
+# ----------------------------------------------------------------------
+# CONTEXT.md namespace ownership table — full matrix
+# Lock the entire policy contract in one place. If a row needs to change,
+# update CONTEXT.md and SHARED_PREFIXES / VERSIONED_PREFIXES in lockstep.
+# ----------------------------------------------------------------------
+
+_PER_NS = "ns/X"  # opaque current namespace for matrix tests
+
+
+@pytest.mark.parametrize(
+    "uri_str,expected_ns,expected_version",
+    [
+        ("core://agent",            "__shared__", True),
+        ("core://kh",               "__shared__", False),
+        ("core://kh/qc_threshold",  "__shared__", False),
+        ("core://my_user_default",  "__shared__", False),
+        ("core://my_user",          _PER_NS,      True),
+        ("preference://qc/cutoff",  _PER_NS,      True),
+        ("preference://global/x",   _PER_NS,      True),
+        ("dataset://pbmc.h5ad",     _PER_NS,      False),
+        ("analysis://run_42",       _PER_NS,      False),
+        ("insight://cluster/3",     _PER_NS,      False),
+        ("project://current",       _PER_NS,      False),
+        ("session://abc123",        _PER_NS,      False),
+    ],
+)
+def test_context_md_table_full_matrix(uri_str, expected_ns, expected_version):
+    uri = MemoryURI.parse(uri_str)
+    assert resolve_namespace(uri, current=_PER_NS) == expected_ns
+    assert should_version(uri) is expected_version

--- a/tests/memory/test_search_indexer_namespace.py
+++ b/tests/memory/test_search_indexer_namespace.py
@@ -1,0 +1,160 @@
+"""Tests for SearchIndexer namespace-aware behavior (PR #3a Task 3a.5).
+
+Covers:
+  - SearchIndexer.refresh_search_documents_for(namespace, uri): surgical
+    single-row rebuild without touching other namespaces' rows.
+  - Glossary keyword join filter: only keywords in the current namespace
+    or ``__shared__`` should feed into search_terms for that namespace's
+    search rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.models import GlossaryKeyword, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), search, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# Surgical refresh
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_creates_single_row(env):
+    eng, search, db = env
+    await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    # Wipe the search row, then surgically refresh just this (namespace, uri).
+    async with db.session() as s:
+        await s.execute(sa.delete(SearchDocument))
+
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://agent"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].namespace == "tg/userA"
+        assert rows[0].path == "agent"
+        assert rows[0].content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_is_noop_when_path_missing(env):
+    _, search, db = env
+    # Should not raise, just silently skip — the surgical refresh has nothing
+    # to rebuild if the (namespace, uri) doesn't exist.
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://nope"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert rows == []
+
+
+# ----------------------------------------------------------------------
+# Glossary namespace filter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_glossary_keyword_filtered_by_namespace(env):
+    """A keyword bound to a node but in a foreign namespace must NOT appear
+    in that node's search row.
+
+    To exercise the filter we bind three keywords to the SAME node:
+      - one with namespace='tg/userA' (current)
+      - one with namespace='tg/userZ' (foreign — must be excluded)
+      - one with namespace='__shared__' (must be included)
+
+    Without the per-namespace glossary filter all three would appear in
+    ``search_terms``.
+    """
+    eng, search, db = env
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        s.add_all([
+            GlossaryKeyword(
+                keyword="alpha-current",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userA",
+            ),
+            GlossaryKeyword(
+                keyword="zeta-foreign",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userZ",
+            ),
+            GlossaryKeyword(
+                keyword="shared-keyword",
+                node_uuid=ref.node_uuid,
+                namespace="__shared__",
+            ),
+        ])
+
+    await search.refresh_search_documents_for_node(ref.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+
+    assert "alpha-current" in sd.search_terms
+    assert "shared-keyword" in sd.search_terms
+    assert "zeta-foreign" not in sd.search_terms
+
+
+@pytest.mark.asyncio
+async def test_glossary_shared_keyword_appears_in_all_namespaces(env):
+    """A keyword with namespace='__shared__' should bleed into any per-user row."""
+    eng, search, db = env
+    ref_a = await eng.upsert("core://agent", "A", namespace="tg/userA")
+
+    # Bind a shared-namespace keyword to A's node — semantically odd in
+    # production, but it's what we'd see for core:// agents whose keywords
+    # are seeded globally.
+    async with db.session() as s:
+        s.add(
+            GlossaryKeyword(
+                keyword="shared-token",
+                node_uuid=ref_a.node_uuid,
+                namespace="__shared__",
+            )
+        )
+
+    await search.refresh_search_documents_for_node(ref_a.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+        assert "shared-token" in sd.search_terms


### PR DESCRIPTION
## Summary

PR #3a of the [memory refactor](docs/2026-05-09-memory-refactor-plan.md) introduces the `MemoryEngine` write path and makes the `SearchIndexer` namespace-aware. This is the third PR in an 8-PR sequence that splits the 1584-line `GraphService` god class into a `MemoryClient` / `MemoryEngine` / `ReviewLog` triad and adds a `namespace` partition to the memory graph.

**Stacked on**: #125 (PR #1 — `MemoryURI` + `namespace_policy`) and #126 (PR #2 — migrations framework + `001_namespace`). Merge **#125 → #126 → this** in order. The PR #1 and PR #2 commits are temporarily cherry-picked into this branch so that local CI/tests have the full dependency stack; after #125 and #126 merge to main I'll rebase and the diff will collapse to just the PR #3a commits.

## What lands here

- **`omicsclaw/memory/engine.py`** (new, ~470 lines) — `MemoryEngine` class with three write verbs (`upsert`, `upsert_versioned`, `patch_edge_metadata`) plus `MemoryRef` / `VersionedMemoryRef` value objects. Read verbs (`recall`, `search`, `list_children`, `get_subtree`) are stubbed for PR #3b.
- **`omicsclaw/memory/models.py`** — adds `namespace` column (default `__shared__`) to `Path`, `SearchDocument`, `GlossaryKeyword` so the ORM matches the schema produced by 001_namespace.
- **`omicsclaw/memory/search.py`** — namespace-aware glossary join (a row only sees its own namespace's keywords plus `__shared__`); new surgical `refresh_search_documents_for(namespace, uri)`; FTS5 SQL widened to 8 bm25 weights and a 3-column join.
- **`omicsclaw/memory/database.py`** — FTS5 virtual-table DDL gets the `namespace` column.
- **`tests/memory/test_memory_engine.py`** (~510 lines, 23 tests) and **`tests/memory/test_search_indexer_namespace.py`** (~160 lines, 4 tests).

## Architecture decisions (frozen — see [docs/CONTEXT.md](docs/CONTEXT.md))

| Decision | Choice |
|---|---|
| Write verbs vs. read verbs | Split: writes here, reads in PR #3b |
| Overwrite vs. versioned | Two APIs: `upsert` (overwrite) and `upsert_versioned` (deprecation chain) |
| Sentinel for unset metadata | `_UnsetType` singleton — distinguishes \"don't touch priority\" from \"set priority=None\" |
| Parent resolution fallback | Falls back to `__shared__` when the per-namespace parent doesn't exist |
| Orphan path on overwrite | Raises `RuntimeError` instead of silently fabricating a new active memory |

## Test plan

- [x] 23 new engine tests pass: create, idempotent update, namespace isolation, version chain (3-link), search refresh, parent resolution (strict + shared fallback), metadata sentinel, MemoryURI input.
- [x] 4 new search-indexer tests pass: surgical refresh, glossary namespace filter, shared-keyword bleed-through.
- [x] Full memory test suite green (109/109 inc. the cherry-picked PR #1 + PR #2 tests).
- [x] Existing GraphService consumers untouched: `tests/test_autoagent_failure_memory.py`, `tests/test_interactive_memory_command_support.py`, `tests/test_memory_server_security.py`, `tests/test_scoped_memory.py` all pass (19/19).
- [x] 5-axis review (correctness, readability, architecture, security, performance) — three issues raised + addressed in `19124d6`.
- [x] No new regressions in unrelated subsystems: full-suite \"failures\" reproduce identically on main when the same files run together.

## Review feedback addressed

Commit `19124d6` folds three reviewer-flagged issues:

1. **FTS5 bm25 weight count** was 7, schema is now 8 columns → would have raised the moment the read path ran. Updated to 8 weights with namespace/domain/node_uuid all at 0.0. Also widened the FTS join from `(domain, path)` to `(namespace, domain, path)` so search hits can't surface across namespaces.
2. **Typed `_UNSET` sentinel** replaces `_UNSET: Any = object()` so type checkers can narrow on `is _UNSET` and the contract reads from the signature, not just the docstring.
3. **`_upsert_existing`** now raises `RuntimeError` when the edge has no active memory (orphan-tail corruption) instead of silently fabricating a new active row that would disconnect the chain.

## Out of scope

- Read verbs (`recall` / `search` / `list_children` / `get_subtree`) — PR #3b
- `GraphService` transitional shim → `MemoryEngine` — PR #3c
- `MemoryClient` strategy layer — PR #4a
- Surface integration (CLI / Desktop / Bot namespace injection) — PR #5
- Cleanup (`_parse_uri` migration, GraphService deletion) — PR #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory system now supports namespace-aware organization, enabling separate memory partitions.
  * Added write operations for memory storage with versioning support and metadata management.
  * Implemented automatic database migration framework for seamless schema updates.

* **Improvements**
  * Search indexing updated for namespace awareness and isolation.
  * Enhanced URI validation and path navigation improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->