### PR TITLE
refactor(memory) PR #3c: GlossaryService namespace + GraphService → MemoryEngine shim

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2608,7 +2608,10 @@ def _memory_snapshot_row_identity(table: str, row: dict[str, Any]):
     if table in {"memories", "edges"}:
         return row["id"]
     if table == "paths":
-        return (row["domain"], row["path"])
+        # PK is (namespace, domain, path) post-001_namespace migration. Older
+        # snapshots predating the namespace column default to "__shared__".
+        namespace = row.get("namespace") or "__shared__"
+        return (namespace, row["domain"], row["path"])
     if table == "glossary_keywords":
         if "id" in row and row["id"] is not None:
             return row["id"]

--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -200,6 +200,7 @@ class DatabaseManager:
                         text("""
                             CREATE VIRTUAL TABLE IF NOT EXISTS search_documents_fts
                             USING fts5(
+                                namespace,
                                 domain,
                                 path,
                                 node_uuid,

--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -136,6 +136,11 @@ class DatabaseManager:
                 if not is_initialized:
                     await conn.run_sync(Base.metadata.create_all)
 
+            # Run any pending schema migrations after the base schema exists.
+            # Imported lazily to avoid a circular import at module load time.
+            from omicsclaw.memory.migrations import run_pending
+            await run_pending(self)
+
             # Ensure the root node exists (all edges reference it as parent)
             await self._ensure_root_node()
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -562,7 +562,15 @@ class MemoryEngine:
         domain: Optional[str] = None,
         limit: int = 10,
     ) -> list[dict]:
-        raise NotImplementedError("PR #3b")
+        """Full-text search restricted to ``namespace`` + ``__shared__``.
+
+        Per-namespace hits are returned ahead of shared hits when scores
+        are otherwise comparable. Each result dict carries a
+        ``namespace`` key indicating which partition the hit came from.
+        """
+        return await self._search.search(
+            query, limit=limit, domain=domain, namespace=namespace
+        )
 
     async def list_children(
         self, uri: str | MemoryURI, *, namespace: str

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -273,16 +273,98 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
         For ``core://*`` and ``preference://*`` URIs where the version
         chain is the audit trail. The old Memory keeps ``deprecated=True``
         and ``migrated_to=new_memory_id``; only the newest is active.
+        First write returns ``old_memory_id=None``.
         """
-        raise NotImplementedError("Task 3a.3")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is None:
+                # No existing path: this is a first write — same shape as upsert
+                # but routed through the versioned helper for return-type symmetry.
+                new_memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+                old_memory_id: Optional[int] = None
+            else:
+                old_memory_id, new_memory_id, node_uuid = (
+                    await self._upsert_versioned_chain(
+                        s, existing_path, content, priority, disclosure
+                    )
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return VersionedMemoryRef(
+            old_memory_id=old_memory_id,
+            new_memory_id=new_memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    async def _upsert_versioned_chain(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[Optional[int], int, str]:
+        """Insert a new active Memory and deprecate the previous active one.
+
+        Returns ``(old_memory_id, new_memory_id, node_uuid)``. ``old_memory_id``
+        is ``None`` only when no active Memory existed (orphan path), which
+        we recover from by treating the new write as the chain's first link.
+        """
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+        node_uuid = edge.child_uuid
+
+        old = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == node_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        new_memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(new_memory)
+        await s.flush()
+
+        old_id: Optional[int] = None
+        if old is not None:
+            old.deprecated = True
+            old.migrated_to = new_memory.id
+            old_id = old.id
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return old_id, new_memory.id, node_uuid
 
     async def patch_edge_metadata(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -1,0 +1,165 @@
+# pyright: reportArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
+
+"""MemoryEngine — namespace-aware hot path for memory writes and reads.
+
+This module is the "engine room" of the OmicsClaw memory architecture.
+It owns the canonical CRUD verbs over Node/Memory/Edge/Path and is the
+only layer that touches those tables directly.
+
+Above it sits ``MemoryClient`` (strategy: which namespace, version vs.
+overwrite); below it sits the ORM. The legacy ``GraphService`` is
+unaffected during PR #3a — see ``docs/2026-05-09-memory-refactor-plan.md``
+for the full migration path.
+
+Verbs landed in this PR (PR #3a):
+    - upsert(uri, content, namespace, ...)
+    - upsert_versioned(uri, content, namespace, ...)
+    - patch_edge_metadata(uri, namespace, ...)
+
+Verbs reserved for PR #3b:
+    - recall(uri, namespace, ...)
+    - search(query, namespace, ...)
+    - list_children(uri, namespace)
+    - get_subtree(uri, namespace, ...)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import select
+
+from .models import Edge, Memory, Node, Path
+from .uri import MemoryURI
+
+if TYPE_CHECKING:
+    from .database import DatabaseManager
+    from .search import SearchIndexer
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRef:
+    """Pointer to a single materialized memory at one (namespace, uri)."""
+
+    memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class VersionedMemoryRef:
+    """Result of a version-creating upsert.
+
+    ``old_memory_id`` is ``None`` on the first write (no chain yet).
+    """
+
+    old_memory_id: Optional[int]
+    new_memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+class MemoryEngine:
+    """Namespace-aware CRUD over the memory graph.
+
+    Constructed once per process and reused. Holds no per-namespace state —
+    every verb takes ``namespace`` as a required argument.
+    """
+
+    def __init__(self, db: "DatabaseManager", search: "SearchIndexer") -> None:
+        self._db = db
+        self._search = search
+
+    # ------------------------------------------------------------------
+    # Write verbs (PR #3a)
+    # ------------------------------------------------------------------
+
+    async def upsert(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> MemoryRef:
+        """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
+
+        Re-calling with the same (uri, namespace) UPDATEs the existing
+        Memory row's content in place — no deprecation chain, no new
+        Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
+        where history is not interesting.
+        """
+        raise NotImplementedError("Task 3a.2")
+
+    async def upsert_versioned(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> VersionedMemoryRef:
+        """Versioned upsert: deprecate the old Memory, insert a new one.
+
+        For ``core://*`` and ``preference://*`` URIs where the version
+        chain is the audit trail. The old Memory keeps ``deprecated=True``
+        and ``migrated_to=new_memory_id``; only the newest is active.
+        """
+        raise NotImplementedError("Task 3a.3")
+
+    async def patch_edge_metadata(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        priority: Optional[int] = None,
+        disclosure: Optional[str] = None,
+    ) -> None:
+        """Update Edge metadata (priority, disclosure) without touching Memory.
+
+        At least one of ``priority``/``disclosure`` must be provided.
+        """
+        raise NotImplementedError("Task 3a.4")
+
+    # ------------------------------------------------------------------
+    # Read verbs (PR #3b)
+    # ------------------------------------------------------------------
+
+    async def recall(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        fallback_to_shared: bool = True,
+    ) -> Optional[Any]:
+        raise NotImplementedError("PR #3b")
+
+    async def search(
+        self,
+        query: str,
+        *,
+        namespace: str,
+        domain: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        raise NotImplementedError("PR #3b")
+
+    async def list_children(
+        self, uri: str | MemoryURI, *, namespace: str
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")
+
+    async def get_subtree(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        limit: int = 100,
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -25,18 +25,21 @@ Verbs reserved for PR #3b:
 
 from __future__ import annotations
 
+import uuid as uuidlib
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Edge, Memory, Node, Path
+from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
+
+_UNSET: Any = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,8 +87,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -93,8 +96,176 @@ class MemoryEngine:
         Memory row's content in place — no deprecation chain, no new
         Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
         where history is not interesting.
+
+        ``priority`` and ``disclosure`` use a sentinel so an update call
+        without them preserves the existing edge's metadata; pass an
+        explicit ``None`` (or any value) to overwrite.
         """
-        raise NotImplementedError("Task 3a.2")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is not None:
+                memory_id, node_uuid = await self._upsert_existing(
+                    s, existing_path, content, priority, disclosure
+                )
+            else:
+                memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return MemoryRef(
+            memory_id=memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers (kept private — tests should drive only via verbs)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _fetch_path(
+        s: AsyncSession, namespace: str, parsed: MemoryURI
+    ) -> Optional[Path]:
+        return (
+            await s.execute(
+                select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def _upsert_existing(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+
+        memory = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == edge.child_uuid,
+                    Memory.deprecated == False,  # noqa: E712 — SQLAlchemy column comparison
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        if memory is None:
+            # Edge exists but has no active memory — create one and attach.
+            memory = Memory(
+                node_uuid=edge.child_uuid, content=content, deprecated=False
+            )
+            s.add(memory)
+            await s.flush()
+        else:
+            memory.content = content
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return memory.id, edge.child_uuid
+
+    async def _upsert_create(
+        self,
+        s: AsyncSession,
+        parsed: MemoryURI,
+        namespace: str,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
+
+        node_uuid = str(uuidlib.uuid4())
+        s.add(Node(uuid=node_uuid))
+        await s.flush()
+
+        memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(memory)
+        await s.flush()
+
+        edge_name = parsed.path.rsplit("/", 1)[-1] if "/" in parsed.path else parsed.path
+        edge = Edge(
+            parent_uuid=parent_uuid,
+            child_uuid=node_uuid,
+            name=edge_name,
+            priority=0 if priority is _UNSET else priority,
+            disclosure=None if disclosure is _UNSET else disclosure,
+        )
+        s.add(edge)
+        await s.flush()
+
+        s.add(
+            Path(
+                namespace=namespace,
+                domain=parsed.domain,
+                path=parsed.path,
+                edge_id=edge.id,
+            )
+        )
+        await s.flush()
+
+        return memory.id, node_uuid
+
+    @staticmethod
+    async def _resolve_parent_node_uuid(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> str:
+        """Resolve the parent node UUID for a new path, with shared fallback.
+
+        Top-level URIs (``core://agent``, ``analysis://sc-de``) attach to
+        ROOT. Nested URIs require the parent path to exist either in the
+        current namespace or in ``__shared__``. Falling back to shared lets
+        a per-user write attach under a globally-known structural parent.
+        """
+        parent_uri = parsed.parent()
+        if parent_uri is None or parent_uri.is_root:
+            return ROOT_NODE_UUID
+
+        for ns in (namespace, "__shared__"):
+            parent_path = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == ns,
+                        Path.domain == parent_uri.domain,
+                        Path.path == parent_uri.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if parent_path is None:
+                continue
+            parent_edge = await s.get(Edge, parent_path.edge_id)
+            if parent_edge is not None:
+                return parent_edge.child_uuid
+
+        raise ValueError(
+            f"Parent path {parent_uri} does not exist in namespace "
+            f"{namespace!r} or '__shared__' — create the parent first."
+        )
 
     async def upsert_versioned(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -371,14 +371,45 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Optional[int] = None,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 
-        At least one of ``priority``/``disclosure`` must be provided.
+        At least one of ``priority``/``disclosure`` must be provided. Pass
+        an explicit ``None`` to clear ``disclosure``. Memory rows and the
+        version chain are untouched; the search_documents row is refreshed
+        because priority and disclosure feed into search_terms.
         """
-        raise NotImplementedError("Task 3a.4")
+        if priority is _UNSET and disclosure is _UNSET:
+            raise ValueError(
+                "patch_edge_metadata requires at least one of priority "
+                "or disclosure to be set."
+            )
+
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            path_row = await self._fetch_path(s, namespace, parsed)
+            if path_row is None:
+                raise LookupError(
+                    f"Path for {parsed} in namespace {namespace!r} not found."
+                )
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                raise RuntimeError(
+                    f"Path {namespace}/{parsed} references a missing edge "
+                    f"— graph corruption."
+                )
+
+            if priority is not _UNSET:
+                edge.priority = priority
+            if disclosure is not _UNSET:
+                edge.disclosure = disclosure
+
+            await self._search.refresh_search_documents_for_node(
+                edge.child_uuid, session=s
+            )
 
     # ------------------------------------------------------------------
     # Read verbs (PR #3b)

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import uuid as uuidlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +39,31 @@ if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
 
-_UNSET: Any = object()
+
+class _UnsetType:
+    """Sentinel class for "argument was not supplied".
+
+    Lets ``priority: int | None | _UnsetType`` distinguish
+    "preserve the current value" (sentinel) from
+    "set the value to None" (explicit None). A regular ``None`` default
+    can't tell those apart.
+    """
+
+    _instance: Optional["_UnsetType"] = None
+
+    def __new__(cls) -> "_UnsetType":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "_UNSET"
+
+
+_UNSET: _UnsetType = _UnsetType()
+
+PriorityArg = Union[int, _UnsetType]
+DisclosureArg = Union[Optional[str], _UnsetType]
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,8 +111,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -150,8 +174,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         edge = await s.get(Edge, path_row.edge_id)
         if edge is None:
@@ -173,14 +197,20 @@ class MemoryEngine:
         ).scalar_one_or_none()
 
         if memory is None:
-            # Edge exists but has no active memory — create one and attach.
-            memory = Memory(
-                node_uuid=edge.child_uuid, content=content, deprecated=False
+            # Edge exists but no active memory: a deprecated chain might
+            # exist with no successor (a crash window in upsert_versioned,
+            # or a direct DB poke). We deliberately do NOT silently
+            # fabricate a fresh active memory — that would disconnect a
+            # deprecated tail from any successor and lose audit lineage.
+            # Surface the corruption so callers can route to ReviewLog.
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"has no active memory but the edge persists; refusing to "
+                f"silently rebuild. Inspect the deprecated chain for node "
+                f"{edge.child_uuid} and resolve via ReviewLog before retrying."
             )
-            s.add(memory)
-            await s.flush()
-        else:
-            memory.content = content
+
+        memory.content = content
 
         if priority is not _UNSET:
             edge.priority = priority
@@ -195,8 +225,8 @@ class MemoryEngine:
         parsed: MemoryURI,
         namespace: str,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
 
@@ -273,8 +303,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
@@ -320,8 +350,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[Optional[int], int, str]:
         """Insert a new active Memory and deprecate the previous active one.
 
@@ -371,8 +401,8 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -37,7 +37,15 @@ from typing import TYPE_CHECKING, Optional, Union
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path, escape_like_literal
+from .models import (
+    ROOT_NODE_UUID,
+    SHARED_NAMESPACE,
+    Edge,
+    Memory,
+    Node,
+    Path,
+    escape_like_literal,
+)
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
@@ -110,9 +118,6 @@ class MemoryRecord:
     uri: str
     content: str
     loaded_namespace: str
-
-
-SHARED_NAMESPACE = "__shared__"
 
 
 class MemoryEngine:
@@ -286,41 +291,56 @@ class MemoryEngine:
 
         return memory.id, node_uuid
 
-    @staticmethod
     async def _resolve_parent_node_uuid(
-        s: AsyncSession, parsed: MemoryURI, namespace: str
+        self, s: AsyncSession, parsed: MemoryURI, namespace: str
     ) -> str:
         """Resolve the parent node UUID for a new path, with shared fallback.
 
         Top-level URIs (``core://agent``, ``analysis://sc-de``) attach to
         ROOT. Nested URIs require the parent path to exist either in the
-        current namespace or in ``__shared__``. Falling back to shared lets
-        a per-user write attach under a globally-known structural parent.
+        current namespace or in ``__shared__`` — falling back to shared
+        lets a per-user write attach under a globally-known parent.
         """
         parent_uri = parsed.parent()
         if parent_uri is None or parent_uri.is_root:
             return ROOT_NODE_UUID
 
-        for ns in (namespace, "__shared__"):
-            parent_path = (
+        uuid = await self._resolve_node_for_uri(s, parent_uri, namespace)
+        if uuid is None:
+            raise ValueError(
+                f"Parent path {parent_uri} does not exist in namespace "
+                f"{namespace!r} or '__shared__' — create the parent first."
+            )
+        return uuid
+
+    @staticmethod
+    async def _resolve_node_for_uri(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> Optional[str]:
+        """Look up the node UUID for ``parsed`` in ``(namespace, __shared__)``.
+
+        Returns the first match's ``child_uuid`` (which is the conceptual
+        node id), or ``None`` if neither namespace has the path. Used by
+        both the write-side parent resolver and the read-side listing
+        parent resolver — see CONTEXT.md for why the loop order matters
+        (per-namespace match wins over a shared one).
+        """
+        for ns in (namespace, SHARED_NAMESPACE):
+            path_row = (
                 await s.execute(
                     select(Path).where(
                         Path.namespace == ns,
-                        Path.domain == parent_uri.domain,
-                        Path.path == parent_uri.path,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
                     )
                 )
             ).scalar_one_or_none()
-            if parent_path is None:
+            if path_row is None:
                 continue
-            parent_edge = await s.get(Edge, parent_path.edge_id)
-            if parent_edge is not None:
-                return parent_edge.child_uuid
-
-        raise ValueError(
-            f"Parent path {parent_uri} does not exist in namespace "
-            f"{namespace!r} or '__shared__' — create the parent first."
-        )
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is not None:
+                return edge.child_uuid
+        return None
 
     async def upsert_versioned(
         self,
@@ -622,24 +642,15 @@ class MemoryEngine:
     async def _resolve_listing_parent(
         self, s: AsyncSession, parsed: MemoryURI, namespace: str
     ) -> Optional[str]:
-        """Return the parent's child_uuid, or None if the parent doesn't exist.
+        """Return the parent's child_uuid, or ``None`` if the path is missing.
 
-        For root URIs (path=""), returns ROOT_NODE_UUID directly. For
-        non-root URIs, looks the path up in ``namespace`` first, then
-        ``__shared__``. Listing through a missing parent returns no children.
+        For root URIs (path=""), returns ``ROOT_NODE_UUID`` directly.
+        Listing through a missing parent returns no children — strict
+        listings don't fail loudly, they just produce nothing.
         """
         if parsed.is_root:
             return ROOT_NODE_UUID
-
-        for ns in (namespace, SHARED_NAMESPACE):
-            parent_path = await self._fetch_path(s, ns, parsed)
-            if parent_path is None:
-                continue
-            parent_edge = await s.get(Edge, parent_path.edge_id)
-            if parent_edge is not None:
-                return parent_edge.child_uuid
-
-        return None
+        return await self._resolve_node_for_uri(s, parsed, namespace)
 
     async def _materialize_listing(
         self,
@@ -650,28 +661,43 @@ class MemoryEngine:
     ) -> list[MemoryRef]:
         """Turn a list of Path rows into MemoryRef objects.
 
-        Skips rows whose node has no active memory (a deprecated chain
-        with no successor — surfaces nothing rather than a half-result).
+        Shared by ``list_children`` and ``get_subtree``. Active-memory
+        lookup is batched to a single query so a 1000-row subtree pays
+        for 2 queries (one for paths, one for memories) instead of 1001.
+        Rows whose node has no active memory (a deprecated chain with no
+        successor) are silently skipped — surface nothing rather than a
+        half-result.
         """
+        if not path_rows:
+            return []
+
+        unique_uuids = {edge_id_to_child_uuid[p.edge_id] for p in path_rows}
+        memory_rows = (
+            await s.execute(
+                select(Memory.node_uuid, Memory.id).where(
+                    Memory.node_uuid.in_(unique_uuids),
+                    Memory.deprecated == False,  # noqa: E712
+                )
+            )
+        ).all()
+
+        # Pick max id per node — newest active wins on the rare path with
+        # multiple non-deprecated rows (shouldn't happen post-3a but the
+        # code is defensive at minimal cost).
+        active_by_node: dict[str, int] = {}
+        for node_uuid, mid in memory_rows:
+            if mid > active_by_node.get(node_uuid, -1):
+                active_by_node[node_uuid] = mid
+
         results: list[MemoryRef] = []
         for path_row in path_rows:
             child_uuid = edge_id_to_child_uuid[path_row.edge_id]
-            memory = (
-                await s.execute(
-                    select(Memory)
-                    .where(
-                        Memory.node_uuid == child_uuid,
-                        Memory.deprecated == False,  # noqa: E712
-                    )
-                    .order_by(Memory.id.desc())
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-            if memory is None:
+            memory_id = active_by_node.get(child_uuid)
+            if memory_id is None:
                 continue
             results.append(
                 MemoryRef(
-                    memory_id=memory.id,
+                    memory_id=memory_id,
                     node_uuid=child_uuid,
                     namespace=namespace,
                     uri=f"{path_row.domain}://{path_row.path}",

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -575,7 +575,109 @@ class MemoryEngine:
     async def list_children(
         self, uri: str | MemoryURI, *, namespace: str
     ) -> list[MemoryRef]:
-        raise NotImplementedError("PR #3b")
+        """List direct children of ``uri`` strictly inside ``namespace``.
+
+        Strict semantics: a child only appears if it has a Path in
+        ``namespace``. Shared children of the same parent are intentionally
+        invisible — use ReviewLog.browse_shared (PR #4b) to see those.
+
+        The parent itself can live in ``namespace`` or in ``__shared__``;
+        we resolve the parent through the same fallback the writer uses,
+        so per-user children of shared parents (e.g., ``core://agent/style``
+        under shared ``core://agent``) list correctly.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            parent_uuid = await self._resolve_listing_parent(s, parsed, namespace)
+            if parent_uuid is None:
+                return []
+
+            child_edges = (
+                await s.execute(
+                    select(Edge).where(Edge.parent_uuid == parent_uuid)
+                )
+            ).scalars().all()
+            if not child_edges:
+                return []
+
+            edge_id_to_child_uuid = {e.id: e.child_uuid for e in child_edges}
+            edge_ids = list(edge_id_to_child_uuid)
+
+            path_rows = (
+                await s.execute(
+                    select(Path)
+                    .where(
+                        Path.namespace == namespace,
+                        Path.edge_id.in_(edge_ids),
+                    )
+                    .order_by(Path.path)
+                )
+            ).scalars().all()
+
+            return await self._materialize_listing(
+                s, path_rows, edge_id_to_child_uuid, namespace
+            )
+
+    async def _resolve_listing_parent(
+        self, s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> Optional[str]:
+        """Return the parent's child_uuid, or None if the parent doesn't exist.
+
+        For root URIs (path=""), returns ROOT_NODE_UUID directly. For
+        non-root URIs, looks the path up in ``namespace`` first, then
+        ``__shared__``. Listing through a missing parent returns no children.
+        """
+        if parsed.is_root:
+            return ROOT_NODE_UUID
+
+        for ns in (namespace, SHARED_NAMESPACE):
+            parent_path = await self._fetch_path(s, ns, parsed)
+            if parent_path is None:
+                continue
+            parent_edge = await s.get(Edge, parent_path.edge_id)
+            if parent_edge is not None:
+                return parent_edge.child_uuid
+
+        return None
+
+    async def _materialize_listing(
+        self,
+        s: AsyncSession,
+        path_rows: list[Path],
+        edge_id_to_child_uuid: dict[int, str],
+        namespace: str,
+    ) -> list[MemoryRef]:
+        """Turn a list of Path rows into MemoryRef objects.
+
+        Skips rows whose node has no active memory (a deprecated chain
+        with no successor — surfaces nothing rather than a half-result).
+        """
+        results: list[MemoryRef] = []
+        for path_row in path_rows:
+            child_uuid = edge_id_to_child_uuid[path_row.edge_id]
+            memory = (
+                await s.execute(
+                    select(Memory)
+                    .where(
+                        Memory.node_uuid == child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    )
+                    .order_by(Memory.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if memory is None:
+                continue
+            results.append(
+                MemoryRef(
+                    memory_id=memory.id,
+                    node_uuid=child_uuid,
+                    namespace=namespace,
+                    uri=f"{path_row.domain}://{path_row.path}",
+                )
+            )
+        return results
 
     async def get_subtree(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -8,19 +8,24 @@ only layer that touches those tables directly.
 
 Above it sits ``MemoryClient`` (strategy: which namespace, version vs.
 overwrite); below it sits the ORM. The legacy ``GraphService`` is
-unaffected during PR #3a — see ``docs/2026-05-09-memory-refactor-plan.md``
+unaffected during PR #3a/#3b — see ``docs/2026-05-09-memory-refactor-plan.md``
 for the full migration path.
 
-Verbs landed in this PR (PR #3a):
+Write verbs (PR #3a):
     - upsert(uri, content, namespace, ...)
     - upsert_versioned(uri, content, namespace, ...)
     - patch_edge_metadata(uri, namespace, ...)
 
-Verbs reserved for PR #3b:
-    - recall(uri, namespace, ...)
-    - search(query, namespace, ...)
-    - list_children(uri, namespace)
-    - get_subtree(uri, namespace, ...)
+Read verbs (PR #3b):
+    - recall(uri, namespace, ...)             — single-row fetch with shared fallback
+    - search(query, namespace, ...)           — FTS over (namespace, __shared__)
+    - list_children(uri, namespace)           — strict-namespace children
+    - get_subtree(uri, namespace, ...)        — flat listing under a prefix
+
+Read-fallback policy (CONTEXT.md): ``recall`` and ``search`` fall back to
+``__shared__`` so per-user contexts can see globally-shared content;
+``list_children`` and ``get_subtree`` are strict so a user's listing
+doesn't get polluted by shared structure they didn't ask for.
 """
 
 from __future__ import annotations
@@ -88,6 +93,26 @@ class VersionedMemoryRef:
     node_uuid: str
     namespace: str
     uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecord:
+    """Materialized result of ``recall``.
+
+    ``namespace`` is the namespace the caller asked for; ``loaded_namespace``
+    is the namespace the row actually came from. They differ when the read
+    fell back to ``__shared__`` because the per-user namespace had no match.
+    """
+
+    memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+    content: str
+    loaded_namespace: str
+
+
+SHARED_NAMESPACE = "__shared__"
 
 
 class MemoryEngine:
@@ -451,8 +476,83 @@ class MemoryEngine:
         *,
         namespace: str,
         fallback_to_shared: bool = True,
-    ) -> Optional[Any]:
-        raise NotImplementedError("PR #3b")
+    ) -> Optional[MemoryRecord]:
+        """Fetch the active memory at ``(namespace, uri)``.
+
+        Returns ``None`` if no active memory exists. When the per-namespace
+        lookup misses and ``fallback_to_shared=True`` (the default), falls
+        back to ``__shared__`` — this is how per-user contexts see
+        globally-shared content like ``core://agent``.
+
+        ``MemoryRecord.loaded_namespace`` records which namespace produced
+        the row (the caller-supplied one or ``__shared__``).
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            record = await self._recall_in_namespace(s, parsed, canonical, namespace)
+            if record is not None:
+                return record
+
+            if (
+                fallback_to_shared
+                and namespace != SHARED_NAMESPACE
+            ):
+                shared = await self._recall_in_namespace(
+                    s, parsed, canonical, SHARED_NAMESPACE
+                )
+                if shared is not None:
+                    # Echo the caller's requested namespace; tag origin separately.
+                    return MemoryRecord(
+                        memory_id=shared.memory_id,
+                        node_uuid=shared.node_uuid,
+                        namespace=namespace,
+                        uri=canonical,
+                        content=shared.content,
+                        loaded_namespace=SHARED_NAMESPACE,
+                    )
+
+        return None
+
+    async def _recall_in_namespace(
+        self,
+        s: AsyncSession,
+        parsed: MemoryURI,
+        canonical: str,
+        namespace: str,
+    ) -> Optional[MemoryRecord]:
+        """Fetch the active memory for ``(namespace, parsed)`` or ``None``."""
+        path_row = await self._fetch_path(s, namespace, parsed)
+        if path_row is None:
+            return None
+
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            return None
+
+        memory = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == edge.child_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if memory is None:
+            return None
+
+        return MemoryRecord(
+            memory_id=memory.id,
+            node_uuid=edge.child_uuid,
+            namespace=namespace,
+            uri=canonical,
+            content=memory.content,
+            loaded_namespace=namespace,
+        )
 
     async def search(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -34,10 +34,10 @@ import uuid as uuidlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path
+from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path, escape_like_literal
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
@@ -686,4 +686,40 @@ class MemoryEngine:
         namespace: str,
         limit: int = 100,
     ) -> list[MemoryRef]:
-        raise NotImplementedError("PR #3b")
+        """Flat list of MemoryRef under ``(namespace, uri)`` up to ``limit``.
+
+        Includes the prefix URI itself plus all descendants. Strict
+        namespace — no shared fallback. Sorted lexicographically by path
+        for deterministic output. A root URI (``analysis://``) lists every
+        path in the namespace under that domain.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            stmt = select(Path).where(
+                Path.namespace == namespace,
+                Path.domain == parsed.domain,
+            )
+            if not parsed.is_root:
+                base = parsed.path
+                safe = escape_like_literal(base)
+                stmt = stmt.where(
+                    or_(
+                        Path.path == base,
+                        Path.path.like(f"{safe}/%", escape="\\"),
+                    )
+                )
+            stmt = stmt.order_by(Path.path).limit(limit)
+            path_rows = (await s.execute(stmt)).scalars().all()
+            if not path_rows:
+                return []
+
+            edge_ids = [p.edge_id for p in path_rows]
+            edges = (
+                await s.execute(select(Edge).where(Edge.id.in_(edge_ids)))
+            ).scalars().all()
+            edge_id_to_child = {e.id: e.child_uuid for e in edges}
+
+            return await self._materialize_listing(
+                s, list(path_rows), edge_id_to_child, namespace
+            )

--- a/omicsclaw/memory/glossary.py
+++ b/omicsclaw/memory/glossary.py
@@ -10,7 +10,8 @@ Aho-Corasick-based content scanning for keyword highlighting.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, Any, List, TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from sqlalchemy import select, delete, and_, func
 from sqlalchemy.exc import IntegrityError
@@ -21,12 +22,26 @@ from .models import (
     Path,
     Memory,
     GlossaryKeyword,
+    SHARED_NAMESPACE,
     serialize_row,
 )
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
+
+
+@dataclass(frozen=True)
+class _KeywordUniverse:
+    """Snapshot of the glossary keywords visible from a given namespace.
+
+    ``fingerprint`` is a (count, max_id, max_created_at) triple used to
+    detect that the cache is stale; ``keywords`` is the de-duplicated
+    keyword list to feed Aho-Corasick.
+    """
+
+    keywords: List[str]
+    fingerprint: tuple
 
 
 class GlossaryService:
@@ -40,13 +55,21 @@ class GlossaryService:
     def __init__(self, db: "DatabaseManager", search_indexer: "SearchIndexer"):
         self._session = db.session
         self._search = search_indexer
-        self._automaton = None
-        self._fingerprint = None
+        # Per-namespace automaton cache. Key is the namespace string or
+        # the literal "__all__" for the legacy unscoped scan.
+        self._automatons: Dict[str, Any] = {}
+        self._fingerprints: Dict[str, tuple] = {}
 
     async def add_glossary_keyword(
-        self, keyword: str, node_uuid: str
+        self, keyword: str, node_uuid: str, namespace: str = SHARED_NAMESPACE
     ) -> Dict[str, Any]:
-        """Bind a glossary keyword to a node."""
+        """Bind a glossary keyword to a node inside ``namespace``.
+
+        ``namespace`` defaults to ``__shared__`` so legacy callers that
+        haven't migrated keep writing into the global partition. Pass an
+        explicit namespace to scope a keyword to one user/surface; or use
+        ``add_glossary_shared`` for clarity.
+        """
         keyword = keyword.strip()
         if not keyword:
             raise ValueError("Glossary keyword cannot be empty")
@@ -56,13 +79,18 @@ class GlossaryService:
             if not node:
                 raise ValueError(f"Node '{node_uuid}' not found")
 
-            entry = GlossaryKeyword(keyword=keyword, node_uuid=node_uuid)
+            entry = GlossaryKeyword(
+                keyword=keyword, node_uuid=node_uuid, namespace=namespace
+            )
             session.add(entry)
 
             try:
                 await session.flush()
             except IntegrityError:
-                raise ValueError(f"Keyword '{keyword}' is already bound to this node")
+                raise ValueError(
+                    f"Keyword '{keyword}' is already bound to this node "
+                    f"in namespace '{namespace}'"
+                )
 
             await self._search.refresh_search_documents_for_node(
                 node_uuid, session=session
@@ -74,20 +102,41 @@ class GlossaryService:
                 "id": entry.id,
                 "keyword": keyword,
                 "node_uuid": node_uuid,
+                "namespace": namespace,
                 "rows_before": {"glossary_keywords": []},
                 "rows_after": {"glossary_keywords": [row_after]},
             }
 
-    async def remove_glossary_keyword(
+    async def add_glossary_shared(
         self, keyword: str, node_uuid: str
     ) -> Dict[str, Any]:
-        """Remove a glossary keyword binding."""
+        """Bind a globally-visible glossary keyword (namespace=__shared__).
+
+        Sugar for ``add_glossary_keyword(..., namespace=SHARED_NAMESPACE)``,
+        intended for callers that want to be explicit about the global
+        scope rather than relying on the default.
+        """
+        return await self.add_glossary_keyword(
+            keyword, node_uuid, namespace=SHARED_NAMESPACE
+        )
+
+    async def remove_glossary_keyword(
+        self, keyword: str, node_uuid: str, namespace: str = SHARED_NAMESPACE
+    ) -> Dict[str, Any]:
+        """Remove a glossary keyword binding within one namespace.
+
+        Default ``__shared__`` matches the legacy callsite, which had no
+        namespace concept. Removal is now namespace-scoped — pass an
+        explicit namespace to remove a per-user binding without touching
+        shared or other-user bindings of the same (keyword, node_uuid).
+        """
         keyword = keyword.strip()
         async with self._session() as session:
             existing = await session.execute(
                 select(GlossaryKeyword).where(
                     GlossaryKeyword.keyword == keyword,
                     GlossaryKeyword.node_uuid == node_uuid,
+                    GlossaryKeyword.namespace == namespace,
                 )
             )
             entry = existing.scalar_one_or_none()
@@ -173,86 +222,112 @@ class GlossaryService:
             ]
 
     async def find_glossary_in_content(
-        self, content: str
+        self,
+        content: str,
+        namespace: Optional[str] = None,
     ) -> Dict[str, List[Dict[str, str]]]:
         """Scan content for glossary keywords using Aho-Corasick.
 
-        Uses a DB-level fingerprint to detect staleness.
-        Returns dict of keyword -> list of {node_uuid, uri} for matches found.
+        When ``namespace`` is provided, restricts the keyword universe to
+        ``(namespace, __shared__)`` — that's how the search reindexer
+        avoids cross-namespace keyword leaks. ``namespace=None`` preserves
+        the legacy "match anything in the DB" behaviour.
+
+        The Aho-Corasick automaton is built per namespace key and cached
+        with a DB-level fingerprint so repeated scans don't repeatedly
+        rebuild. ``namespace=None`` still uses the same cache slot.
         """
         try:
             import ahocorasick
         except ImportError:
             # ahocorasick not installed — fall back to simple substring matching
-            return await self._find_glossary_simple(content)
+            return await self._find_glossary_simple(content, namespace=namespace)
 
-        async with self._session() as session:
-            fp_row = await session.execute(
-                select(
-                    func.count(GlossaryKeyword.id),
-                    func.coalesce(func.max(GlossaryKeyword.id), 0),
-                    func.max(GlossaryKeyword.created_at),
-                )
-            )
-            current_fp = tuple(fp_row.one())
+        keyword_universe = await self._fetch_keyword_universe(namespace)
 
-        if current_fp[0] == 0:
-            self._automaton = None
-            self._fingerprint = current_fp
-            return {}
-
-        if current_fp != self._fingerprint:
-            async with self._session() as session:
-                kw_result = await session.execute(
-                    select(GlossaryKeyword.keyword).distinct()
-                )
-                all_keywords = [row[0] for row in kw_result.all()]
-
-            if not all_keywords:
-                self._automaton = None
+        # Cache the automaton keyed by namespace so different scopes don't
+        # invalidate each other's caches every call.
+        cache_key = namespace if namespace is not None else "__all__"
+        cached_fp = self._fingerprints.get(cache_key)
+        if keyword_universe.fingerprint != cached_fp:
+            if not keyword_universe.keywords:
+                self._automatons[cache_key] = None
             else:
                 automaton = ahocorasick.Automaton()
-                for kw in all_keywords:
+                for kw in keyword_universe.keywords:
                     automaton.add_word(kw, kw)
                 automaton.make_automaton()
-                self._automaton = automaton
+                self._automatons[cache_key] = automaton
+            self._fingerprints[cache_key] = keyword_universe.fingerprint
 
-            self._fingerprint = current_fp
-
-        if self._automaton is None:
+        automaton = self._automatons.get(cache_key)
+        if automaton is None:
             return {}
 
         found_keywords: set = set()
-        for _, kw in self._automaton.iter(content):
+        for _, kw in automaton.iter(content):
             found_keywords.add(kw)
 
         if not found_keywords:
             return {}
 
-        return await self._resolve_keyword_nodes(found_keywords)
+        return await self._resolve_keyword_nodes(found_keywords, namespace=namespace)
 
     async def _find_glossary_simple(
-        self, content: str
+        self,
+        content: str,
+        namespace: Optional[str] = None,
     ) -> Dict[str, List[Dict[str, str]]]:
         """Fallback: simple substring matching when ahocorasick is unavailable."""
-        async with self._session() as session:
-            kw_result = await session.execute(
-                select(GlossaryKeyword.keyword).distinct()
-            )
-            all_keywords = [row[0] for row in kw_result.all()]
-
-        found_keywords = {kw for kw in all_keywords if kw in content}
+        keyword_universe = await self._fetch_keyword_universe(namespace)
+        found_keywords = {
+            kw for kw in keyword_universe.keywords if kw in content
+        }
         if not found_keywords:
             return {}
+        return await self._resolve_keyword_nodes(found_keywords, namespace=namespace)
 
-        return await self._resolve_keyword_nodes(found_keywords)
+    async def _fetch_keyword_universe(
+        self, namespace: Optional[str]
+    ) -> "_KeywordUniverse":
+        """Pull the keywords + fingerprint visible from ``namespace``.
+
+        ``namespace=None`` returns every keyword (legacy behaviour).
+        Otherwise restricts to ``(namespace, __shared__)``.
+        """
+        async with self._session() as session:
+            stmt_count = select(
+                func.count(GlossaryKeyword.id),
+                func.coalesce(func.max(GlossaryKeyword.id), 0),
+                func.max(GlossaryKeyword.created_at),
+            )
+            stmt_keys = select(GlossaryKeyword.keyword).distinct()
+            if namespace is not None:
+                ns_filter = GlossaryKeyword.namespace.in_(
+                    [namespace, SHARED_NAMESPACE]
+                )
+                stmt_count = stmt_count.where(ns_filter)
+                stmt_keys = stmt_keys.where(ns_filter)
+
+            fp_row = await session.execute(stmt_count)
+            fingerprint = tuple(fp_row.one())
+
+            kw_result = await session.execute(stmt_keys)
+            keywords = [row[0] for row in kw_result.all()]
+
+        return _KeywordUniverse(keywords=keywords, fingerprint=fingerprint)
 
     async def _resolve_keyword_nodes(
-        self, found_keywords: set
+        self, found_keywords: set, namespace: Optional[str] = None
     ) -> Dict[str, List[Dict[str, str]]]:
-        """Resolve found keywords to their node UUIDs and URIs."""
+        """Resolve found keywords to their node UUIDs and URIs.
+
+        If ``namespace`` is provided, only resolves keywords scoped to
+        ``(namespace, __shared__)`` so a user-scoped scan can't leak the
+        existence of a foreign-namespace keyword.
+        """
         async with self._session() as session:
-            result = await session.execute(
+            stmt = (
                 select(
                     GlossaryKeyword.keyword,
                     GlossaryKeyword.node_uuid,
@@ -265,6 +340,11 @@ class GlossaryService:
                 .where(GlossaryKeyword.keyword.in_(found_keywords))
                 .order_by(GlossaryKeyword.keyword, Path.domain, Path.path)
             )
+            if namespace is not None:
+                stmt = stmt.where(
+                    GlossaryKeyword.namespace.in_([namespace, SHARED_NAMESPACE])
+                )
+            result = await session.execute(stmt)
 
             matches: Dict[str, Dict[str, str]] = defaultdict(dict)
             for keyword, node_uuid, domain, path in result.all():

--- a/omicsclaw/memory/graph.py
+++ b/omicsclaw/memory/graph.py
@@ -28,8 +28,10 @@ from sqlalchemy import (
     not_,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from .engine import MemoryEngine
 from .models import (
     ROOT_NODE_UUID,
+    SHARED_NAMESPACE,
     Node,
     Memory,
     Edge,
@@ -67,6 +69,11 @@ class GraphService:
         self.session = db.session
         self._optional_session = db._optional_session
         self._search = search
+        # Transitional shim (PR #3c): the mutating verbs delegate to
+        # MemoryEngine with namespace='__shared__', preserving the legacy
+        # observable behaviour. PR #6 deletes the shim entirely once
+        # callers have moved to MemoryClient/MemoryEngine directly.
+        self._engine = MemoryEngine(db, search)
 
     @staticmethod
     def _decode_legacy(content: str) -> str:
@@ -900,7 +907,14 @@ class GraphService:
         Create a new memory under a parent path.
 
         Creates: Node -> Memory -> Edge (parent->child) -> Path.
+
+        PR #3c shim: delegates the actual write to ``MemoryEngine.upsert_versioned``
+        with ``namespace='__shared__'``. The path-computation policy
+        (auto-numbering when ``title`` is omitted, the duplicate-path check)
+        stays here because it has no engine equivalent. PR #6 removes the
+        shim once callers move to ``MemoryClient`` / ``MemoryEngine`` directly.
         """
+        # Pre-flight: resolve parent, compute final path, reject duplicates.
         async with self.session() as session:
             if not parent_path:
                 parent_uuid = ROOT_NODE_UUID
@@ -922,43 +936,56 @@ class GraphService:
                 )
 
             existing = await session.execute(
-                select(Path).where(Path.domain == domain, Path.path == final_path)
+                select(Path).where(
+                    Path.namespace == SHARED_NAMESPACE,
+                    Path.domain == domain,
+                    Path.path == final_path,
+                )
             )
             if existing.scalar_one_or_none():
                 raise ValueError(f"Path '{domain}://{final_path}' already exists")
 
-            new_uuid = str(uuid_lib.uuid4())
-            node = await self._ensure_node(session, new_uuid)
-            memory = await self._insert_memory(session, new_uuid, content)
+        # Delegate the row-creating part to MemoryEngine. Engine produces
+        # Node + Memory + Edge + Path inside ``__shared__`` and refreshes
+        # the search index. Returned ref carries memory_id and node_uuid.
+        ref = await self._engine.upsert_versioned(
+            f"{domain}://{final_path}",
+            content,
+            namespace=SHARED_NAMESPACE,
+            priority=priority,
+            disclosure=disclosure,
+        )
 
-            edge_name = title if title else final_path.rsplit("/", 1)[-1]
-            created = await self._create_edge_with_paths(
-                session,
-                parent_uuid,
-                new_uuid,
-                edge_name,
-                domain,
-                final_path,
-                priority,
-                disclosure,
-            )
+        # Re-fetch the four rows we just created so the caller's changeset
+        # bookkeeping (rows_after) gets the canonical serialised shape.
+        async with self.session() as session:
+            path_row = (
+                await session.execute(
+                    select(Path).where(
+                        Path.namespace == SHARED_NAMESPACE,
+                        Path.domain == domain,
+                        Path.path == final_path,
+                    )
+                )
+            ).scalar_one()
+            edge = await session.get(Edge, path_row.edge_id)
+            node = await session.get(Node, ref.node_uuid)
+            memory = await session.get(Memory, ref.new_memory_id)
 
-            await self._search.refresh_search_documents_for_node(new_uuid, session=session)
-
-            return {
-                "id": memory.id,
-                "node_uuid": new_uuid,
-                "domain": domain,
-                "path": final_path,
-                "uri": f"{domain}://{final_path}",
-                "priority": priority,
-                "rows_after": {
-                    "nodes": [serialize_row(node)],
-                    "memories": [serialize_memory_ref(memory)],
-                    "edges": [serialize_row(created["edge"])],
-                    "paths": [serialize_row(created["path"])],
-                },
-            }
+        return {
+            "id": ref.new_memory_id,
+            "node_uuid": ref.node_uuid,
+            "domain": domain,
+            "path": final_path,
+            "uri": f"{domain}://{final_path}",
+            "priority": priority,
+            "rows_after": {
+                "nodes": [serialize_row(node)],
+                "memories": [serialize_memory_ref(memory)],
+                "edges": [serialize_row(edge)],
+                "paths": [serialize_row(path_row)],
+            },
+        }
 
     async def update_memory(
         self,
@@ -971,8 +998,17 @@ class GraphService:
         """
         Update a memory.
 
-        Content change -> new Memory row with the same node_uuid.
+        Content change -> new Memory row with the same node_uuid (deprecation chain).
         Metadata change -> update the Edge directly.
+
+        PR #3c shim: delegates to ``MemoryEngine.upsert_versioned`` (when
+        content changes) or ``MemoryEngine.patch_edge_metadata`` (metadata
+        only) with ``namespace='__shared__'``. Pre-flight resolves the
+        path and snapshots ``rows_before``; post-flight re-fetches to
+        build ``rows_after``. The ``priority``/``disclosure`` defaults of
+        ``None`` mean "preserve" in the legacy contract — we translate
+        that into the engine's ``_UNSET`` sentinel by simply omitting
+        unset kwargs from the engine call.
         """
         if path == "":
             raise ValueError("Cannot update the root node.")
@@ -983,6 +1019,7 @@ class GraphService:
                 "At least one of content, priority, or disclosure must be set."
             )
 
+        # Pre-flight: snapshot the current edge + active memory.
         async with self.session() as session:
             result = await session.execute(
                 select(Memory, Edge, Path)
@@ -995,81 +1032,81 @@ class GraphService:
                         Memory.deprecated == False,
                     ),
                 )
-                .where(Path.domain == domain, Path.path == path)
+                .where(
+                    Path.namespace == SHARED_NAMESPACE,
+                    Path.domain == domain,
+                    Path.path == path,
+                )
                 .order_by(Memory.created_at.desc())
                 .limit(1)
             )
             row = result.first()
-
             if not row:
                 raise ValueError(
                     f"Path '{domain}://{path}' not found or memory is deprecated"
                 )
-
-            old_memory, edge, path_obj = row
+            old_memory, edge, _ = row
             old_id = old_memory.id
+            edge_id = edge.id
             node_uuid = edge.child_uuid
-
-            rows_before: Dict[str, list] = {}
-            rows_after: Dict[str, list] = {}
-
             edge_before = serialize_row(edge)
+            old_memory_ref = serialize_memory_ref(old_memory)
 
-            if priority is not None:
-                edge.priority = priority
-                session.add(edge)
-            if disclosure is not None:
-                edge.disclosure = disclosure
-                session.add(edge)
+        # Translate legacy "None means preserve" into engine's _UNSET via
+        # kwargs omission. Engine helpers preserve current values when an
+        # arg isn't supplied.
+        engine_kwargs: Dict[str, Any] = {}
+        if priority is not None:
+            engine_kwargs["priority"] = priority
+        if disclosure is not None:
+            engine_kwargs["disclosure"] = disclosure
 
-            edge_after = serialize_row(edge)
+        if content is not None:
+            ref = await self._engine.upsert_versioned(
+                f"{domain}://{path}",
+                content,
+                namespace=SHARED_NAMESPACE,
+                **engine_kwargs,
+            )
+            new_memory_id = ref.new_memory_id
+        else:
+            await self._engine.patch_edge_metadata(
+                f"{domain}://{path}",
+                namespace=SHARED_NAMESPACE,
+                **engine_kwargs,
+            )
+            new_memory_id = old_id
+
+        # Post-flight: re-fetch updated rows for changeset bookkeeping.
+        rows_before: Dict[str, list] = {}
+        rows_after: Dict[str, list] = {}
+
+        async with self.session() as session:
+            edge_after_obj = await session.get(Edge, edge_id)
+            edge_after = serialize_row(edge_after_obj)
             if edge_before != edge_after:
                 rows_before["edges"] = [edge_before]
                 rows_after["edges"] = [edge_after]
 
-            new_memory_id = old_id
-
             if content is not None:
-                rows_before["memories"] = [serialize_memory_ref(old_memory)]
-
-                new_memory = await self._insert_memory(
-                    session, node_uuid, content, deprecated=True
-                )
-                new_memory_id = new_memory.id
-                await self._deprecate_node_memories(
-                    session,
-                    node_uuid,
-                    successor_id=new_memory_id,
-                )
-                await session.execute(
-                    update(Memory)
-                    .where(Memory.id == new_memory_id)
-                    .values(deprecated=False, migrated_to=None)
-                )
-
-                await session.flush()
-                updated = await session.execute(
-                    select(Memory).where(Memory.id.in_([old_id, new_memory_id]))
-                )
+                rows_before["memories"] = [old_memory_ref]
+                old_after = await session.get(Memory, old_id)
+                new_after = await session.get(Memory, new_memory_id)
                 rows_after["memories"] = [
-                    serialize_memory_ref(m) for m in updated.scalars().all()
+                    serialize_memory_ref(old_after),
+                    serialize_memory_ref(new_after),
                 ]
 
-            if content is None:
-                session.add(path_obj)
-
-            await self._search.refresh_search_documents_for_node(node_uuid, session=session)
-
-            return {
-                "domain": domain,
-                "path": path,
-                "uri": f"{domain}://{path}",
-                "old_memory_id": old_id,
-                "new_memory_id": new_memory_id,
-                "node_uuid": node_uuid,
-                "rows_before": rows_before,
-                "rows_after": rows_after,
-            }
+        return {
+            "domain": domain,
+            "path": path,
+            "uri": f"{domain}://{path}",
+            "old_memory_id": old_id,
+            "new_memory_id": new_memory_id,
+            "node_uuid": node_uuid,
+            "rows_before": rows_before,
+            "rows_after": rows_after,
+        }
 
     async def rollback_to_memory(
         self, target_memory_id: int, session: Optional[AsyncSession] = None

--- a/omicsclaw/memory/migrations/001_namespace.py
+++ b/omicsclaw/memory/migrations/001_namespace.py
@@ -1,0 +1,167 @@
+"""001_namespace: Add namespace partition to paths, search_documents, glossary_keywords.
+
+Idempotent — checks for the namespace column on ``paths`` before doing any
+work. Backfills namespace from the ``disclosure`` field of session and memory
+records (best-effort; rows without parseable disclosure stay at ``__shared__``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+VERSION = "001_namespace"
+DESCRIPTION = "Add namespace partition to paths, search_documents, glossary_keywords"
+
+# Disclosure formats produced by compat.py:
+#   "Memory from session <platform>:<user_id>:<session_uuid>"
+#   "Session for user <user_id> on <platform>"
+_DISCLOSURE_MEMORY_RE = re.compile(r"Memory from session (\S+?):(\S+?):")
+_DISCLOSURE_SESSION_RE = re.compile(r"Session for user (\S+) on (\S+)")
+
+
+async def _column_exists(s, table: str, column: str) -> bool:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.all())
+
+
+def _parse_disclosure_namespace(disclosure: str | None) -> str | None:
+    """Extract ``f"{platform}/{user_id}"`` from a disclosure string, if possible."""
+    if not disclosure:
+        return None
+    m = _DISCLOSURE_MEMORY_RE.search(disclosure)
+    if m:
+        platform, user_id = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    m = _DISCLOSURE_SESSION_RE.search(disclosure)
+    if m:
+        user_id, platform = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    return None
+
+
+async def _backfill_namespace_from_disclosure(s) -> None:
+    """Update ``namespace`` on paths + search_documents based on disclosure data."""
+    result = await s.execute(
+        sa.text(
+            "SELECT domain, path, disclosure FROM search_documents "
+            "WHERE disclosure IS NOT NULL"
+        )
+    )
+    for domain, path, disclosure in result.all():
+        ns = _parse_disclosure_namespace(disclosure)
+        if not ns:
+            continue
+        await s.execute(
+            sa.text(
+                "UPDATE paths SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "UPDATE search_documents SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+
+
+async def apply(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        # Idempotent guard — column already added means migration has been applied.
+        if await _column_exists(s, "paths", "namespace"):
+            return
+
+        # 1. Rebuild paths with composite PK (namespace, domain, path)
+        await s.execute(sa.text("""
+            CREATE TABLE paths_new (
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO paths_new (namespace, domain, path, edge_id, created_at)
+            SELECT '__shared__', domain, path, edge_id, created_at FROM paths
+        """))
+        await s.execute(sa.text("DROP TABLE paths"))
+        await s.execute(sa.text("ALTER TABLE paths_new RENAME TO paths"))
+
+        # 2. Rebuild search_documents with composite PK
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents_new (
+                namespace    VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_new
+                (namespace, domain, path, node_uuid, memory_id, uri,
+                 content, disclosure, search_terms, priority, updated_at)
+            SELECT '__shared__', domain, path, node_uuid, memory_id, uri,
+                   content, disclosure, search_terms, priority, updated_at
+            FROM search_documents
+        """))
+        await s.execute(sa.text("DROP TABLE search_documents"))
+        await s.execute(sa.text("ALTER TABLE search_documents_new RENAME TO search_documents"))
+
+        # 3. Rebuild glossary_keywords with namespace + new UNIQUE constraint
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords_new (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                created_at DATETIME,
+                UNIQUE (namespace, keyword, node_uuid)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO glossary_keywords_new (id, keyword, node_uuid, namespace, created_at)
+            SELECT id, keyword, node_uuid, '__shared__', created_at FROM glossary_keywords
+        """))
+        await s.execute(sa.text("DROP TABLE glossary_keywords"))
+        await s.execute(sa.text("ALTER TABLE glossary_keywords_new RENAME TO glossary_keywords"))
+
+        # 4. Best-effort namespace backfill from disclosure metadata
+        await _backfill_namespace_from_disclosure(s)
+
+        # 5. Rebuild FTS5 virtual table with namespace column, repopulate from search_documents
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents_fts"))
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                namespace, domain, path, node_uuid, uri, content,
+                disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_fts (
+                rowid, namespace, domain, path, node_uuid, uri,
+                content, disclosure, search_terms
+            )
+            SELECT rowid, namespace, domain, path, node_uuid, uri,
+                   content, disclosure, search_terms
+            FROM search_documents
+        """))

--- a/omicsclaw/memory/migrations/__init__.py
+++ b/omicsclaw/memory/migrations/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight migrations framework for OmicsClaw memory schema.
+
+Each migration is a module exposing module-level ``VERSION`` (str),
+``DESCRIPTION`` (str), and ``async def apply(db: DatabaseManager) -> None``.
+The runner discovers them, applies pending ones in version-sorted order,
+and records applications in the ``_schema_version`` table.
+"""
+
+from omicsclaw.memory.migrations.runner import run_pending
+
+__all__ = ["run_pending"]

--- a/omicsclaw/memory/migrations/runner.py
+++ b/omicsclaw/memory/migrations/runner.py
@@ -1,0 +1,93 @@
+"""Lightweight migrations runner — see omicsclaw/memory/migrations/__init__.py."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Iterable, Protocol
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+_DEFAULT_MIGRATIONS_PACKAGE = "omicsclaw.memory.migrations"
+
+
+class Migration(Protocol):
+    VERSION: str
+    DESCRIPTION: str
+
+    async def apply(self, db: "DatabaseManager") -> None: ...
+
+
+_SCHEMA_VERSION_DDL = sa.text(
+    "CREATE TABLE IF NOT EXISTS _schema_version ("
+    "  version TEXT PRIMARY KEY,"
+    "  applied_at TEXT NOT NULL"
+    ")"
+)
+
+
+async def _ensure_schema_version_table(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        await s.execute(_SCHEMA_VERSION_DDL)
+
+
+async def _get_applied_versions(db: "DatabaseManager") -> set[str]:
+    async with db.session() as s:
+        result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+        return {row[0] for row in result.all()}
+
+
+async def _record_applied(db: "DatabaseManager", version: str) -> None:
+    async with db.session() as s:
+        await s.execute(
+            sa.text(
+                "INSERT INTO _schema_version (version, applied_at) "
+                "VALUES (:v, :t)"
+            ),
+            {"v": version, "t": datetime.now(timezone.utc).isoformat()},
+        )
+
+
+def _discover_migrations(package: str = _DEFAULT_MIGRATIONS_PACKAGE) -> list[Migration]:
+    """Import every NNN_*.py module in ``package`` and return them as migrations."""
+    pkg = importlib.import_module(package)
+    found: list[Migration] = []
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if not info.name[:1].isdigit():
+            continue
+        mod = importlib.import_module(f"{package}.{info.name}")
+        if all(hasattr(mod, attr) for attr in ("VERSION", "DESCRIPTION", "apply")):
+            found.append(mod)  # type: ignore[arg-type]
+    return found
+
+
+async def run_pending(
+    db: "DatabaseManager",
+    *,
+    migrations: Iterable[Migration] | None = None,
+) -> list[str]:
+    """Apply pending migrations in version-sorted order. Returns versions applied.
+
+    If ``migrations`` is None, discovers them from
+    ``omicsclaw.memory.migrations`` (numbered modules: ``001_*.py``).
+    """
+    if migrations is None:
+        migrations = _discover_migrations()
+
+    await _ensure_schema_version_table(db)
+    applied = await _get_applied_versions(db)
+
+    pending = [m for m in migrations if m.VERSION not in applied]
+    pending.sort(key=lambda m: m.VERSION)
+
+    versions_applied: list[str] = []
+    for m in pending:
+        await m.apply(db)
+        await _record_applied(db, m.VERSION)
+        versions_applied.append(m.VERSION)
+
+    return versions_applied

--- a/omicsclaw/memory/models.py
+++ b/omicsclaw/memory/models.py
@@ -142,14 +142,20 @@ class Edge(Base):
 
 
 class Path(Base):
-    """Materialized URI cache: (domain, path_string) → edge.
+    """Materialized URI cache: (namespace, domain, path_string) → edge.
 
     The source of truth for tree structure is the edges table.
-    Paths are a routing convenience for URI resolution.
+    Paths are a routing convenience for URI resolution. ``namespace``
+    partitions identical (domain, path) URIs across surfaces/users.
+    Default ``__shared__`` keeps legacy callers (GraphService) writing into
+    the same partition they always have.
     """
 
     __tablename__ = "paths"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     edge_id = Column(Integer, ForeignKey("edges.id"), nullable=True)
@@ -159,10 +165,11 @@ class Path(Base):
 
 
 class GlossaryKeyword(Base):
-    """Glossary keyword-to-node binding.
+    """Glossary keyword-to-node binding, partitioned by namespace.
 
     When a keyword appears in a memory's content, the frontend highlights
-    the keyword and links it to the associated node.
+    the keyword and links it to the associated node. Each namespace owns
+    its own keyword set; ``__shared__`` keywords are visible to all.
     """
 
     __tablename__ = "glossary_keywords"
@@ -174,20 +181,32 @@ class GlossaryKeyword(Base):
         ForeignKey("nodes.uuid", ondelete="CASCADE"),
         nullable=False,
     )
+    namespace = Column(
+        String(128), nullable=False, default="__shared__"
+    )
     created_at = Column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (
-        UniqueConstraint("keyword", "node_uuid", name="uq_glossary_keyword_node"),
+        UniqueConstraint(
+            "namespace", "keyword", "node_uuid", name="uq_glossary_keyword_node"
+        ),
     )
 
     node = relationship("Node")
 
 
 class SearchDocument(Base):
-    """Derived search row for one reachable path of an active node."""
+    """Derived search row for one reachable path of an active node.
+
+    Composite PK ``(namespace, domain, path)`` matches Path's so the indexer
+    can refresh exactly one row per write target.
+    """
 
     __tablename__ = "search_documents"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     node_uuid = Column(

--- a/omicsclaw/memory/models.py
+++ b/omicsclaw/memory/models.py
@@ -33,6 +33,11 @@ Base = declarative_base()
 # Using a fixed UUID instead of NULL avoids SQLite's NULL != NULL uniqueness quirk.
 ROOT_NODE_UUID = "00000000-0000-0000-0000-000000000000"
 
+# Shared (cross-namespace) partition. Read fallback target for recall/search;
+# also the implicit default for legacy callers that don't pass ``namespace``.
+# Single source of truth — engine.py / search.py / migrations import from here.
+SHARED_NAMESPACE = "__shared__"
+
 
 # =============================================================================
 # Shared Utilities

--- a/omicsclaw/memory/namespace_policy.py
+++ b/omicsclaw/memory/namespace_policy.py
@@ -1,0 +1,51 @@
+"""Namespace + version policy — see docs/CONTEXT.md.
+
+Two independent classifications of a Memory URI:
+
+  resolve_namespace(uri, current=N)
+    → "__shared__" if uri matches a SHARED_PREFIXES entry, else N
+
+  should_version(uri)
+    → True if uri matches a VERSIONED_PREFIXES entry, else False
+
+Prefix semantics for both tables (`(domain, prefix)` tuples):
+  - empty prefix matches the whole domain (e.g., all of preference://*)
+  - non-empty prefix matches exact path OR "<prefix>/..." sub-paths
+  - "kh" does NOT match "khaki" — matching is by path-segment, not raw startswith
+"""
+
+from omicsclaw.memory.uri import MemoryURI
+
+SHARED = "__shared__"
+
+SHARED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "kh"),
+    ("core", "my_user_default"),
+)
+
+VERSIONED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "my_user"),
+    ("preference", ""),
+)
+
+
+def _matches_prefix(uri: MemoryURI, domain: str, prefix: str) -> bool:
+    if uri.domain != domain:
+        return False
+    if prefix == "":
+        return True
+    return uri.path == prefix or uri.path.startswith(prefix + "/")
+
+
+def _matches_any(uri: MemoryURI, prefixes: tuple[tuple[str, str], ...]) -> bool:
+    return any(_matches_prefix(uri, d, p) for d, p in prefixes)
+
+
+def resolve_namespace(uri: MemoryURI, *, current: str) -> str:
+    return SHARED if _matches_any(uri, SHARED_PREFIXES) else current
+
+
+def should_version(uri: MemoryURI) -> bool:
+    return _matches_any(uri, VERSIONED_PREFIXES)

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -373,26 +373,54 @@ class SearchIndexer:
     # -----------------------------------------------------------------
 
     async def search(
-        self, query: str, limit: int = 10, domain: Optional[str] = None
+        self,
+        query: str,
+        limit: int = 10,
+        domain: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search memories by path and content using the derived FTS index."""
+        """Search memories by path and content using the derived FTS index.
+
+        When ``namespace`` is provided, results are restricted to that
+        namespace plus the shared partition; per-namespace hits are sorted
+        ahead of shared ones. ``namespace=None`` preserves legacy
+        unfiltered behavior for callers that haven't migrated.
+        """
         async with self._session() as session:
             candidate_limit = max(limit * 5, 50)
             params: Dict[str, Any] = {"candidate_limit": candidate_limit}
+
             domain_clause = ""
             if domain is not None:
                 params["domain"] = domain
                 domain_clause = "AND sd.domain = :domain"
 
+            namespace_clause, namespace_order = "", ""
+            if namespace is not None:
+                params["current_ns"] = namespace
+                params["shared_ns"] = SHARED_NAMESPACE
+                namespace_clause = (
+                    "AND sd.namespace IN (:current_ns, :shared_ns)"
+                )
+                namespace_order = (
+                    "CASE WHEN sd.namespace = :current_ns THEN 0 ELSE 1 END ASC,"
+                )
+
             if self.db_type == "sqlite":
                 # Try FTS5 first, fall back to LIKE search
                 try:
                     return await self._search_sqlite_fts(
-                        session, query, params, domain_clause, limit
+                        session,
+                        query,
+                        params,
+                        domain_clause,
+                        namespace_clause,
+                        namespace_order,
+                        limit,
                     )
                 except Exception:
                     return await self._search_sqlite_like(
-                        session, query, limit, domain
+                        session, query, limit, domain, namespace
                     )
             else:
                 normalized = expand_query_terms(query)
@@ -411,6 +439,7 @@ class SearchIndexer:
                             sd.priority,
                             sd.content,
                             sd.disclosure,
+                            sd.namespace AS namespace,
                             ts_rank_cd(
                                 to_tsvector(
                                     'simple',
@@ -432,7 +461,8 @@ class SearchIndexer:
                                 coalesce(sd.search_terms, '')
                               ) @@ websearch_to_tsquery('simple', :ts_query)
                           {domain_clause}
-                        ORDER BY score DESC, sd.priority ASC, char_length(sd.path) ASC
+                          {namespace_clause}
+                        ORDER BY {namespace_order} score DESC, sd.priority ASC, char_length(sd.path) ASC
                         LIMIT :candidate_limit
                         """
                     ),
@@ -447,6 +477,8 @@ class SearchIndexer:
         query: str,
         params: Dict[str, Any],
         domain_clause: str,
+        namespace_clause: str,
+        namespace_order: str,
         limit: int,
     ) -> List[Dict[str, Any]]:
         """Search using SQLite FTS5."""
@@ -466,6 +498,7 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
+                    sd.namespace AS namespace,
                     -- 8 bm25 weights, one per FTS column in declaration order:
                     -- namespace, domain, path, node_uuid, uri, content,
                     -- disclosure, search_terms. namespace gets 0.0 because
@@ -479,7 +512,8 @@ class SearchIndexer:
                  AND search_documents_fts.path      = sd.path
                 WHERE search_documents_fts MATCH :match_query
                   {domain_clause}
-                ORDER BY score ASC, sd.priority ASC, length(sd.path) ASC
+                  {namespace_clause}
+                ORDER BY {namespace_order} score ASC, sd.priority ASC, length(sd.path) ASC
                 LIMIT :candidate_limit
                 """
             ),
@@ -493,6 +527,7 @@ class SearchIndexer:
         query: str,
         limit: int,
         domain: Optional[str],
+        namespace: Optional[str],
     ) -> List[Dict[str, Any]]:
         """Fallback search using LIKE when FTS5 is unavailable."""
         safe_query = f"%{escape_like_literal(query)}%"
@@ -502,6 +537,17 @@ class SearchIndexer:
         if domain:
             params["domain"] = domain
             domain_clause = "AND sd.domain = :domain"
+
+        namespace_clause, namespace_order = "", ""
+        if namespace is not None:
+            params["current_ns"] = namespace
+            params["shared_ns"] = SHARED_NAMESPACE
+            namespace_clause = (
+                "AND sd.namespace IN (:current_ns, :shared_ns)"
+            )
+            namespace_order = (
+                "CASE WHEN sd.namespace = :current_ns THEN 0 ELSE 1 END ASC,"
+            )
 
         result = await session.execute(
             text(
@@ -514,11 +560,13 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
+                    sd.namespace AS namespace,
                     0 AS score
                 FROM search_documents AS sd
                 WHERE (sd.content LIKE :query ESCAPE '\\' OR sd.path LIKE :query ESCAPE '\\')
                   {domain_clause}
-                ORDER BY sd.priority ASC, length(sd.path) ASC
+                  {namespace_clause}
+                ORDER BY {namespace_order} sd.priority ASC, length(sd.path) ASC
                 LIMIT :limit
                 """
             ),
@@ -537,6 +585,7 @@ class SearchIndexer:
             seen_nodes.add(row["node_uuid"])
             matches.append(
                 {
+                    "namespace": row.get("namespace"),
                     "domain": row["domain"],
                     "path": row["path"],
                     "uri": row["uri"],

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -18,6 +18,7 @@ from .models import (
     Path,
     GlossaryKeyword,
     SearchDocument,
+    SHARED_NAMESPACE,
     escape_like_literal,
 )
 from .search_terms import build_document_search_terms, expand_query_terms
@@ -25,8 +26,6 @@ from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
-
-SHARED_NAMESPACE = "__shared__"
 
 
 class SearchIndexer:

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -105,11 +105,13 @@ class SearchIndexer:
 
         path_rows = (
             await session.execute(
-                select(Path.domain, Path.path, Edge.priority, Edge.disclosure)
+                select(
+                    Path.namespace, Path.domain, Path.path, Edge.priority, Edge.disclosure
+                )
                 .select_from(Path)
                 .join(Edge, Path.edge_id == Edge.id)
                 .where(Edge.child_uuid == node_uuid)
-                .order_by(Path.domain, Path.path)
+                .order_by(Path.namespace, Path.domain, Path.path)
             )
         ).all()
         if not path_rows:
@@ -127,6 +129,7 @@ class SearchIndexer:
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
+                    "namespace": row.namespace,
                     "domain": row.domain,
                     "path": row.path,
                     "node_uuid": node_uuid,
@@ -182,9 +185,9 @@ class SearchIndexer:
                     text(
                         """
                         INSERT INTO search_documents_fts (
-                            domain, path, node_uuid, uri, content, disclosure, search_terms
+                            namespace, domain, path, node_uuid, uri, content, disclosure, search_terms
                         ) VALUES (
-                            :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
+                            :namespace, :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
                         )
                         """
                     ),

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -466,11 +466,17 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
-                    bm25(search_documents_fts, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
+                    -- 8 bm25 weights, one per FTS column in declaration order:
+                    -- namespace, domain, path, node_uuid, uri, content,
+                    -- disclosure, search_terms. namespace gets 0.0 because
+                    -- the JOIN already filters it; domain/node_uuid stay 0.0
+                    -- so they don't influence ranking.
+                    bm25(search_documents_fts, 0.0, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
                 FROM search_documents AS sd
                 JOIN search_documents_fts
-                  ON search_documents_fts.domain = sd.domain
-                 AND search_documents_fts.path = sd.path
+                  ON search_documents_fts.namespace = sd.namespace
+                 AND search_documents_fts.domain    = sd.domain
+                 AND search_documents_fts.path      = sd.path
                 WHERE search_documents_fts MATCH :match_query
                   {domain_clause}
                 ORDER BY score ASC, sd.priority ASC, length(sd.path) ASC

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -21,9 +21,12 @@ from .models import (
     escape_like_literal,
 )
 from .search_terms import build_document_search_terms, expand_query_terms
+from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
+
+SHARED_NAMESPACE = "__shared__"
 
 
 class SearchIndexer:
@@ -117,15 +120,29 @@ class SearchIndexer:
         if not path_rows:
             return []
 
-        keyword_rows = await session.execute(
-            select(GlossaryKeyword.keyword)
-            .where(GlossaryKeyword.node_uuid == node_uuid)
-            .order_by(GlossaryKeyword.keyword)
-        )
-        glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+        # Glossary keywords are partitioned by namespace; for each search
+        # row we include only keywords visible from its namespace, i.e. the
+        # row's own namespace plus the global ``__shared__`` namespace.
+        keyword_rows = (
+            await session.execute(
+                select(GlossaryKeyword.keyword, GlossaryKeyword.namespace)
+                .where(GlossaryKeyword.node_uuid == node_uuid)
+                .order_by(GlossaryKeyword.namespace, GlossaryKeyword.keyword)
+            )
+        ).all()
+        keyword_by_ns: Dict[str, List[str]] = {}
+        for kw, ns in keyword_rows:
+            if not kw:
+                continue
+            keyword_by_ns.setdefault(ns, []).append(kw)
 
         documents = []
+        shared_keywords = keyword_by_ns.get(SHARED_NAMESPACE, [])
         for row in path_rows:
+            visible = list(keyword_by_ns.get(row.namespace, []))
+            if row.namespace != SHARED_NAMESPACE:
+                visible.extend(shared_keywords)
+            glossary_text = " ".join(visible)
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
@@ -199,11 +216,114 @@ class SearchIndexer:
     async def refresh_search_documents_for_node(
         self, node_uuid: str, session: Optional[AsyncSession] = None
     ) -> None:
-        """Rebuild derived search rows for one node."""
+        """Rebuild derived search rows for one node (all namespaces).
+
+        Used when a node's content or structural metadata changed and every
+        path pointing at it needs to be reindexed.
+        """
         async with self._optional_session(session) as session:
             documents = await self._build_search_documents_for_node(session, node_uuid)
             await self._delete_search_documents_for_node(session, node_uuid)
             await self._insert_search_documents(session, documents)
+
+    async def refresh_search_documents_for(
+        self,
+        namespace: str,
+        uri: str | MemoryURI,
+        session: Optional[AsyncSession] = None,
+    ) -> None:
+        """Surgically rebuild ONE search row at (namespace, domain, path).
+
+        Useful when a write touches only a single (namespace, uri) and we
+        don't want to disturb sibling rows for the same node in other
+        namespaces. No-op if the path doesn't exist or has no active memory.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._optional_session(session) as s:
+            path_row = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == namespace,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if path_row is None:
+                return
+
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                return
+
+            memory = (
+                await s.execute(
+                    select(Memory)
+                    .where(
+                        Memory.node_uuid == edge.child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    )
+                    .order_by(Memory.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if memory is None:
+                return
+
+            keyword_rows = (
+                await s.execute(
+                    select(GlossaryKeyword.keyword)
+                    .where(
+                        GlossaryKeyword.node_uuid == edge.child_uuid,
+                        GlossaryKeyword.namespace.in_(
+                            [namespace, SHARED_NAMESPACE]
+                        ),
+                    )
+                    .order_by(GlossaryKeyword.keyword)
+                )
+            ).all()
+            glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+
+            uri_str = f"{parsed.domain}://{parsed.path}"
+            doc = {
+                "namespace": namespace,
+                "domain": parsed.domain,
+                "path": parsed.path,
+                "node_uuid": edge.child_uuid,
+                "memory_id": memory.id,
+                "uri": uri_str,
+                "content": memory.content,
+                "disclosure": edge.disclosure,
+                "search_terms": build_document_search_terms(
+                    parsed.path,
+                    uri_str,
+                    memory.content,
+                    edge.disclosure,
+                    glossary_text,
+                ),
+                "priority": edge.priority,
+            }
+
+            if self.db_type == "sqlite":
+                try:
+                    await s.execute(
+                        text(
+                            "DELETE FROM search_documents_fts "
+                            "WHERE namespace = :ns AND domain = :d AND path = :p"
+                        ),
+                        {"ns": namespace, "d": parsed.domain, "p": parsed.path},
+                    )
+                except Exception:
+                    pass
+            await s.execute(
+                delete(SearchDocument).where(
+                    SearchDocument.namespace == namespace,
+                    SearchDocument.domain == parsed.domain,
+                    SearchDocument.path == parsed.path,
+                )
+            )
+            await self._insert_search_documents(s, [doc])
 
     async def get_node_uuids_for_prefix(
         self, session: AsyncSession, domain: str, base_path: str

--- a/omicsclaw/memory/uri.py
+++ b/omicsclaw/memory/uri.py
@@ -1,0 +1,61 @@
+"""MemoryURI value object — see docs/CONTEXT.md → "Memory URI"."""
+
+from dataclasses import dataclass
+
+DEFAULT_DOMAIN = "core"
+SCHEME_SEPARATOR = "://"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryURI:
+    """Stable identifier for a memory location, independent of row id.
+
+    Invariants (enforced in ``__post_init__``):
+      - ``domain`` is non-empty, contains no ``://``, no control chars
+      - ``path`` contains no ``://`` (slashes are fine; they delimit segments)
+
+    Construct via ``parse(raw)`` for ``"domain://path"`` strings, or
+    via ``root(domain)`` for the root URI of a domain.
+    """
+
+    domain: str
+    path: str
+
+    def __post_init__(self) -> None:
+        if not self.domain:
+            raise ValueError("MemoryURI domain must be non-empty")
+        if SCHEME_SEPARATOR in self.domain:
+            raise ValueError(f"MemoryURI domain must not contain '://': {self.domain!r}")
+        if any(ord(c) < 0x20 for c in self.domain):
+            raise ValueError(f"MemoryURI domain must not contain control characters: {self.domain!r}")
+        if SCHEME_SEPARATOR in self.path:
+            raise ValueError(f"MemoryURI path must not contain '://': {self.path!r}")
+
+    @classmethod
+    def parse(cls, raw: str) -> "MemoryURI":
+        if SCHEME_SEPARATOR in raw:
+            domain, path = raw.split(SCHEME_SEPARATOR, 1)
+        else:
+            domain, path = DEFAULT_DOMAIN, raw
+        return cls(domain=domain, path=path)
+
+    @classmethod
+    def root(cls, domain: str = DEFAULT_DOMAIN) -> "MemoryURI":
+        return cls(domain=domain, path="")
+
+    def __str__(self) -> str:
+        return f"{self.domain}{SCHEME_SEPARATOR}{self.path}"
+
+    @property
+    def is_root(self) -> bool:
+        return self.path == ""
+
+    def child(self, name: str) -> "MemoryURI":
+        new_path = f"{self.path}/{name}" if self.path else name
+        return MemoryURI(domain=self.domain, path=new_path)
+
+    def parent(self) -> "MemoryURI | None":
+        if self.is_root:
+            return None
+        head, _, _ = self.path.rpartition("/")
+        return MemoryURI(domain=self.domain, path=head)

--- a/scripts/migrate_dry_run.py
+++ b/scripts/migrate_dry_run.py
@@ -1,0 +1,154 @@
+"""Dry-run for OmicsClaw memory schema migrations.
+
+Copies a memory.db to a temp location and runs all pending migrations against
+the copy, printing a diff (table row counts before/after, namespace
+distribution after, count of disclosures we couldn't parse). Exit code 0
+only if the migration ran cleanly and row counts are preserved.
+
+The original memory.db is never touched.
+
+Usage:
+
+    python scripts/migrate_dry_run.py
+        # Defaults to ~/.config/omicsclaw/memory.db
+
+    python scripts/migrate_dry_run.py --db-path /path/to/memory.db
+
+Recommended workflow before deploying a new migration:
+
+    1. cp ~/.config/omicsclaw/memory.db ~/.config/omicsclaw/memory.db.pre-NNN.bak
+    2. python scripts/migrate_dry_run.py
+    3. Inspect output; rollback recipe is `cp memory.db.pre-NNN.bak memory.db`
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import sqlalchemy as sa
+
+
+_TABLES = ("nodes", "memories", "edges", "paths", "search_documents", "glossary_keywords")
+
+
+async def _row_counts(db) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    async with db.session() as s:
+        for table in _TABLES:
+            try:
+                result = await s.execute(sa.text(f"SELECT COUNT(*) FROM {table}"))
+                counts[table] = result.scalar_one()
+            except Exception as e:
+                counts[table] = -1  # table missing in this state
+    return counts
+
+
+async def _namespace_distribution(db) -> dict[str, int]:
+    """After migration, count rows per namespace across paths."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT namespace, COUNT(*) FROM paths GROUP BY namespace ORDER BY 2 DESC"
+            )
+        )
+        return {row[0]: row[1] for row in result.all()}
+
+
+async def _unparseable_disclosures(db) -> int:
+    """Count search_documents rows that have a non-empty disclosure but
+    still ended up in __shared__ (likely unparseable)."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM search_documents "
+                "WHERE namespace = '__shared__' "
+                "AND disclosure IS NOT NULL "
+                "AND TRIM(disclosure) <> ''"
+            )
+        )
+        return result.scalar_one()
+
+
+async def main_async(db_path: Path) -> int:
+    if not db_path.exists():
+        print(f"ERROR: source DB not found at {db_path}", file=sys.stderr)
+        return 2
+
+    # Copy to a temp file so the original is untouched
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        copy_path = Path(tmp.name)
+    shutil.copy2(db_path, copy_path)
+    print(f"Copied {db_path} -> {copy_path}")
+    print(f"Source size:  {db_path.stat().st_size:,} bytes")
+
+    # Defer DatabaseManager import so the script remains usable even with a
+    # partial install; if memory deps are missing it will surface here.
+    from omicsclaw.memory.database import DatabaseManager
+
+    url = f"sqlite+aiosqlite:///{copy_path}"
+    db = DatabaseManager(url)
+    try:
+        before = await _row_counts(db)
+        print(f"\nRow counts BEFORE migration:")
+        for tbl, n in before.items():
+            print(f"  {tbl:24s} {n:>8d}")
+
+        # init_db runs all pending migrations via the runner
+        await db.init_db()
+
+        after = await _row_counts(db)
+        print(f"\nRow counts AFTER migration:")
+        for tbl, n in after.items():
+            change = "" if before[tbl] == after[tbl] else f"  ← was {before[tbl]}"
+            print(f"  {tbl:24s} {n:>8d}{change}")
+
+        ns_dist = await _namespace_distribution(db)
+        print(f"\nNamespace distribution (paths) after migration:")
+        for ns, n in ns_dist.items():
+            print(f"  {ns:32s} {n:>8d}")
+
+        unparseable = await _unparseable_disclosures(db)
+        print(f"\nUnparseable disclosures: {unparseable}")
+
+        # Assertions
+        ok = True
+        for tbl in _TABLES:
+            if before[tbl] >= 0 and before[tbl] != after[tbl]:
+                print(
+                    f"\n❌ Row count changed for {tbl}: {before[tbl]} -> {after[tbl]}",
+                    file=sys.stderr,
+                )
+                ok = False
+
+        if ok:
+            print("\n✅ Migration applied cleanly. Row counts preserved.")
+            return 0
+        return 1
+    finally:
+        await db.close()
+        try:
+            copy_path.unlink()
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    default = Path.home() / ".config" / "omicsclaw" / "memory.db"
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=default,
+        help=f"Path to source memory.db (default: {default})",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args.db_path))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/memory/test_glossary_namespace.py
+++ b/tests/memory/test_glossary_namespace.py
@@ -1,0 +1,191 @@
+"""Tests for namespace-aware GlossaryService (PR #3c Task 3c.1).
+
+The existing public API stays backward-compatible: ``add_glossary_keyword``
+without ``namespace`` still writes to ``__shared__`` so legacy callers
+(server.py, api/browse.py) keep working unchanged. New callers can pass
+an explicit namespace to scope a keyword to one user/surface, and use
+``add_glossary_shared`` for the explicit shared variant.
+
+``find_glossary_in_content`` gains an optional ``namespace`` filter so
+the search reindexer can scope content scans to (current, ``__shared__``).
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.glossary import GlossaryService
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    eng = MemoryEngine(db, search)
+    glossary = GlossaryService(db, search)
+    yield eng, glossary, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# add_glossary_keyword — namespace parameter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_keyword_default_namespace_is_shared(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword("alpha", ref.node_uuid)
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("alpha", "__shared__")]
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_keyword_with_explicit_namespace(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="tg/userA")
+
+    await glossary.add_glossary_keyword(
+        "user-A-only", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("user-A-only", "tg/userA")]
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_shared_helper(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_shared("globally-known", ref.node_uuid)
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("globally-known", "__shared__")]
+
+
+@pytest.mark.asyncio
+async def test_same_keyword_can_exist_in_multiple_namespaces(env):
+    """Composite UNIQUE on (namespace, keyword, node_uuid) means the same
+    (keyword, node_uuid) can co-exist across namespaces."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword(
+        "shared-token", ref.node_uuid, namespace="__shared__"
+    )
+    await glossary.add_glossary_keyword(
+        "shared-token", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = sorted(
+        await _all_keywords_with_namespace(db, ref.node_uuid)
+    )
+    assert keywords == [
+        ("shared-token", "__shared__"),
+        ("shared-token", "tg/userA"),
+    ]
+
+
+# ----------------------------------------------------------------------
+# remove_glossary_keyword — namespace-scoped
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_glossary_keyword_namespace_scoped(env):
+    """Removing in one namespace must not delete the same keyword in others."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userB"
+    )
+
+    await glossary.remove_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = sorted(
+        await _all_keywords_with_namespace(db, ref.node_uuid)
+    )
+    assert keywords == [("ambiguous", "tg/userB")]
+
+
+# ----------------------------------------------------------------------
+# find_glossary_in_content — namespace filter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_glossary_in_content_filters_to_namespace_plus_shared(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+    await glossary.add_glossary_keyword(
+        "userA-tag", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "userB-tag", ref.node_uuid, namespace="tg/userB"
+    )
+    await glossary.add_glossary_keyword(
+        "global-tag", ref.node_uuid, namespace="__shared__"
+    )
+
+    matches = await glossary.find_glossary_in_content(
+        "userA-tag userB-tag global-tag",
+        namespace="tg/userA",
+    )
+
+    assert "userA-tag" in matches
+    assert "global-tag" in matches
+    assert "userB-tag" not in matches
+
+
+@pytest.mark.asyncio
+async def test_find_glossary_in_content_no_namespace_returns_all(env):
+    """Backward-compatible call (namespace=None) sees every keyword."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+    await glossary.add_glossary_keyword(
+        "userA-tag", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "global-tag", ref.node_uuid, namespace="__shared__"
+    )
+
+    matches = await glossary.find_glossary_in_content(
+        "userA-tag global-tag"
+    )
+
+    assert "userA-tag" in matches
+    assert "global-tag" in matches
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+async def _all_keywords_with_namespace(db, node_uuid):
+    import sqlalchemy as sa
+
+    from omicsclaw.memory.models import GlossaryKeyword
+
+    async with db.session() as s:
+        result = await s.execute(
+            sa.select(GlossaryKeyword.keyword, GlossaryKeyword.namespace).where(
+                GlossaryKeyword.node_uuid == node_uuid
+            )
+        )
+        return [(row[0], row[1]) for row in result.all()]

--- a/tests/memory/test_init_db_runs_migrations.py
+++ b/tests/memory/test_init_db_runs_migrations.py
@@ -1,0 +1,45 @@
+"""Tests that DatabaseManager.init_db() invokes the migrations runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        # Capture version count after first init
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            count_after_first = result.scalar_one()
+
+        # Second init must not raise and must not re-apply anything
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            assert result.scalar_one() == count_after_first
+    finally:
+        await db.close()

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -331,6 +331,22 @@ async def test_upsert_versioned_chain_can_have_3_links(engine):
 
 
 @pytest.mark.asyncio
+async def test_upsert_refuses_to_silently_rebuild_orphan_path(engine):
+    """If the active memory has been deactivated leaving a deprecated tail
+    behind, upsert (overwrite) must raise rather than silently fabricate
+    a new active memory — that would break the chain's audit lineage."""
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True  # simulated corruption: active row lost
+
+    with pytest.raises(RuntimeError, match="no active memory"):
+        await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+
+@pytest.mark.asyncio
 async def test_upsert_versioned_returns_namespace_isolated(engine):
     eng, db = engine
 

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -233,3 +233,111 @@ async def test_upsert_accepts_memory_uri_object(engine):
         namespace="tg/userA",
     )
     assert ref.uri == "core://agent"
+
+
+# ----------------------------------------------------------------------
+# upsert_versioned (deprecation chain mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_first_write_no_chain(engine):
+    eng, db = engine
+
+    ref = await eng.upsert_versioned(
+        "core://agent", "v1", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, VersionedMemoryRef)
+    assert ref.old_memory_id is None
+    assert ref.new_memory_id > 0
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.new_memory_id)
+        assert memory.deprecated is False
+        assert memory.migrated_to is None
+        assert memory.content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_creates_chain_on_second_write(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    assert second.old_memory_id == first.new_memory_id
+    assert second.new_memory_id != first.new_memory_id
+    assert second.node_uuid == first.node_uuid
+
+    async with db.session() as s:
+        old = await s.get(Memory, first.new_memory_id)
+        new = await s.get(Memory, second.new_memory_id)
+
+        assert old.deprecated is True
+        assert old.migrated_to == second.new_memory_id
+
+        assert new.deprecated is False
+        assert new.migrated_to is None
+        assert new.content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_old_search_doc_replaced(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalars().all()
+        # Exactly one search_documents row at (namespace, domain, path) — the
+        # composite PK guarantees that, but we also assert it points at the
+        # new memory_id, not the deprecated one.
+        assert len(rows) == 1
+        assert rows[0].memory_id == second.new_memory_id
+        assert rows[0].content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_chain_can_have_3_links(engine):
+    eng, db = engine
+
+    r1 = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    r2 = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+    r3 = await eng.upsert_versioned("core://agent", "v3", namespace="tg/userA")
+
+    async with db.session() as s:
+        m1 = await s.get(Memory, r1.new_memory_id)
+        m2 = await s.get(Memory, r2.new_memory_id)
+        m3 = await s.get(Memory, r3.new_memory_id)
+
+        assert m1.deprecated is True and m1.migrated_to == r2.new_memory_id
+        assert m2.deprecated is True and m2.migrated_to == r3.new_memory_id
+        assert m3.deprecated is False and m3.migrated_to is None
+
+        # All three memories share the same node_uuid (the conceptual entity).
+        assert m1.node_uuid == m2.node_uuid == m3.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_returns_namespace_isolated(engine):
+    eng, db = engine
+
+    a = await eng.upsert_versioned("core://agent", "for A", namespace="tg/userA")
+    b = await eng.upsert_versioned("core://agent", "for B", namespace="tg/userB")
+
+    # Different namespaces → independent chains, independent nodes.
+    assert a.node_uuid != b.node_uuid
+    assert a.old_memory_id is None
+    assert b.old_memory_id is None  # B's first write also has no chain

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -341,3 +341,146 @@ async def test_upsert_versioned_returns_namespace_isolated(engine):
     assert a.node_uuid != b.node_uuid
     assert a.old_memory_id is None
     assert b.old_memory_id is None  # B's first write also has no chain
+
+
+# ----------------------------------------------------------------------
+# patch_edge_metadata
+# ----------------------------------------------------------------------
+
+
+async def _get_edge_for(eng, uri: str, namespace: str):
+    """Helper: load the edge backing (namespace, uri)."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    parsed = MemoryURI.parse(uri)
+    async with eng._db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one()
+        return await s.get(Edge, path_row.edge_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_priority(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=9
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 9
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_disclosure(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", disclosure="hidden from search"
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.disclosure == "hidden from search"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_both(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent",
+        namespace="tg/userA",
+        priority=3,
+        disclosure="why this exists",
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 3
+    assert edge.disclosure == "why this exists"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_does_not_touch_memory(engine):
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        before = (await s.get(Memory, ref.memory_id)).content
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=1
+    )
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        # Same content; same row id (no new memory created).
+        assert memory.content == before
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == ref.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_refreshes_search_doc(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=7
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.priority == 7
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_namespace_isolated(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "A", namespace="tg/userA", priority=1)
+    await eng.upsert("core://agent", "B", namespace="tg/userB", priority=1)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=99
+    )
+
+    edge_a = await _get_edge_for(eng, "core://agent", "tg/userA")
+    edge_b = await _get_edge_for(eng, "core://agent", "tg/userB")
+    assert edge_a.priority == 99
+    assert edge_b.priority == 1  # B unchanged
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_raises_if_path_missing(engine):
+    eng, _ = engine
+    with pytest.raises(LookupError, match="not found"):
+        await eng.patch_edge_metadata(
+            "core://nonexistent", namespace="tg/userA", priority=1
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_requires_at_least_one_field(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "x", namespace="tg/userA")
+    with pytest.raises(ValueError, match="at least one"):
+        await eng.patch_edge_metadata("core://agent", namespace="tg/userA")

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -1,0 +1,235 @@
+"""Tests for MemoryEngine — namespace-aware hot-path writes.
+
+PR #3a covers the three write verbs (upsert, upsert_versioned,
+patch_edge_metadata). Read verbs are reserved for PR #3b.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine, MemoryRef, VersionedMemoryRef
+from omicsclaw.memory.models import Edge, Memory, Path, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# upsert (overwrite mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_path_and_memory(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "you are a helpful agent", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, MemoryRef)
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+    assert ref.memory_id > 0
+    assert ref.node_uuid
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert path_row.edge_id is not None
+
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.child_uuid == ref.node_uuid
+        assert edge.name == "agent"
+
+        memory = await s.get(Memory, ref.memory_id)
+        assert memory.content == "you are a helpful agent"
+        assert memory.deprecated is False
+        assert memory.node_uuid == ref.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_idempotent_same_namespace_updates_content(engine):
+    eng, db = engine
+
+    first = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+    # Same memory row — overwrite mode does NOT create a new Memory.
+    assert first.memory_id == second.memory_id
+    assert first.node_uuid == second.node_uuid
+
+    async with db.session() as s:
+        memory = await s.get(Memory, second.memory_id)
+        assert memory.content == "v2"
+
+        # Exactly one Memory row total for this node.
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == second.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_different_namespace_creates_separate_path(engine):
+    eng, db = engine
+
+    a = await eng.upsert("core://agent", "voice for A", namespace="tg/userA")
+    b = await eng.upsert("core://agent", "voice for B", namespace="tg/userB")
+
+    # Independent paths, independent nodes/memories.
+    assert a.namespace != b.namespace
+    assert a.node_uuid != b.node_uuid
+    assert a.memory_id != b.memory_id
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "core", Path.path == "agent"
+                )
+            )
+        ).scalars().all()
+        namespaces = sorted(r.namespace for r in rows)
+        assert namespaces == ["tg/userA", "tg/userB"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_refreshes_search_document(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "search me", namespace="tg/userA", priority=5
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.content == "search me"
+        assert sd.memory_id == ref.memory_id
+        assert sd.node_uuid == ref.node_uuid
+        assert sd.uri == "core://agent"
+        assert sd.priority == 5
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_requires_parent(engine):
+    eng, _ = engine
+
+    with pytest.raises(ValueError, match="Parent path"):
+        await eng.upsert(
+            "analysis://sc-de/run_42",
+            "results",
+            namespace="tg/userA",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_works_when_parent_exists(engine):
+    eng, db = engine
+
+    parent = await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    child = await eng.upsert(
+        "analysis://sc-de/run_42", "results", namespace="tg/userA"
+    )
+
+    assert child.node_uuid != parent.node_uuid
+
+    async with db.session() as s:
+        edge = (
+            await s.execute(
+                sa.select(Edge).where(Edge.child_uuid == child.node_uuid)
+            )
+        ).scalar_one()
+        assert edge.parent_uuid == parent.node_uuid
+        assert edge.name == "run_42"
+
+
+@pytest.mark.asyncio
+async def test_upsert_priority_and_disclosure_on_create(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent",
+        "content",
+        namespace="tg/userA",
+        priority=7,
+        disclosure="user-set",
+    )
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 7
+        assert edge.disclosure == "user-set"
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_clobber_priority_when_omitted_on_update(engine):
+    """Re-calling upsert without priority should preserve the edge's priority."""
+    eng, db = engine
+
+    await eng.upsert("core://agent", "v1", namespace="tg/userA", priority=42)
+    await eng.upsert("core://agent", "v2", namespace="tg/userA")  # priority omitted
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 42
+
+
+@pytest.mark.asyncio
+async def test_upsert_accepts_memory_uri_object(engine):
+    """upsert should accept either a string or a MemoryURI."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    eng, db = engine
+    ref = await eng.upsert(
+        MemoryURI(domain="core", path="agent"),
+        "content",
+        namespace="tg/userA",
+    )
+    assert ref.uri == "core://agent"

--- a/tests/memory/test_memory_engine_integration.py
+++ b/tests/memory/test_memory_engine_integration.py
@@ -1,0 +1,193 @@
+"""End-to-end + cross-namespace integration tests for MemoryEngine.
+
+Exercise the full upsert → recall → search → list_children → get_subtree
+loop under realistic multi-tenant scenarios. These tests are the
+checkpoint guardrails referenced in the plan §3b — if they regress,
+namespace isolation has cracked somewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# Plan checkpoint scenarios
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_across_three_namespaces(engine):
+    """Upsert and recall round-trip independently for three users."""
+    eng, _ = engine
+    namespaces = ("tg/userA", "tg/userB", "app/desktop_user")
+    for ns in namespaces:
+        await eng.upsert(
+            "preference://style",
+            f"{ns}'s style",
+            namespace=ns,
+        )
+
+    for ns in namespaces:
+        record = await eng.recall("preference://style", namespace=ns)
+        assert record is not None
+        assert record.content == f"{ns}'s style"
+        assert record.loaded_namespace == ns
+
+
+@pytest.mark.asyncio
+async def test_cross_namespace_isolation_without_fallback(engine):
+    """A write in ns/A is invisible from ns/B when fallback is disabled."""
+    eng, _ = engine
+    await eng.upsert(
+        "dataset://pbmc.h5ad", "user A's secret", namespace="tg/userA"
+    )
+
+    # Each surface gets a clean view without fallback.
+    for other_ns in ("tg/userB", "app/desktop_user"):
+        record = await eng.recall(
+            "dataset://pbmc.h5ad",
+            namespace=other_ns,
+            fallback_to_shared=False,
+        )
+        assert record is None
+
+        hits = await eng.search("secret", namespace=other_ns)
+        assert all(h["uri"] != "dataset://pbmc.h5ad" for h in hits)
+
+        children = await eng.list_children(
+            "dataset://", namespace=other_ns
+        )
+        assert all(
+            c.uri != "dataset://pbmc.h5ad" for c in children
+        )
+
+
+@pytest.mark.asyncio
+async def test_shared_content_visible_via_recall_fallback(engine):
+    """Globally-shared content (core://agent) is visible from any namespace."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent",
+        "you are a helpful agent",
+        namespace="__shared__",
+    )
+
+    for ns in ("tg/userA", "tg/userB", "app/desktop_user"):
+        record = await eng.recall("core://agent", namespace=ns)
+        assert record is not None
+        assert record.content == "you are a helpful agent"
+        assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_user_override_shadows_shared_in_recall(engine):
+    """When a per-user write exists, it shadows the shared one for that user."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared default", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent", "user A override", namespace="tg/userA"
+    )
+
+    a = await eng.recall("core://agent", namespace="tg/userA")
+    b = await eng.recall("core://agent", namespace="tg/userB")
+
+    assert a.content == "user A override"
+    assert a.loaded_namespace == "tg/userA"
+    assert b.content == "shared default"
+    assert b.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_search_combines_namespace_and_shared(engine):
+    """Search returns both per-namespace and shared hits."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "helpful agent (shared)", namespace="__shared__"
+    )
+    await eng.upsert(
+        "preference://style",
+        "user A wants helpful style",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("helpful", namespace="tg/userA", limit=10)
+    uris = {h["uri"] for h in hits}
+
+    assert "core://agent" in uris
+    assert "preference://style" in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_does_not_combine_with_shared(engine):
+    """Strict listing — shared subtree is invisible to per-user list_children."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared parent", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+
+    user_children = await eng.list_children(
+        "core://agent", namespace="tg/userA"
+    )
+    shared_children = await eng.list_children(
+        "core://agent", namespace="__shared__"
+    )
+
+    assert user_children == []
+    assert {c.uri for c in shared_children} == {"core://agent/voice"}
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_strict_to_namespace(engine):
+    """Subtree listing is strict — does not blend in shared content."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/style", "user A style", namespace="tg/userA"
+    )
+
+    subtree = await eng.get_subtree("core://agent", namespace="tg/userA")
+    uris = sorted(r.uri for r in subtree)
+
+    # Only the user's own writes — no shared parent, no shared voice.
+    assert uris == ["core://agent/style"]
+
+
+@pytest.mark.asyncio
+async def test_versioned_chain_recall_returns_active_head(engine):
+    """After three versioned writes, recall returns the active head only."""
+    eng, _ = engine
+    await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+    r3 = await eng.upsert_versioned(
+        "core://agent", "v3", namespace="tg/userA"
+    )
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+    assert record is not None
+    assert record.content == "v3"
+    assert record.memory_id == r3.new_memory_id

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -263,3 +263,125 @@ async def test_search_orders_namespace_before_shared(engine):
     a_idx = uris.index("preference://style")
     shared_idx = uris.index("core://agent")
     assert a_idx < shared_idx
+
+
+# ----------------------------------------------------------------------
+# list_children — strict-namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_direct_children_in_namespace(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_42", "child A", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_99", "child B", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+
+    uris = sorted(c.uri for c in children)
+    assert uris == ["analysis://sc-de/run_42", "analysis://sc-de/run_99"]
+    assert all(c.namespace == "tg/userA" for c in children)
+
+
+@pytest.mark.asyncio
+async def test_list_children_does_not_include_grandchildren(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_42", "child", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_42/sub", "grandchild", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+    uris = [c.uri for c in children]
+
+    assert "analysis://sc-de/run_42" in uris
+    assert "analysis://sc-de/run_42/sub" not in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_strict_excludes_shared_children(engine):
+    """When the parent is shared and a child also lives in __shared__, that
+    shared child must NOT appear in a per-user listing — strict semantics."""
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared parent", namespace="__shared__")
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/style",
+        "user A's style override",
+        namespace="tg/userA",
+    )
+
+    children = await eng.list_children("core://agent", namespace="tg/userA")
+    uris = sorted(c.uri for c in children)
+
+    assert uris == ["core://agent/style"]
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_empty_when_no_children(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent only", namespace="tg/userA")
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+    assert children == []
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_empty_when_parent_missing(engine):
+    eng, _ = engine
+    children = await eng.list_children(
+        "analysis://nonexistent", namespace="tg/userA"
+    )
+    assert children == []
+
+
+@pytest.mark.asyncio
+async def test_list_children_root_lists_top_level(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "top1", namespace="tg/userA")
+    await eng.upsert("analysis://sc-velocity", "top2", namespace="tg/userA")
+
+    from omicsclaw.memory.uri import MemoryURI
+
+    children = await eng.list_children(
+        MemoryURI(domain="analysis", path=""), namespace="tg/userA"
+    )
+    uris = sorted(c.uri for c in children)
+
+    assert "analysis://sc-de" in uris
+    assert "analysis://sc-velocity" in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_active_memory_ref(engine):
+    eng, db = engine
+    parent = await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    child = await eng.upsert(
+        "analysis://sc-de/run_42", "child", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+
+    assert len(children) == 1
+    ref = children[0]
+    assert isinstance(ref, MemoryRef)
+    assert ref.memory_id == child.memory_id
+    assert ref.node_uuid == child.node_uuid

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -385,3 +385,131 @@ async def test_list_children_returns_active_memory_ref(engine):
     assert isinstance(ref, MemoryRef)
     assert ref.memory_id == child.memory_id
     assert ref.node_uuid == child.node_uuid
+
+
+# ----------------------------------------------------------------------
+# get_subtree — flat listing under a prefix
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_returns_root_and_descendants(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_1", "child1", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_1/sub", "grand", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_2", "child2", namespace="tg/userA"
+    )
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert uris == [
+        "analysis://sc-de",
+        "analysis://sc-de/run_1",
+        "analysis://sc-de/run_1/sub",
+        "analysis://sc-de/run_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_excludes_other_namespaces(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "user A's", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_1", "user A's child", namespace="tg/userA"
+    )
+    await eng.upsert("analysis://sc-de", "user B's", namespace="tg/userB")
+    await eng.upsert(
+        "analysis://sc-de/run_99", "user B's child", namespace="tg/userB"
+    )
+    await eng.upsert("analysis://sc-de", "shared", namespace="__shared__")
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = sorted(r.uri for r in subtree)
+    namespaces = {r.namespace for r in subtree}
+
+    assert uris == ["analysis://sc-de", "analysis://sc-de/run_1"]
+    assert namespaces == {"tg/userA"}
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_excludes_paths_outside_prefix(engine):
+    """Sibling paths that share a prefix substring (not a directory prefix)
+    must not be included — e.g. ``sc-de-bonus`` is not under ``sc-de``."""
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "x", namespace="tg/userA")
+    await eng.upsert("analysis://sc-de/run_1", "y", namespace="tg/userA")
+    await eng.upsert("analysis://sc-de-bonus", "z", namespace="tg/userA")
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert "analysis://sc-de-bonus" not in uris
+    assert "analysis://sc-de/run_1" in uris
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_respects_limit(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    for i in range(10):
+        await eng.upsert(
+            f"analysis://sc-de/run_{i}", f"r{i}", namespace="tg/userA"
+        )
+
+    subtree = await eng.get_subtree(
+        "analysis://sc-de", namespace="tg/userA", limit=3
+    )
+    assert len(subtree) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_returns_empty_when_no_match(engine):
+    eng, _ = engine
+    subtree = await eng.get_subtree(
+        "analysis://nope", namespace="tg/userA"
+    )
+    assert subtree == []
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_root_uri_lists_namespace_in_domain(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "x", namespace="tg/userA")
+    await eng.upsert("analysis://sc-velocity", "y", namespace="tg/userA")
+    await eng.upsert("dataset://pbmc.h5ad", "z", namespace="tg/userA")
+
+    from omicsclaw.memory.uri import MemoryURI
+
+    subtree = await eng.get_subtree(
+        MemoryURI(domain="analysis", path=""), namespace="tg/userA"
+    )
+    uris = sorted(r.uri for r in subtree)
+
+    assert uris == ["analysis://sc-de", "analysis://sc-velocity"]
+    assert all(r.uri.startswith("analysis://") for r in subtree)
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_skips_paths_with_no_active_memory(engine):
+    eng, db = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    ref = await eng.upsert(
+        "analysis://sc-de/run_1", "child", namespace="tg/userA"
+    )
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert "analysis://sc-de" in uris
+    assert "analysis://sc-de/run_1" not in uris

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -150,3 +150,116 @@ async def test_recall_accepts_memory_uri_object(engine):
     )
     assert record is not None
     assert record.uri == "core://agent"
+
+
+# ----------------------------------------------------------------------
+# search — namespace-combined FTS
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_finds_in_namespace(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "analysis://sc-de", "perform differential expression", namespace="tg/userA"
+    )
+
+    hits = await eng.search("differential", namespace="tg/userA")
+
+    assert any(hit["uri"] == "analysis://sc-de" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_finds_shared_content(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent",
+        "you are a helpful spatial omics agent",
+        namespace="__shared__",
+    )
+
+    hits = await eng.search("spatial omics", namespace="tg/userA")
+
+    assert any(hit["uri"] == "core://agent" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_leak_across_namespaces(engine):
+    """Critical: writes in ns/A must not appear in searches from ns/B."""
+    eng, _ = engine
+    await eng.upsert(
+        "dataset://pbmc.h5ad",
+        "user A's secret dataset",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("secret", namespace="tg/userB")
+
+    assert all(hit["uri"] != "dataset://pbmc.h5ad" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_respects_domain_filter(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "analysis://sc-de", "differential expression", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "dataset://pbmc.h5ad", "differential dataset", namespace="tg/userA"
+    )
+
+    hits = await eng.search(
+        "differential", namespace="tg/userA", domain="analysis"
+    )
+
+    assert all(hit["domain"] == "analysis" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_respects_limit(engine):
+    eng, _ = engine
+    for i in range(5):
+        await eng.upsert(
+            f"analysis://run_{i}",
+            f"differential expression run {i}",
+            namespace="tg/userA",
+        )
+
+    hits = await eng.search("differential", namespace="tg/userA", limit=2)
+
+    assert len(hits) <= 2
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_for_no_match(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "alpha", namespace="tg/userA")
+
+    hits = await eng.search("zeta-not-present", namespace="tg/userA")
+
+    assert hits == []
+
+
+@pytest.mark.asyncio
+async def test_search_orders_namespace_before_shared(engine):
+    """Per-namespace hits should outrank __shared__ hits with comparable score.
+
+    Both rows match the same query token; the namespace's row should appear
+    in the result list before the shared one.
+    """
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "you are a helpful agent", namespace="__shared__"
+    )
+    await eng.upsert(
+        "preference://style",
+        "user A prefers helpful agents",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("helpful", namespace="tg/userA", limit=10)
+
+    uris = [h["uri"] for h in hits]
+    a_idx = uris.index("preference://style")
+    shared_idx = uris.index("core://agent")
+    assert a_idx < shared_idx

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -1,0 +1,152 @@
+"""Tests for MemoryEngine read verbs (PR #3b).
+
+Covers ``recall`` (with shared fallback), ``search`` (namespace-combined),
+``list_children`` (strict-namespace), ``get_subtree`` (flat listing), and
+the cross-namespace integration scenarios from the plan checkpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine, MemoryRecord, MemoryRef
+from omicsclaw.memory.models import Memory
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# recall — happy path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_record_when_present(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "you are an agent", namespace="tg/userA")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record is not None
+    assert isinstance(record, MemoryRecord)
+    assert record.content == "you are an agent"
+    assert record.namespace == "tg/userA"
+    assert record.loaded_namespace == "tg/userA"
+    assert record.uri == "core://agent"
+    assert record.memory_id > 0
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_none_when_missing(engine):
+    eng, _ = engine
+    record = await eng.recall("core://nope", namespace="tg/userA")
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_none_when_only_deprecated_versions_exist(engine):
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+    assert record is None
+
+
+# ----------------------------------------------------------------------
+# recall — shared fallback
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_falls_back_to_shared_when_default(engine):
+    eng, _ = engine
+    # Seed the same URI in __shared__ only.
+    await eng.upsert("core://agent", "shared content", namespace="__shared__")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record is not None
+    assert record.content == "shared content"
+    # Fields preserve the *requested* namespace; loaded_namespace tells the
+    # caller where the row actually came from.
+    assert record.namespace == "tg/userA"
+    assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_recall_strict_does_not_fall_back(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared content", namespace="__shared__")
+
+    record = await eng.recall(
+        "core://agent", namespace="tg/userA", fallback_to_shared=False
+    )
+
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_prefers_namespace_over_shared(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared", namespace="__shared__")
+    await eng.upsert("core://agent", "user A own", namespace="tg/userA")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record.content == "user A own"
+    assert record.loaded_namespace == "tg/userA"
+
+
+@pytest.mark.asyncio
+async def test_recall_namespace_isolation(engine):
+    """Without fallback, a write in ns/A is invisible from ns/B."""
+    eng, _ = engine
+    await eng.upsert("dataset://pbmc.h5ad", "user A's dataset", namespace="tg/userA")
+
+    record = await eng.recall(
+        "dataset://pbmc.h5ad",
+        namespace="tg/userB",
+        fallback_to_shared=False,
+    )
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_shared_recall_from_shared_returns_directly(engine):
+    """Reading from __shared__ shouldn't try to fall back to itself twice."""
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared", namespace="__shared__")
+
+    record = await eng.recall("core://agent", namespace="__shared__")
+
+    assert record is not None
+    assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_recall_accepts_memory_uri_object(engine):
+    from omicsclaw.memory.uri import MemoryURI
+
+    eng, _ = engine
+    await eng.upsert("core://agent", "x", namespace="tg/userA")
+
+    record = await eng.recall(
+        MemoryURI(domain="core", path="agent"), namespace="tg/userA"
+    )
+    assert record is not None
+    assert record.uri == "core://agent"

--- a/tests/memory/test_memory_uri.py
+++ b/tests/memory/test_memory_uri.py
@@ -1,0 +1,113 @@
+"""Tests for MemoryURI value object.
+
+See docs/CONTEXT.md → "Memory URI" for the contract this exercises.
+"""
+
+import pytest
+
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_parse_basic_uri():
+    uri = MemoryURI.parse("core://agent")
+    assert uri.domain == "core"
+    assert uri.path == "agent"
+
+
+def test_str_canonical_form():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    assert str(uri) == "dataset://pbmc.h5ad"
+
+
+def test_is_root_property():
+    assert MemoryURI(domain="core", path="").is_root is True
+    assert MemoryURI(domain="core", path="agent").is_root is False
+
+
+def test_child_appends_name_with_slash():
+    parent = MemoryURI(domain="analysis", path="sc-de")
+    assert parent.child("run_42") == MemoryURI(domain="analysis", path="sc-de/run_42")
+
+
+def test_child_of_root_has_no_leading_slash():
+    root = MemoryURI(domain="core", path="")
+    assert root.child("agent") == MemoryURI(domain="core", path="agent")
+
+
+def test_parent_strips_last_segment():
+    uri = MemoryURI(domain="analysis", path="sc-de/run_42")
+    assert uri.parent() == MemoryURI(domain="analysis", path="sc-de")
+
+
+def test_parent_of_single_segment_returns_root():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    parent = uri.parent()
+    assert parent == MemoryURI(domain="dataset", path="")
+    assert parent.is_root
+
+
+def test_parent_of_root_returns_none():
+    root = MemoryURI(domain="core", path="")
+    assert root.parent() is None
+
+
+def test_parse_without_scheme_defaults_to_core():
+    uri = MemoryURI.parse("agent")
+    assert uri == MemoryURI(domain="core", path="agent")
+
+
+def test_parse_root_uri_with_empty_path():
+    uri = MemoryURI.parse("core://")
+    assert uri == MemoryURI(domain="core", path="")
+    assert uri.is_root
+
+
+def test_root_classmethod_creates_root_uri():
+    assert MemoryURI.root("dataset") == MemoryURI(domain="dataset", path="")
+    assert MemoryURI.root() == MemoryURI(domain="core", path="")
+    assert MemoryURI.root("dataset").is_root
+
+
+def test_parse_str_roundtrip():
+    for raw in (
+        "core://agent",
+        "dataset://pbmc.h5ad",
+        "analysis://sc-de/run_42",
+        "core://",
+    ):
+        assert str(MemoryURI.parse(raw)) == raw, f"roundtrip failed for {raw!r}"
+
+
+def test_uri_is_hashable_and_equal_by_value():
+    a = MemoryURI(domain="core", path="agent")
+    b = MemoryURI(domain="core", path="agent")
+    c = MemoryURI(domain="core", path="other")
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+    assert len({a, b, c}) == 2  # set deduplicates a/b
+
+
+def test_empty_domain_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="", path="agent")
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI.parse("://agent")
+
+
+def test_domain_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="core://nope", path="agent")
+
+
+def test_path_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI(domain="core", path="x://y")
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI.parse("core://x://y")
+
+
+@pytest.mark.parametrize("bad_char", ["\n", "\t", "\x00", "\r"])
+def test_domain_with_control_chars_rejected(bad_char):
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain=f"core{bad_char}", path="agent")

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -14,9 +14,56 @@ def _load_001():
 
 
 async def _build_legacy_schema(db: DatabaseManager) -> None:
-    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    """Create the pre-001 schema explicitly (no namespace column).
+
+    The current ORM models already include ``namespace``, so we can't simply
+    call ``Base.metadata.create_all`` and expect a legacy result. Instead:
+
+    1. ``create_all`` to set up unrelated tables (nodes, memories, edges).
+    2. Drop the three namespace-bearing tables and recreate them with the
+       pre-001 schema using raw SQL so the migration has real legacy rows
+       to act on.
+    """
     async with db.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    async with db.session() as s:
+        await s.execute(sa.text("DROP TABLE IF EXISTS paths"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS glossary_keywords"))
+        await s.execute(sa.text("""
+            CREATE TABLE paths (
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents (
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                created_at DATETIME,
+                UNIQUE (keyword, node_uuid)
+            )
+        """))
 
 
 async def _pk_columns_in_order(s, table: str) -> list[str]:

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -1,0 +1,421 @@
+"""Tests for migration 001_namespace — schema rebuild + disclosure backfill."""
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.models import Base
+
+
+def _load_001():
+    return importlib.import_module("omicsclaw.memory.migrations.001_namespace")
+
+
+async def _build_legacy_schema(db: DatabaseManager) -> None:
+    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    async with db.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def _pk_columns_in_order(s, table: str) -> list[str]:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    rows = [(row[1], row[5]) for row in result.all() if row[5] > 0]
+    rows.sort(key=lambda x: x[1])
+    return [name for name, _ in rows]
+
+
+@pytest.mark.asyncio
+async def test_001_adds_namespace_column_to_paths(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_paths_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "paths") == ["namespace", "domain", "path"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_search_documents_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "search_documents") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+            result = await s.execute(sa.text("PRAGMA table_info(search_documents)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+        await mig.apply(db)  # second invocation must not raise or duplicate work
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert cols.count("namespace") == 1
+            assert await _pk_columns_in_order(s, "paths") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_idempotent_does_not_reset_post_migration_namespaces(tmp_path):
+    """Re-running 001 must preserve any namespace edits already applied."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a single legacy path
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('n1')"))
+            await s.execute(
+                sa.text(
+                    "INSERT INTO edges (id, parent_uuid, child_uuid, name) "
+                    "VALUES (1, 'n1', 'n1', 'test')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO paths (domain, path, edge_id) "
+                    "VALUES ('core', 'foo', 1)"
+                )
+            )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Caller updates namespace after migration
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "UPDATE paths SET namespace='tg/userA' "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+
+        # Re-running the migration must NOT reset that namespace
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+async def _build_legacy_schema_with_fts(db: DatabaseManager) -> None:
+    """Legacy schema + the legacy FTS5 virtual table (no namespace col)."""
+    await _build_legacy_schema(db)
+    async with db.session() as s:
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                domain, path, node_uuid, uri, content, disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+
+
+@pytest.mark.asyncio
+async def test_001_rebuilds_fts5_with_namespace_column(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            # If namespace is a column on the FTS table, this query parses.
+            await s.execute(sa.text("SELECT namespace FROM search_documents_fts LIMIT 0"))
+    finally:
+        await db.close()
+
+
+async def _seed_path_with_disclosure(
+    db: DatabaseManager,
+    *,
+    domain: str,
+    path: str,
+    disclosure: str,
+) -> None:
+    """Seed nodes/edges/paths/memories/search_documents for one path row."""
+    async with db.session() as s:
+        await s.execute(sa.text("INSERT OR IGNORE INTO nodes (uuid) VALUES ('n1')"))
+        await s.execute(
+            sa.text(
+                "INSERT OR IGNORE INTO edges (id, parent_uuid, child_uuid, name) "
+                "VALUES (1, 'n1', 'n1', 'seed')"
+            )
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO paths (domain, path, edge_id) "
+                "VALUES (:d, :p, 1)"
+            ),
+            {"d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO memories (node_uuid, content) "
+                "VALUES ('n1', 'test-content')"
+            )
+        )
+        result = await s.execute(sa.text("SELECT last_insert_rowid()"))
+        memory_id = result.scalar_one()
+        await s.execute(
+            sa.text(
+                "INSERT INTO search_documents "
+                "(domain, path, node_uuid, memory_id, uri, content, "
+                "disclosure, search_terms, priority) "
+                "VALUES (:d, :p, 'n1', :mid, :uri, 'test-content', :disc, :st, 0)"
+            ),
+            {
+                "d": domain,
+                "p": path,
+                "mid": memory_id,
+                "uri": f"{domain}://{path}",
+                "disc": disclosure,
+                "st": path,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_memory_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="sc-de/run42",
+            disclosure="Memory from session app:userA:abcdef",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM search_documents "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_session_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="session",
+            path="abc123",
+            disclosure="Session for user userA on tg",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='session' AND path='abc123'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_falls_back_to_shared_when_disclosure_unparseable(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="orphan",
+            disclosure="some garbage that doesn't match",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='orphan'"
+                )
+            )
+            assert result.scalar_one() == "__shared__"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_preserves_row_counts(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        for i in range(5):
+            await _seed_path_with_disclosure(
+                db,
+                domain="analysis",
+                path=f"run_{i}",
+                disclosure=f"Memory from session app:user{i}:s{i}",
+            )
+
+        async def counts(s):
+            return {
+                tbl: (
+                    await s.execute(sa.text(f"SELECT COUNT(*) FROM {tbl}"))
+                ).scalar_one()
+                for tbl in ("paths", "search_documents", "memories", "nodes", "edges")
+            }
+
+        async with db.session() as s:
+            before = await counts(s)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            after = await counts(s)
+
+        assert before == after
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_discovered_and_run_via_init_db(tmp_path):
+    """End-to-end: init_db on a fresh DB applies 001 via discovery."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            # paths has namespace column post-migration
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+
+            # 001 was recorded by the runner
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert "001_namespace" in {row[0] for row in result.all()}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_glossary_keywords_has_namespace_in_unique_constraint(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a node so glossary FK is valid
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('node-1')"))
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Same (keyword, node_uuid) but different namespace — both must succeed
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns1')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns2')"
+                )
+            )
+            result = await s.execute(
+                sa.text("SELECT COUNT(*) FROM glossary_keywords")
+            )
+            assert result.scalar_one() == 2
+
+        # Duplicate (namespace, keyword, node_uuid) — must fail
+        with pytest.raises(Exception):
+            async with db.session() as s:
+                await s.execute(
+                    sa.text(
+                        "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                        "VALUES ('foo', 'node-1', 'ns1')"
+                    )
+                )
+    finally:
+        await db.close()

--- a/tests/memory/test_migration_runner.py
+++ b/tests/memory/test_migration_runner.py
@@ -1,0 +1,151 @@
+"""Tests for the lightweight migrations framework runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.migrations.runner import run_pending
+
+
+@pytest.mark.asyncio
+async def test_run_pending_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await run_pending(db, migrations=[])
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_migration_and_records_version(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_calls: list[DatabaseManager] = []
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            apply_calls.append(d)
+
+    try:
+        versions = await run_pending(db, migrations=[Mig()])
+        assert versions == ["001_test"]
+        assert apply_calls == [db]
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001_test"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_skips_already_applied(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_count = 0
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            nonlocal apply_count
+            apply_count += 1
+
+    try:
+        v1 = await run_pending(db, migrations=[Mig()])
+        v2 = await run_pending(db, migrations=[Mig()])
+        assert v1 == ["001_test"]
+        assert v2 == []
+        assert apply_count == 1  # idempotent
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_in_version_sorted_order(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    order_seen: list[str] = []
+
+    def make_mig(v: str):
+        class M:
+            VERSION = v
+            DESCRIPTION = f"m{v}"
+
+            async def apply(self, d: DatabaseManager) -> None:
+                order_seen.append(v)
+        return M()
+
+    try:
+        # Caller passes in reversed order — runner must sort
+        versions = await run_pending(
+            db, migrations=[make_mig("003"), make_mig("001"), make_mig("002")]
+        )
+        assert versions == ["001", "002", "003"]
+        assert order_seen == ["001", "002", "003"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_migration_is_not_recorded(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+
+    class GoodMig:
+        VERSION = "001"
+        DESCRIPTION = "good"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            pass
+
+    class BadMig:
+        VERSION = "002"
+        DESCRIPTION = "bad"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            raise RuntimeError("boom")
+
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await run_pending(db, migrations=[GoodMig(), BadMig()])
+
+        # 001 succeeded → recorded; 002 raised → NOT recorded
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001"}
+    finally:
+        await db.close()
+
+
+def test_discover_migrations_imports_numbered_modules(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / "fake_mig_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "001_alpha.py").write_text(
+        "VERSION = '001_alpha'\nDESCRIPTION = 'a'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    (pkg_dir / "002_beta.py").write_text(
+        "VERSION = '002_beta'\nDESCRIPTION = 'b'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    # non-numbered modules in the package should be ignored
+    (pkg_dir / "helper.py").write_text("# not a migration\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    from omicsclaw.memory.migrations.runner import _discover_migrations
+    found = _discover_migrations("fake_mig_pkg")
+
+    versions = sorted(m.VERSION for m in found)
+    assert versions == ["001_alpha", "002_beta"]

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,0 +1,104 @@
+"""Tests for namespace_policy — see docs/CONTEXT.md namespace ownership table."""
+
+import pytest
+
+from omicsclaw.memory.namespace_policy import resolve_namespace, should_version
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_resolve_namespace_returns_shared_for_core_agent():
+    uri = MemoryURI.parse("core://agent")
+    assert resolve_namespace(uri, current="tg/A") == "__shared__"
+
+
+def test_resolve_namespace_returns_current_for_per_namespace_uri():
+    assert resolve_namespace(MemoryURI.parse("dataset://pbmc.h5ad"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("analysis://run_42"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("project://current"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_kh_prefix_is_shared():
+    # core://kh and any sub-path under it are shared
+    assert resolve_namespace(MemoryURI.parse("core://kh"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/qc_threshold"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/sc/marker"), current="X") == "__shared__"
+
+
+def test_resolve_namespace_false_prefix_does_not_match():
+    # 'kh' must not match 'khaki' (path-segment matching, not raw startswith)
+    assert resolve_namespace(MemoryURI.parse("core://khaki"), current="X") == "X"
+    assert resolve_namespace(MemoryURI.parse("core://agent_alt"), current="X") == "X"
+
+
+def test_resolve_namespace_my_user_is_per_namespace():
+    # core://my_user is per-user, not shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_my_user_default_is_shared():
+    # core://my_user_default is the fallback template, shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user_default"), current="tg/A") == "__shared__"
+
+
+def test_should_version_core_agent_true():
+    assert should_version(MemoryURI.parse("core://agent")) is True
+
+
+def test_should_version_false_for_non_versioned_domains():
+    assert should_version(MemoryURI.parse("dataset://pbmc.h5ad")) is False
+    assert should_version(MemoryURI.parse("analysis://sc-de/run_42")) is False
+    assert should_version(MemoryURI.parse("session://abc123")) is False
+    assert should_version(MemoryURI.parse("insight://cluster/3")) is False
+    assert should_version(MemoryURI.parse("project://current")) is False
+
+
+def test_should_version_core_my_user_true():
+    # core://my_user is per-namespace (Q3) but versioned (Q5) — both rules independent
+    assert should_version(MemoryURI.parse("core://my_user")) is True
+
+
+def test_should_version_all_preferences_true():
+    # whole `preference://` domain is versioned
+    assert should_version(MemoryURI.parse("preference://qc/cutoff")) is True
+    assert should_version(MemoryURI.parse("preference://global/theme")) is True
+    assert should_version(MemoryURI.parse("preference://anything_at_all")) is True
+
+
+def test_should_version_kh_and_my_user_default_false():
+    # core://kh is shared but NOT versioned (static system content)
+    assert should_version(MemoryURI.parse("core://kh")) is False
+    assert should_version(MemoryURI.parse("core://kh/qc_threshold")) is False
+    # core://my_user_default is the static fallback template, NOT versioned
+    assert should_version(MemoryURI.parse("core://my_user_default")) is False
+
+
+# ----------------------------------------------------------------------
+# CONTEXT.md namespace ownership table — full matrix
+# Lock the entire policy contract in one place. If a row needs to change,
+# update CONTEXT.md and SHARED_PREFIXES / VERSIONED_PREFIXES in lockstep.
+# ----------------------------------------------------------------------
+
+_PER_NS = "ns/X"  # opaque current namespace for matrix tests
+
+
+@pytest.mark.parametrize(
+    "uri_str,expected_ns,expected_version",
+    [
+        ("core://agent",            "__shared__", True),
+        ("core://kh",               "__shared__", False),
+        ("core://kh/qc_threshold",  "__shared__", False),
+        ("core://my_user_default",  "__shared__", False),
+        ("core://my_user",          _PER_NS,      True),
+        ("preference://qc/cutoff",  _PER_NS,      True),
+        ("preference://global/x",   _PER_NS,      True),
+        ("dataset://pbmc.h5ad",     _PER_NS,      False),
+        ("analysis://run_42",       _PER_NS,      False),
+        ("insight://cluster/3",     _PER_NS,      False),
+        ("project://current",       _PER_NS,      False),
+        ("session://abc123",        _PER_NS,      False),
+    ],
+)
+def test_context_md_table_full_matrix(uri_str, expected_ns, expected_version):
+    uri = MemoryURI.parse(uri_str)
+    assert resolve_namespace(uri, current=_PER_NS) == expected_ns
+    assert should_version(uri) is expected_version

--- a/tests/memory/test_search_indexer_namespace.py
+++ b/tests/memory/test_search_indexer_namespace.py
@@ -1,0 +1,160 @@
+"""Tests for SearchIndexer namespace-aware behavior (PR #3a Task 3a.5).
+
+Covers:
+  - SearchIndexer.refresh_search_documents_for(namespace, uri): surgical
+    single-row rebuild without touching other namespaces' rows.
+  - Glossary keyword join filter: only keywords in the current namespace
+    or ``__shared__`` should feed into search_terms for that namespace's
+    search rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.models import GlossaryKeyword, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), search, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# Surgical refresh
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_creates_single_row(env):
+    eng, search, db = env
+    await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    # Wipe the search row, then surgically refresh just this (namespace, uri).
+    async with db.session() as s:
+        await s.execute(sa.delete(SearchDocument))
+
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://agent"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].namespace == "tg/userA"
+        assert rows[0].path == "agent"
+        assert rows[0].content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_is_noop_when_path_missing(env):
+    _, search, db = env
+    # Should not raise, just silently skip — the surgical refresh has nothing
+    # to rebuild if the (namespace, uri) doesn't exist.
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://nope"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert rows == []
+
+
+# ----------------------------------------------------------------------
+# Glossary namespace filter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_glossary_keyword_filtered_by_namespace(env):
+    """A keyword bound to a node but in a foreign namespace must NOT appear
+    in that node's search row.
+
+    To exercise the filter we bind three keywords to the SAME node:
+      - one with namespace='tg/userA' (current)
+      - one with namespace='tg/userZ' (foreign — must be excluded)
+      - one with namespace='__shared__' (must be included)
+
+    Without the per-namespace glossary filter all three would appear in
+    ``search_terms``.
+    """
+    eng, search, db = env
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        s.add_all([
+            GlossaryKeyword(
+                keyword="alpha-current",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userA",
+            ),
+            GlossaryKeyword(
+                keyword="zeta-foreign",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userZ",
+            ),
+            GlossaryKeyword(
+                keyword="shared-keyword",
+                node_uuid=ref.node_uuid,
+                namespace="__shared__",
+            ),
+        ])
+
+    await search.refresh_search_documents_for_node(ref.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+
+    assert "alpha-current" in sd.search_terms
+    assert "shared-keyword" in sd.search_terms
+    assert "zeta-foreign" not in sd.search_terms
+
+
+@pytest.mark.asyncio
+async def test_glossary_shared_keyword_appears_in_all_namespaces(env):
+    """A keyword with namespace='__shared__' should bleed into any per-user row."""
+    eng, search, db = env
+    ref_a = await eng.upsert("core://agent", "A", namespace="tg/userA")
+
+    # Bind a shared-namespace keyword to A's node — semantically odd in
+    # production, but it's what we'd see for core:// agents whose keywords
+    # are seeded globally.
+    async with db.session() as s:
+        s.add(
+            GlossaryKeyword(
+                keyword="shared-token",
+                node_uuid=ref_a.node_uuid,
+                namespace="__shared__",
+            )
+        )
+
+    await search.refresh_search_documents_for_node(ref_a.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+        assert "shared-token" in sd.search_terms


### PR DESCRIPTION
## Summary

PR #3c of the [memory refactor](docs/2026-05-09-memory-refactor-plan.md) — the **highest-risk** PR in Phase 2 because it rewrites mutating verbs in `GraphService` (1584 lines) while preserving every existing caller's contract. After this lands, all GraphService writes route through `MemoryEngine`, and `GlossaryService` is namespace-aware.

**Stacked on**: #125 (PR #1), #126 (PR #2), #127 (PR #3a), #128 (PR #3b). Merge **#125 → #126 → #127 → #128 → this** in order.

## What lands here

### `GlossaryService` — namespace-aware (Task 3c.1)
- `add_glossary_keyword(keyword, node_uuid, namespace=__shared__)` — new optional namespace; default keeps the four existing callers (`server.py` + `api/browse.py`) writing to the global partition unchanged.
- `add_glossary_shared(keyword, node_uuid)` — explicit-shared sugar.
- `remove_glossary_keyword(keyword, node_uuid, namespace=__shared__)` — removal is now namespace-scoped.
- `find_glossary_in_content(content, namespace=None)` — optional namespace filter restricting the keyword universe to `(namespace, __shared__)`. The Aho-Corasick automaton cache is now keyed by namespace so different scopes don't invalidate each other on every call. `_KeywordUniverse` dataclass introduced for the snapshot+fingerprint pair.

### `GraphService` → `MemoryEngine` shim (Task 3c.2)
- `__init__` constructs an internal `MemoryEngine`. No public API change to the constructor.
- `create_memory(parent_path, content, ...)` — pre-flight (parent resolution, auto-numbered final path, duplicate-path check) stays in `GraphService`; the actual Node/Memory/Edge/Path creation delegates to `MemoryEngine.upsert_versioned(... namespace='__shared__')`. A post-flight session re-fetches the four created rows for the legacy `rows_after` changeset shape callers depend on.
- `update_memory(path, content=None, priority=None, disclosure=None)` — pre-flight snapshots active edge + memory; delegates content updates to `upsert_versioned`, metadata-only updates to `patch_edge_metadata`. Legacy `None`-means-preserve translates into engine `_UNSET` by kwargs omission.

### Baseline fix (folded in)
- `omicsclaw/app/server.py:_memory_snapshot_row_identity` — pre-existing PR #3a regression: the path PK identity tuple was 2-arg (`(domain, path)`) but post-#3a the PK is 3-arg (`(namespace, domain, path)`), which broke `test_memory_review_clear_discards_pending_memory_create`. Discovered while baselining; fixed in `47fb8fb`.

## Test plan

- [x] **7 new glossary tests** — namespace-aware add/remove/find, multi-namespace co-existence under the composite UNIQUE.
- [x] **All existing GraphService tests still pass without modification** — 56 in `tests/test_app_server.py` exercise create_memory/update_memory through the changeset rollback path. **Plan acceptance criterion satisfied.**
- [x] **210/210 across full memory + downstream consumer set**: `tests/memory/ + tests/test_autoagent_failure_memory.py + tests/test_interactive_memory_command_support.py + tests/test_memory_server_security.py + tests/test_scoped_memory.py + tests/test_app_server.py`.
- [x] **5-axis review** — APPROVED ship-with-followups; reviewer confirmed correctness across all 7 axes (TOCTOU note tracked below).

## Known transitional cost

The 3-session split in `create_memory` (pre-flight check → engine call with own session → post-fetch) widens a pre-existing TOCTOU vs. legacy's single transaction. Two concurrent `create_memory` calls can both pass the duplicate-path pre-flight; the second engine call then takes the silent `upsert_versioned` versioning branch instead of raising. Single-process callers are unaffected (single-threaded test suite green); concurrent multi-process scenarios will drift from the legacy "Path already exists" error message. **Acceptable for a transitional shim** — PR #6 deletes `GraphService` entirely once callers have moved to `MemoryClient`/`MemoryEngine` directly.

## Out of scope

- `MemoryClient` strategy layer — PR #4a
- `ReviewLog` (cold path) — PR #4b
- Surface integration (CLI / Desktop / Bot namespace injection) — PR #5
- `GraphService` deletion + `_parse_uri` migration — PR #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)