### PR TITLE
refactor(memory) PR #6: Phase 5 cleanup — _parse_uri removal + README/AGENTS memory section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,16 +202,37 @@ evidence.
 
 ## Graph Memory System
 
-OmicsClaw uses a centralized graph-based memory system to persist context across sessions, agents, and tool invocations. The core system is located in `omicsclaw/memory/`.
+OmicsClaw uses a centralized graph-based memory system to persist context across sessions, agents, and tool invocations. The core system is located in `omicsclaw/memory/`. Vocabulary, decisions, and architectural diagrams live in [`docs/CONTEXT.md`](docs/CONTEXT.md).
 
 ### Architecture
 
-The memory system is backed by SQLite/PostgreSQL and is built as a graph database overlay using SQLAlchemy.
+Three layers over a SQLite/PostgreSQL graph database (SQLAlchemy):
 
-- **Nodes & Edges**: Every entity (session, dataset, user preference) is a node connected via edges to a central root node (`ROOT_NODE_UUID`). Nodes are addressed by URIs (e.g., `session://user123/cli`).
-- **MemoryClient**: High-level abstract client (`omicsclaw/memory/memory_client.py`) used by multi-agent pipelines to `remember()`, `recall()`, and `search()`.
-- **Compat Layer**: To maintain backward compatibility with old bot memory, `omicsclaw/memory/compat.py` implements the old interface but routes it through the graph engine.
-- **REST API**: A FastAPI backend provides management capabilities, accessible via `oc memory-server`.
+| Layer | Module | Role |
+|---|---|---|
+| Strategy | `MemoryClient(engine, namespace=...)` | Decides which Namespace a write lands in and whether it's versioned vs. overwrite. |
+| Hot path | `MemoryEngine` (`omicsclaw/memory/engine.py`) | 7 verbs over `(uri, namespace)`: `upsert`, `upsert_versioned`, `patch_edge_metadata`, `recall`, `search`, `list_children`, `get_subtree`. |
+| Cold path | `ReviewLog` (`omicsclaw/memory/review_log.py`) | Version-chain inspection, rollback, orphan/GC, browse_shared, changeset approve/discard — for the desktop Review & Audit pane. |
+
+- **Nodes & Edges**: Every entity (session, dataset, user preference) is a node connected via edges to a central root (`ROOT_NODE_UUID`). Nodes are addressed by URIs (e.g., `core://agent`, `dataset://pbmc.h5ad`).
+- **Namespace partition**: `paths`, `search_documents`, and `glossary_keywords` carry a `namespace` column; surfaces inject the value (CLI = workspace path, Desktop = `app/<launch_id>`, Bot = `<platform>/<user_id>`, system = `__shared__`).
+- **Read fallback is asymmetric**: `recall` and `search` see `__shared__` content automatically; `list_children` and `get_subtree` are strict so private inventories don't get polluted by shared structure.
+- **Compat Layer**: `omicsclaw/memory/compat.py` (`CompatMemoryStore`) is the bot's drop-in replacement for the legacy `bot.memory.MemoryStore`; it derives a per-session namespace from `(platform, user_id)`.
+- **REST API**: A FastAPI backend provides management capabilities (browse, search, review, rollback, orphan inspection), accessible via `oc memory-server`. The desktop's `/memory/review/*` routes go through `ReviewLog`.
+
+#### Surface helpers
+
+```python
+from omicsclaw.memory import (
+    cli_namespace_from_workspace,  # absolute workspace path (cwd if None)
+    desktop_namespace,             # app/<OMICSCLAW_DESKTOP_LAUNCH_ID> or app/desktop_user
+    get_memory_client,             # factory: MemoryClient bound to a namespace
+    get_memory_engine,             # singleton MemoryEngine
+    get_review_log,                # singleton ReviewLog
+)
+```
+
+> **Migration note (PRs #125–#132).** `MemoryEngine` and `ReviewLog` replace the legacy 1584-line `GraphService`. New code MUST use `MemoryEngine`/`ReviewLog`/`MemoryClient`; `GraphService` lingers as a transitional shim while five remaining call sites (`/memory/update`, `/memory/children`, `/memory/domains`, `MemoryClient.forget`, `MemoryClient.get_recent`) are migrated.
 
 ### Running the Dashboard API
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ metadata noise when `oc doctor` and the targeted import checks pass.
 
 Run `oc list` for the current CLI catalog.
 
+## 🧠 Memory Architecture
+
+Graph-backed agent memory at `omicsclaw/memory/`. Sessions, dataset / analysis / preference / insight lineage, and core agent identity persist across runs and replay back into chat context. Three layers:
+
+| Layer | Module | Role |
+|---|---|---|
+| Strategy | `MemoryClient(engine, namespace=...)` | Decides which **Namespace** a write lands in and whether it's versioned vs. overwrite. |
+| Hot path | `MemoryEngine` | 7 verbs over `(uri, namespace)`: `upsert`, `upsert_versioned`, `patch_edge_metadata`, `recall`, `search`, `list_children`, `get_subtree`. |
+| Cold path | `ReviewLog` | Version-chain inspection, rollback, orphan/GC, browse_shared, changeset approve/discard — for the desktop Review & Audit pane. |
+
+**Namespace partition** keeps surfaces isolated:
+
+| Surface | Namespace |
+|---|---|
+| CLI / TUI | absolute workspace path (cwd unless `--workspace` is set) |
+| Desktop | `app/<OMICSCLAW_DESKTOP_LAUNCH_ID>` or `app/desktop_user` |
+| Telegram / Feishu bot | `f"{platform}/{user_id}"` |
+| Globally shared | `__shared__` (read-fallback target for every other namespace) |
+
+Read fallback is asymmetric: `recall` and `search` see `__shared__` content automatically; `list_children` and `get_subtree` are strict so private inventories don't get polluted by shared structure.
+
+Vocabulary, decisions, and architectural diagrams live in [`docs/CONTEXT.md`](docs/CONTEXT.md).
+
 ## ❓ FAQ
 
 <details>

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2561,6 +2561,22 @@ class ScopedPruneRequest(BaseModel):
 
 # -- Helper: get graph / glossary / changeset services ----------------------
 
+def _get_review_log():
+    """Return the singleton ReviewLog (cold-path operations).
+
+    Used by /memory/review/* endpoints. Falls back with a 503 if the
+    memory module isn't installed or is mid-initialization.
+    """
+    try:
+        from omicsclaw.memory import get_review_log
+    except Exception as exc:
+        raise HTTPException(503, detail=f"Memory system unavailable: {exc}")
+    try:
+        return get_review_log()
+    except Exception as exc:
+        raise HTTPException(503, detail=f"Memory system unavailable: {exc}")
+
+
 def _get_graph_service():
     """Return GraphService, raising 503 if the memory module is not available."""
     try:
@@ -2977,20 +2993,125 @@ async def memory_review_approve():
 
 @app.post("/memory/review/rollback")
 async def memory_review_rollback(req: MemoryRollbackRequest):
-    """Rollback a specific memory to a previous version."""
+    """Rollback a specific memory to a previous version.
+
+    PR #5: routed through ReviewLog instead of GraphService. Namespace
+    is the desktop's launch-derived namespace so the rollback is
+    confined to whatever partition the desktop user is editing.
+    """
     if _memory_client is None:
         raise HTTPException(503, detail="Memory system not available")
 
     try:
-        graph = _get_graph_service()
-        result = await graph.rollback_to_memory(target_memory_id=req.target_memory_id)
-        return {"ok": True, "result": result}
+        from omicsclaw.memory import desktop_namespace
+
+        review = _get_review_log()
+        result = await review.rollback_to(
+            req.target_memory_id, namespace=desktop_namespace()
+        )
+        return {
+            "ok": True,
+            "result": {
+                "restored_memory_id": result.restored_memory_id,
+                "node_uuid": result.node_uuid,
+                "was_already_active": result.was_already_active,
+            },
+        }
     except ValueError as exc:
         raise HTTPException(400, detail=str(exc))
     except HTTPException:
         raise
     except Exception as exc:
         logger.exception("Memory review rollback error")
+        raise HTTPException(500, detail=str(exc))
+
+
+# -- GET /memory/review/orphans ----------------------------------------------
+
+@app.get("/memory/review/orphans")
+async def memory_review_orphans(
+    namespace: Optional[str] = Query(
+        None,
+        description=(
+            "Restrict to one namespace. Omit for the desktop's own "
+            "namespace; pass an empty string for the global view."
+        ),
+    ),
+):
+    """List deprecated memories whose successor was deleted (orphan chains).
+
+    Default namespace is the desktop's own; an explicit empty string
+    means "across all partitions" (admin view).
+    """
+    if _memory_client is None:
+        raise HTTPException(503, detail="Memory system not available")
+
+    try:
+        from dataclasses import asdict
+
+        from omicsclaw.memory import desktop_namespace
+
+        review = _get_review_log()
+
+        if namespace is None:
+            ns_filter: Optional[str] = desktop_namespace()
+        elif namespace == "":
+            ns_filter = None
+        else:
+            ns_filter = namespace
+
+        orphans = await review.list_orphans(namespace=ns_filter)
+        return {
+            "namespace": ns_filter,
+            "count": len(orphans),
+            "orphans": [asdict(o) for o in orphans],
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Memory review orphans error")
+        raise HTTPException(500, detail=str(exc))
+
+
+# -- GET /memory/review/version-chain ----------------------------------------
+
+@app.get("/memory/review/version-chain")
+async def memory_review_version_chain(
+    uri: str = Query(..., description="Memory URI (e.g. 'core://agent')"),
+    namespace: Optional[str] = Query(
+        None,
+        description="Override the desktop default namespace.",
+    ),
+):
+    """List the version chain for a versioned URI in age order.
+
+    Returns 400 if the URI is overwrite-only (``dataset://``,
+    ``analysis://``) — those structurally cannot have a chain.
+    """
+    if _memory_client is None:
+        raise HTTPException(503, detail="Memory system not available")
+
+    try:
+        from dataclasses import asdict
+
+        from omicsclaw.memory import desktop_namespace
+        from omicsclaw.memory.review_log import NoVersionHistoryError
+
+        review = _get_review_log()
+        ns = namespace or desktop_namespace()
+        chain = await review.list_version_chain(uri, namespace=ns)
+        return {
+            "uri": uri,
+            "namespace": ns,
+            "count": len(chain),
+            "entries": [asdict(e) for e in chain],
+        }
+    except NoVersionHistoryError as exc:
+        raise HTTPException(400, detail=str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Memory review version-chain error")
         raise HTTPException(500, detail=str(exc))
 
 

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2608,7 +2608,10 @@ def _memory_snapshot_row_identity(table: str, row: dict[str, Any]):
     if table in {"memories", "edges"}:
         return row["id"]
     if table == "paths":
-        return (row["domain"], row["path"])
+        # PK is (namespace, domain, path) post-001_namespace migration. Older
+        # snapshots predating the namespace column default to "__shared__".
+        namespace = row.get("namespace") or "__shared__"
+        return (namespace, row["domain"], row["path"])
     if table == "glossary_keywords":
         if "id" in row and row["id"] is not None:
             return row["id"]

--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -405,12 +405,23 @@ async def lifespan(app: FastAPI):
             _NOTEBOOK_IMPORT_ERROR or "(import failed without message)",
         )
 
-    # Optionally expose MemoryClient for browse/search endpoints
+    # Optionally expose MemoryClient for browse/search endpoints. The
+    # desktop client is bound to a launch-id-derived namespace
+    # (``app/<launch_id>`` or ``app/desktop_user`` for single-user runs)
+    # so its writes/reads are partitioned from the bot's per-user
+    # namespaces and from CLI workspace namespaces.
     try:
-        from omicsclaw.memory.memory_client import MemoryClient
-        _memory_client = MemoryClient()
-        await _memory_client.initialize()
-        logger.info("MemoryClient initialised")
+        from omicsclaw.memory import (
+            desktop_namespace,
+            get_engine_db,
+            get_memory_client,
+        )
+
+        await get_engine_db().init_db()
+        _memory_client = get_memory_client(namespace=desktop_namespace())
+        logger.info(
+            "MemoryClient initialised (namespace=%s)", _memory_client.namespace
+        )
     except Exception as exc:
         logger.warning("MemoryClient unavailable (non-fatal): %s", exc)
         _memory_client = None
@@ -2466,19 +2477,23 @@ async def memory_browse(
         raise HTTPException(503, detail="Memory system not available")
 
     try:
+        from dataclasses import asdict
+
         uri = f"{domain}://{path}" if path else f"{domain}://"
         children = await _memory_client.list_children(uri)
 
         # Also get the node itself if path is provided
         node = None
         if path:
-            node = await _memory_client.recall(f"{domain}://{path}")
+            record = await _memory_client.recall(f"{domain}://{path}")
+            if record is not None:
+                node = asdict(record)
 
         return {
             "path": path,
             "domain": domain,
             "node": node,
-            "children": children,
+            "children": [asdict(c) for c in children],
         }
     except Exception as exc:
         logger.exception("Memory browse error")

--- a/omicsclaw/memory/__init__.py
+++ b/omicsclaw/memory/__init__.py
@@ -25,7 +25,6 @@ Usage (lazy init):
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
 from .scoped_memory import (
@@ -157,10 +156,14 @@ def cli_namespace_from_workspace(workspace_dir: Optional[str]) -> str:
     ``None`` means "use cwd" — the natural default for ``oc interactive``
     invoked without ``--workspace``.
     """
+    # Local import — module-level ``from pathlib import Path`` would
+    # shadow the lazy ``omicsclaw.memory.Path`` ORM export below.
+    from pathlib import Path as _PathlibPath
+
     if workspace_dir is None or workspace_dir == "":
-        target = Path.cwd()
+        target = _PathlibPath.cwd()
     else:
-        target = Path(workspace_dir)
+        target = _PathlibPath(workspace_dir)
     return str(target.resolve())
 
 

--- a/omicsclaw/memory/__init__.py
+++ b/omicsclaw/memory/__init__.py
@@ -25,6 +25,7 @@ Usage (lazy init):
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
 from .scoped_memory import (
@@ -53,7 +54,10 @@ from .snapshot import ChangesetStore, get_changeset_store
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
+    from .engine import MemoryEngine
     from .graph import GraphService
+    from .memory_client import MemoryClient
+    from .review_log import ReviewLog
     from .search import SearchIndexer
     from .glossary import GlossaryService
 
@@ -61,14 +65,19 @@ _db_manager: Optional["DatabaseManager"] = None
 _graph_service: Optional["GraphService"] = None
 _search_indexer: Optional["SearchIndexer"] = None
 _glossary_service: Optional["GlossaryService"] = None
+_memory_engine: Optional["MemoryEngine"] = None
+_review_log: Optional["ReviewLog"] = None
 
 
 def _ensure_initialized():
     global _db_manager, _graph_service, _search_indexer, _glossary_service
+    global _memory_engine, _review_log
     if _db_manager is not None:
         return
 
     from .database import DatabaseManager
+    from .engine import MemoryEngine
+    from .review_log import ReviewLog
     from .search import SearchIndexer
     from .glossary import GlossaryService
     from .graph import GraphService
@@ -80,6 +89,8 @@ def _ensure_initialized():
     _search_indexer = SearchIndexer(_db_manager)
     _glossary_service = GlossaryService(_db_manager, _search_indexer)
     _graph_service = GraphService(_db_manager, _search_indexer)
+    _memory_engine = MemoryEngine(_db_manager, _search_indexer)
+    _review_log = ReviewLog(_db_manager, _memory_engine)
 
 
 def get_db_manager() -> DatabaseManager:
@@ -100,6 +111,74 @@ def get_search_indexer() -> "SearchIndexer":
 def get_glossary_service() -> "GlossaryService":
     _ensure_initialized()
     return _glossary_service  # type: ignore[return-value]
+
+
+def get_memory_engine() -> "MemoryEngine":
+    """Return the singleton MemoryEngine bound to the configured database."""
+    _ensure_initialized()
+    return _memory_engine  # type: ignore[return-value]
+
+
+def get_engine_db() -> "DatabaseManager":
+    """Sugar for ``get_memory_engine().db`` — used by surfaces that need
+    to call ``init_db`` before opening any session."""
+    return get_memory_engine().db
+
+
+def get_review_log() -> "ReviewLog":
+    """Return the singleton ReviewLog (cold-path operations)."""
+    _ensure_initialized()
+    return _review_log  # type: ignore[return-value]
+
+
+def get_memory_client(*, namespace: str) -> "MemoryClient":
+    """Return a MemoryClient bound to ``namespace`` and the singleton engine.
+
+    This is the canonical way for a surface (CLI, Desktop, Bot) to obtain
+    a namespaced client. The underlying engine is shared so per-call
+    construction is cheap.
+    """
+    from .memory_client import MemoryClient
+
+    return MemoryClient(engine=get_memory_engine(), namespace=namespace)
+
+
+# ----------------------------------------------------------------------
+# Surface namespace derivation helpers
+# ----------------------------------------------------------------------
+
+
+def cli_namespace_from_workspace(workspace_dir: Optional[str]) -> str:
+    """Derive a CLI/TUI namespace from a workspace directory.
+
+    Resolves to an absolute path so two terminals running in the same
+    directory share a namespace, and two different directories don't.
+    A relative path resolves against the current working directory.
+    ``None`` means "use cwd" — the natural default for ``oc interactive``
+    invoked without ``--workspace``.
+    """
+    if workspace_dir is None or workspace_dir == "":
+        target = Path.cwd()
+    else:
+        target = Path(workspace_dir)
+    return str(target.resolve())
+
+
+_DESKTOP_DEFAULT_NAMESPACE = "app/desktop_user"
+
+
+def desktop_namespace() -> str:
+    """Derive the Desktop FastAPI namespace.
+
+    Reads ``OMICSCLAW_DESKTOP_LAUNCH_ID`` if set (multi-user desktop or
+    sandboxed launch), otherwise the single-user default. The launch id
+    is prefixed with ``app/`` so cross-surface collisions with bot
+    namespaces (``telegram/...``, ``feishu/...``) are impossible.
+    """
+    launch_id = (os.getenv("OMICSCLAW_DESKTOP_LAUNCH_ID") or "").strip()
+    if launch_id:
+        return f"app/{launch_id}"
+    return _DESKTOP_DEFAULT_NAMESPACE
 
 
 def __getattr__(name: str):
@@ -130,18 +209,24 @@ def __getattr__(name: str):
 async def close_db():
     """Tear down all services and close the database connection."""
     global _db_manager, _graph_service, _search_indexer, _glossary_service
+    global _memory_engine, _review_log
     if _db_manager:
         await _db_manager.close()
     _db_manager = None
     _graph_service = None
     _search_indexer = None
     _glossary_service = None
+    _memory_engine = None
+    _review_log = None
 
 
 __all__ = [
     "DatabaseManager",
     "get_db_manager", "get_graph_service",
     "get_search_indexer", "get_glossary_service",
+    "get_memory_engine", "get_review_log", "get_memory_client",
+    "get_engine_db",
+    "cli_namespace_from_workspace", "desktop_namespace",
     "close_db",
     "ChangesetStore", "get_changeset_store",
     "Base", "ROOT_NODE_UUID", "Node", "Memory", "Edge", "Path",

--- a/omicsclaw/memory/compat.py
+++ b/omicsclaw/memory/compat.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from .memory_client import MemoryClient
+from .models import SHARED_NAMESPACE
 
 logger = logging.getLogger(__name__)
 
@@ -222,18 +223,89 @@ class CompatMemoryStore:
 
     Maps flat memory operations to graph memory URIs.
     Preserves: deduplication, session management, search.
+
+    Namespace policy (PR #4a):
+      - Sessions live in ``__shared__`` so a session_id can be resolved
+        to its owner without a global directory lookup.
+      - User memories (dataset/analysis/preference/insight/project) land
+        in the session-derived namespace ``f"{platform}/{user_id}"``,
+        so two telegram users on the same bot can't see each other's
+        ``dataset://pbmc.h5ad`` row.
     """
 
     def __init__(self, database_url: Optional[str] = None):
-        self._client = MemoryClient(database_url)
+        self._database_url = database_url
+        self._db = None
+        self._search = None
+        self._engine = None
+        # Always-shared client for session metadata.
+        self._session_client: Optional[MemoryClient] = None
+        # Cached lightweight clients keyed by namespace string. Engines
+        # are stateless so all clients share one engine instance.
+        self._memory_clients: dict[str, MemoryClient] = {}
+        self._initialized = False
 
     async def initialize(self) -> None:
         """Initialize storage backend."""
-        await self._client.initialize()
+        if self._initialized:
+            return
+
+        from .database import DatabaseManager
+        from .engine import MemoryEngine
+        from .search import SearchIndexer
+
+        self._db = DatabaseManager(self._database_url)
+        await self._db.init_db()
+        self._search = SearchIndexer(self._db)
+        self._engine = MemoryEngine(self._db, self._search)
+        self._session_client = MemoryClient(
+            engine=self._engine, namespace=SHARED_NAMESPACE
+        )
+        self._initialized = True
 
     async def close(self) -> None:
         """Close backend resources."""
-        await self._client.close()
+        if self._db is not None:
+            await self._db.close()
+        self._db = None
+        self._engine = None
+        self._search = None
+        self._session_client = None
+        self._memory_clients.clear()
+        self._initialized = False
+
+    @property
+    def _client(self) -> MemoryClient:
+        """Backward-compat shim — old call sites that read ``self._client``
+        get the shared session client. New methods route via
+        ``_client_for_session`` so memory ops land in the user's namespace.
+        """
+        assert self._session_client is not None, (
+            "CompatMemoryStore must be initialised before use"
+        )
+        return self._session_client
+
+    def _client_for_namespace(self, namespace: str) -> MemoryClient:
+        """Get-or-create a lightweight MemoryClient for ``namespace``."""
+        assert self._engine is not None
+        client = self._memory_clients.get(namespace)
+        if client is None:
+            client = MemoryClient(engine=self._engine, namespace=namespace)
+            self._memory_clients[namespace] = client
+        return client
+
+    async def _client_for_session(self, session_id: str) -> MemoryClient:
+        """Resolve a session to its owner-namespace client.
+
+        Falls back to ``__shared__`` when the session can't be resolved
+        (defensive — in production the bot always creates a session before
+        the first save_memory call).
+        """
+        session = await self.get_session(session_id)
+        if session is None:
+            return self._client_for_namespace(SHARED_NAMESPACE)
+        namespace = f"{session.platform}/{session.user_id}"
+        return self._client_for_namespace(namespace)
 
     async def create_session(self, user_id: str, platform: str, chat_id: str = "", session_id: str = None) -> Session:
         """Create a new session in the graph memory."""
@@ -253,11 +325,11 @@ class CompatMemoryStore:
         return session
 
     async def get_session(self, session_id: str) -> Optional[Session]:
-        """Retrieve session by ID."""
-        mem = await self._client.recall(f"session://{session_id}")
-        if not mem or not mem.get("content"):
+        """Retrieve session by ID. Sessions live in __shared__."""
+        record = await self._client.recall(f"session://{session_id}")
+        if record is None or not record.content:
             return None
-        content = mem["content"]
+        content = record.content
         # Auto-decode legacy base64 content from old encryption system
         decoded = _decode_legacy_content(content)
         if decoded != content:
@@ -291,12 +363,18 @@ class CompatMemoryStore:
         )
 
     async def save_memory(self, session_id: str, memory: BaseMemory) -> str:
-        """Save a memory, return memory_id."""
+        """Save a memory, return memory_id.
+
+        The memory lands in the session's owner namespace
+        (``f"{platform}/{user_id}"``); session metadata stays shared.
+        """
+        client = await self._client_for_session(session_id)
+
         domain = _TYPE_TO_DOMAIN.get(memory.memory_type, "core")
         path = _memory_to_uri_path(memory)
         content = _memory_to_content(memory)
 
-        await self._client.remember(
+        await client.remember(
             uri=f"{domain}://{path}",
             content=content,
             disclosure=f"Memory from session {session_id}",
@@ -315,7 +393,16 @@ class CompatMemoryStore:
     async def get_memories(
         self, session_id: str, memory_type: Optional[str] = None, limit: int = 100
     ) -> list[BaseMemory]:
-        """Retrieve memories, optionally filtered by type."""
+        """Retrieve memories, optionally filtered by type.
+
+        Reads through the session's owner-namespace client so a user
+        only sees their own memories. The shared partition is consulted
+        via the engine's read-fallback only on individual ``recall``
+        calls — listings are strict, so shared keywords don't bleed
+        into a per-user inventory.
+        """
+        client = await self._client_for_session(session_id)
+
         if memory_type:
             domain = _TYPE_TO_DOMAIN.get(memory_type)
             if not domain:
@@ -329,16 +416,16 @@ class CompatMemoryStore:
             """Recursively collect leaf memories from a domain tree."""
             if len(results) >= limit:
                 return
-            children = await self._client.list_children(uri)
+            children = await client.list_children(uri)
             for child in children:
                 if len(results) >= limit:
                     return
-                child_uri = f"{child['domain']}://{child['path']}"
-                mem = await self._client.recall(child_uri)
-                if mem and mem.get("content"):
-                    content = _decode_legacy_content(mem["content"])
-                    if content != mem["content"]:
-                        await self._client.remember(uri=child_uri, content=content)
+                child_uri = child.uri
+                rec = await client.recall(child_uri)
+                if rec is not None and rec.content:
+                    content = _decode_legacy_content(rec.content)
+                    if content != rec.content:
+                        await client.remember(uri=child_uri, content=content)
                     obj = _content_to_memory(content, mtype)
                     if obj:
                         results.append(obj)
@@ -357,25 +444,38 @@ class CompatMemoryStore:
         return results[:limit]
 
     async def update_memory(self, memory_id: str, updates: dict) -> None:
-        """Update memory fields — search and update in place."""
-        # Search for the memory by ID substring
-        results = await self._client.search(memory_id, limit=5)
-        for r in results:
-            mem = await self._client.recall(r["uri"])
-            if mem and mem.get("content"):
-                content = mem["content"]
+        """Update memory fields — search and update in place.
+
+        Searches every cached per-namespace client; without a session_id
+        the caller hasn't told us which user the memory_id belongs to,
+        and we don't want a global scan that could match the wrong user's
+        memory_id collision. ``memory_id`` is a uuid4 so collisions are
+        astronomically unlikely, but the per-namespace search keeps the
+        update strictly within whichever namespace the row lives.
+        """
+        # Touch the session client first so the shared partition is
+        # always considered (covers the legacy "everything in shared"
+        # case before the namespace migration).
+        candidate_clients = [self._session_client] + list(self._memory_clients.values())
+        seen = set()
+        for client in candidate_clients:
+            if client is None or id(client) in seen:
+                continue
+            seen.add(id(client))
+            results = await client.search(memory_id, limit=5)
+            for r in results:
+                rec = await client.recall(r["uri"])
+                if rec is None or not rec.content:
+                    continue
                 try:
-                    data = json.loads(content)
-                    if data.get("memory_id") == memory_id:
-                        data.update(updates)
-                        new_content = json.dumps(data)
-                        await self._client.remember(
-                            uri=r["uri"],
-                            content=new_content,
-                        )
-                        return
+                    data = json.loads(rec.content)
                 except json.JSONDecodeError:
                     continue
+                if data.get("memory_id") != memory_id:
+                    continue
+                data.update(updates)
+                await client.remember(uri=r["uri"], content=json.dumps(data))
+                return
 
     async def delete_session(self, session_id: str) -> None:
         """Delete session."""
@@ -387,21 +487,23 @@ class CompatMemoryStore:
     async def search_memories(
         self, session_id: str, query: str, memory_type: Optional[str] = None
     ) -> list[BaseMemory]:
-        """Search memories by content."""
+        """Search memories by content within the session's namespace."""
+        client = await self._client_for_session(session_id)
+
         domain = _TYPE_TO_DOMAIN.get(memory_type) if memory_type else None
-        results = await self._client.search(query, limit=20, domain=domain)
+        results = await client.search(query, limit=20, domain=domain)
 
         memories = []
         for r in results:
-            mem = await self._client.recall(r["uri"])
-            if mem and mem.get("content"):
-                content = mem["content"]
-                # Try to detect memory type from the domain
-                rd = r.get("domain", "")
-                mt = _DOMAIN_TO_TYPE.get(rd, memory_type or "")
-                obj = _content_to_memory(content, mt)
-                if obj:
-                    memories.append(obj)
+            rec = await client.recall(r["uri"])
+            if rec is None or not rec.content:
+                continue
+            content = rec.content
+            rd = r.get("domain", "")
+            mt = _DOMAIN_TO_TYPE.get(rd, memory_type or "")
+            obj = _content_to_memory(content, mt)
+            if obj:
+                memories.append(obj)
 
         return memories
 

--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -200,6 +200,7 @@ class DatabaseManager:
                         text("""
                             CREATE VIRTUAL TABLE IF NOT EXISTS search_documents_fts
                             USING fts5(
+                                namespace,
                                 domain,
                                 path,
                                 node_uuid,

--- a/omicsclaw/memory/database.py
+++ b/omicsclaw/memory/database.py
@@ -136,6 +136,11 @@ class DatabaseManager:
                 if not is_initialized:
                     await conn.run_sync(Base.metadata.create_all)
 
+            # Run any pending schema migrations after the base schema exists.
+            # Imported lazily to avoid a circular import at module load time.
+            from omicsclaw.memory.migrations import run_pending
+            await run_pending(self)
+
             # Ensure the root node exists (all edges reference it as parent)
             await self._ensure_root_node()
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -562,7 +562,15 @@ class MemoryEngine:
         domain: Optional[str] = None,
         limit: int = 10,
     ) -> list[dict]:
-        raise NotImplementedError("PR #3b")
+        """Full-text search restricted to ``namespace`` + ``__shared__``.
+
+        Per-namespace hits are returned ahead of shared hits when scores
+        are otherwise comparable. Each result dict carries a
+        ``namespace`` key indicating which partition the hit came from.
+        """
+        return await self._search.search(
+            query, limit=limit, domain=domain, namespace=namespace
+        )
 
     async def list_children(
         self, uri: str | MemoryURI, *, namespace: str

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -273,16 +273,98 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
         For ``core://*`` and ``preference://*`` URIs where the version
         chain is the audit trail. The old Memory keeps ``deprecated=True``
         and ``migrated_to=new_memory_id``; only the newest is active.
+        First write returns ``old_memory_id=None``.
         """
-        raise NotImplementedError("Task 3a.3")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is None:
+                # No existing path: this is a first write — same shape as upsert
+                # but routed through the versioned helper for return-type symmetry.
+                new_memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+                old_memory_id: Optional[int] = None
+            else:
+                old_memory_id, new_memory_id, node_uuid = (
+                    await self._upsert_versioned_chain(
+                        s, existing_path, content, priority, disclosure
+                    )
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return VersionedMemoryRef(
+            old_memory_id=old_memory_id,
+            new_memory_id=new_memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    async def _upsert_versioned_chain(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[Optional[int], int, str]:
+        """Insert a new active Memory and deprecate the previous active one.
+
+        Returns ``(old_memory_id, new_memory_id, node_uuid)``. ``old_memory_id``
+        is ``None`` only when no active Memory existed (orphan path), which
+        we recover from by treating the new write as the chain's first link.
+        """
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+        node_uuid = edge.child_uuid
+
+        old = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == node_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        new_memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(new_memory)
+        await s.flush()
+
+        old_id: Optional[int] = None
+        if old is not None:
+            old.deprecated = True
+            old.migrated_to = new_memory.id
+            old_id = old.id
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return old_id, new_memory.id, node_uuid
 
     async def patch_edge_metadata(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -1,0 +1,165 @@
+# pyright: reportArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
+
+"""MemoryEngine — namespace-aware hot path for memory writes and reads.
+
+This module is the "engine room" of the OmicsClaw memory architecture.
+It owns the canonical CRUD verbs over Node/Memory/Edge/Path and is the
+only layer that touches those tables directly.
+
+Above it sits ``MemoryClient`` (strategy: which namespace, version vs.
+overwrite); below it sits the ORM. The legacy ``GraphService`` is
+unaffected during PR #3a — see ``docs/2026-05-09-memory-refactor-plan.md``
+for the full migration path.
+
+Verbs landed in this PR (PR #3a):
+    - upsert(uri, content, namespace, ...)
+    - upsert_versioned(uri, content, namespace, ...)
+    - patch_edge_metadata(uri, namespace, ...)
+
+Verbs reserved for PR #3b:
+    - recall(uri, namespace, ...)
+    - search(query, namespace, ...)
+    - list_children(uri, namespace)
+    - get_subtree(uri, namespace, ...)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import select
+
+from .models import Edge, Memory, Node, Path
+from .uri import MemoryURI
+
+if TYPE_CHECKING:
+    from .database import DatabaseManager
+    from .search import SearchIndexer
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRef:
+    """Pointer to a single materialized memory at one (namespace, uri)."""
+
+    memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class VersionedMemoryRef:
+    """Result of a version-creating upsert.
+
+    ``old_memory_id`` is ``None`` on the first write (no chain yet).
+    """
+
+    old_memory_id: Optional[int]
+    new_memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+
+
+class MemoryEngine:
+    """Namespace-aware CRUD over the memory graph.
+
+    Constructed once per process and reused. Holds no per-namespace state —
+    every verb takes ``namespace`` as a required argument.
+    """
+
+    def __init__(self, db: "DatabaseManager", search: "SearchIndexer") -> None:
+        self._db = db
+        self._search = search
+
+    # ------------------------------------------------------------------
+    # Write verbs (PR #3a)
+    # ------------------------------------------------------------------
+
+    async def upsert(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> MemoryRef:
+        """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
+
+        Re-calling with the same (uri, namespace) UPDATEs the existing
+        Memory row's content in place — no deprecation chain, no new
+        Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
+        where history is not interesting.
+        """
+        raise NotImplementedError("Task 3a.2")
+
+    async def upsert_versioned(
+        self,
+        uri: str | MemoryURI,
+        content: str,
+        *,
+        namespace: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> VersionedMemoryRef:
+        """Versioned upsert: deprecate the old Memory, insert a new one.
+
+        For ``core://*`` and ``preference://*`` URIs where the version
+        chain is the audit trail. The old Memory keeps ``deprecated=True``
+        and ``migrated_to=new_memory_id``; only the newest is active.
+        """
+        raise NotImplementedError("Task 3a.3")
+
+    async def patch_edge_metadata(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        priority: Optional[int] = None,
+        disclosure: Optional[str] = None,
+    ) -> None:
+        """Update Edge metadata (priority, disclosure) without touching Memory.
+
+        At least one of ``priority``/``disclosure`` must be provided.
+        """
+        raise NotImplementedError("Task 3a.4")
+
+    # ------------------------------------------------------------------
+    # Read verbs (PR #3b)
+    # ------------------------------------------------------------------
+
+    async def recall(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        fallback_to_shared: bool = True,
+    ) -> Optional[Any]:
+        raise NotImplementedError("PR #3b")
+
+    async def search(
+        self,
+        query: str,
+        *,
+        namespace: str,
+        domain: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        raise NotImplementedError("PR #3b")
+
+    async def list_children(
+        self, uri: str | MemoryURI, *, namespace: str
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")
+
+    async def get_subtree(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        limit: int = 100,
+    ) -> list[MemoryRef]:
+        raise NotImplementedError("PR #3b")

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -25,18 +25,21 @@ Verbs reserved for PR #3b:
 
 from __future__ import annotations
 
+import uuid as uuidlib
 from dataclasses import dataclass
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Edge, Memory, Node, Path
+from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
+
+_UNSET: Any = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,8 +87,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: int = 0,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -93,8 +96,176 @@ class MemoryEngine:
         Memory row's content in place — no deprecation chain, no new
         Memory row. Use this for ``dataset://`` and ``analysis://`` URIs
         where history is not interesting.
+
+        ``priority`` and ``disclosure`` use a sentinel so an update call
+        without them preserves the existing edge's metadata; pass an
+        explicit ``None`` (or any value) to overwrite.
         """
-        raise NotImplementedError("Task 3a.2")
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            existing_path = await self._fetch_path(s, namespace, parsed)
+
+            if existing_path is not None:
+                memory_id, node_uuid = await self._upsert_existing(
+                    s, existing_path, content, priority, disclosure
+                )
+            else:
+                memory_id, node_uuid = await self._upsert_create(
+                    s, parsed, namespace, content, priority, disclosure
+                )
+
+            await self._search.refresh_search_documents_for_node(
+                node_uuid, session=s
+            )
+
+        return MemoryRef(
+            memory_id=memory_id,
+            node_uuid=node_uuid,
+            namespace=namespace,
+            uri=canonical,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers (kept private — tests should drive only via verbs)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _fetch_path(
+        s: AsyncSession, namespace: str, parsed: MemoryURI
+    ) -> Optional[Path]:
+        return (
+            await s.execute(
+                select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def _upsert_existing(
+        self,
+        s: AsyncSession,
+        path_row: Path,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"references a missing edge — graph corruption."
+            )
+
+        memory = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == edge.child_uuid,
+                    Memory.deprecated == False,  # noqa: E712 — SQLAlchemy column comparison
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        if memory is None:
+            # Edge exists but has no active memory — create one and attach.
+            memory = Memory(
+                node_uuid=edge.child_uuid, content=content, deprecated=False
+            )
+            s.add(memory)
+            await s.flush()
+        else:
+            memory.content = content
+
+        if priority is not _UNSET:
+            edge.priority = priority
+        if disclosure is not _UNSET:
+            edge.disclosure = disclosure
+
+        return memory.id, edge.child_uuid
+
+    async def _upsert_create(
+        self,
+        s: AsyncSession,
+        parsed: MemoryURI,
+        namespace: str,
+        content: str,
+        priority: Any,
+        disclosure: Any,
+    ) -> tuple[int, str]:
+        parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
+
+        node_uuid = str(uuidlib.uuid4())
+        s.add(Node(uuid=node_uuid))
+        await s.flush()
+
+        memory = Memory(node_uuid=node_uuid, content=content, deprecated=False)
+        s.add(memory)
+        await s.flush()
+
+        edge_name = parsed.path.rsplit("/", 1)[-1] if "/" in parsed.path else parsed.path
+        edge = Edge(
+            parent_uuid=parent_uuid,
+            child_uuid=node_uuid,
+            name=edge_name,
+            priority=0 if priority is _UNSET else priority,
+            disclosure=None if disclosure is _UNSET else disclosure,
+        )
+        s.add(edge)
+        await s.flush()
+
+        s.add(
+            Path(
+                namespace=namespace,
+                domain=parsed.domain,
+                path=parsed.path,
+                edge_id=edge.id,
+            )
+        )
+        await s.flush()
+
+        return memory.id, node_uuid
+
+    @staticmethod
+    async def _resolve_parent_node_uuid(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> str:
+        """Resolve the parent node UUID for a new path, with shared fallback.
+
+        Top-level URIs (``core://agent``, ``analysis://sc-de``) attach to
+        ROOT. Nested URIs require the parent path to exist either in the
+        current namespace or in ``__shared__``. Falling back to shared lets
+        a per-user write attach under a globally-known structural parent.
+        """
+        parent_uri = parsed.parent()
+        if parent_uri is None or parent_uri.is_root:
+            return ROOT_NODE_UUID
+
+        for ns in (namespace, "__shared__"):
+            parent_path = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == ns,
+                        Path.domain == parent_uri.domain,
+                        Path.path == parent_uri.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if parent_path is None:
+                continue
+            parent_edge = await s.get(Edge, parent_path.edge_id)
+            if parent_edge is not None:
+                return parent_edge.child_uuid
+
+        raise ValueError(
+            f"Parent path {parent_uri} does not exist in namespace "
+            f"{namespace!r} or '__shared__' — create the parent first."
+        )
 
     async def upsert_versioned(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -371,14 +371,45 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Optional[int] = None,
-        disclosure: Optional[str] = None,
+        priority: Any = _UNSET,
+        disclosure: Any = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 
-        At least one of ``priority``/``disclosure`` must be provided.
+        At least one of ``priority``/``disclosure`` must be provided. Pass
+        an explicit ``None`` to clear ``disclosure``. Memory rows and the
+        version chain are untouched; the search_documents row is refreshed
+        because priority and disclosure feed into search_terms.
         """
-        raise NotImplementedError("Task 3a.4")
+        if priority is _UNSET and disclosure is _UNSET:
+            raise ValueError(
+                "patch_edge_metadata requires at least one of priority "
+                "or disclosure to be set."
+            )
+
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            path_row = await self._fetch_path(s, namespace, parsed)
+            if path_row is None:
+                raise LookupError(
+                    f"Path for {parsed} in namespace {namespace!r} not found."
+                )
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                raise RuntimeError(
+                    f"Path {namespace}/{parsed} references a missing edge "
+                    f"— graph corruption."
+                )
+
+            if priority is not _UNSET:
+                edge.priority = priority
+            if disclosure is not _UNSET:
+                edge.disclosure = disclosure
+
+            await self._search.refresh_search_documents_for_node(
+                edge.child_uuid, session=s
+            )
 
     # ------------------------------------------------------------------
     # Read verbs (PR #3b)

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -139,8 +139,12 @@ class MemoryEngine:
         return self._db
 
     @property
-    def search(self) -> "SearchIndexer":
-        """The underlying ``SearchIndexer``."""
+    def search_indexer(self) -> "SearchIndexer":
+        """The underlying ``SearchIndexer``.
+
+        Note: not named ``search`` because the engine has a ``search``
+        verb (full-text query) that would shadow it.
+        """
         return self._search
 
     # ------------------------------------------------------------------

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import uuid as uuidlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +39,31 @@ if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
 
-_UNSET: Any = object()
+
+class _UnsetType:
+    """Sentinel class for "argument was not supplied".
+
+    Lets ``priority: int | None | _UnsetType`` distinguish
+    "preserve the current value" (sentinel) from
+    "set the value to None" (explicit None). A regular ``None`` default
+    can't tell those apart.
+    """
+
+    _instance: Optional["_UnsetType"] = None
+
+    def __new__(cls) -> "_UnsetType":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "_UNSET"
+
+
+_UNSET: _UnsetType = _UnsetType()
+
+PriorityArg = Union[int, _UnsetType]
+DisclosureArg = Union[Optional[str], _UnsetType]
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,8 +111,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> MemoryRef:
         """Overwrite-mode upsert: create-or-replace the active memory at (namespace, uri).
 
@@ -150,8 +174,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         edge = await s.get(Edge, path_row.edge_id)
         if edge is None:
@@ -173,14 +197,20 @@ class MemoryEngine:
         ).scalar_one_or_none()
 
         if memory is None:
-            # Edge exists but has no active memory — create one and attach.
-            memory = Memory(
-                node_uuid=edge.child_uuid, content=content, deprecated=False
+            # Edge exists but no active memory: a deprecated chain might
+            # exist with no successor (a crash window in upsert_versioned,
+            # or a direct DB poke). We deliberately do NOT silently
+            # fabricate a fresh active memory — that would disconnect a
+            # deprecated tail from any successor and lose audit lineage.
+            # Surface the corruption so callers can route to ReviewLog.
+            raise RuntimeError(
+                f"Path {path_row.namespace}/{path_row.domain}/{path_row.path} "
+                f"has no active memory but the edge persists; refusing to "
+                f"silently rebuild. Inspect the deprecated chain for node "
+                f"{edge.child_uuid} and resolve via ReviewLog before retrying."
             )
-            s.add(memory)
-            await s.flush()
-        else:
-            memory.content = content
+
+        memory.content = content
 
         if priority is not _UNSET:
             edge.priority = priority
@@ -195,8 +225,8 @@ class MemoryEngine:
         parsed: MemoryURI,
         namespace: str,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[int, str]:
         parent_uuid = await self._resolve_parent_node_uuid(s, parsed, namespace)
 
@@ -273,8 +303,8 @@ class MemoryEngine:
         content: str,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> VersionedMemoryRef:
         """Versioned upsert: deprecate the old Memory, insert a new one.
 
@@ -320,8 +350,8 @@ class MemoryEngine:
         s: AsyncSession,
         path_row: Path,
         content: str,
-        priority: Any,
-        disclosure: Any,
+        priority: PriorityArg,
+        disclosure: DisclosureArg,
     ) -> tuple[Optional[int], int, str]:
         """Insert a new active Memory and deprecate the previous active one.
 
@@ -371,8 +401,8 @@ class MemoryEngine:
         uri: str | MemoryURI,
         *,
         namespace: str,
-        priority: Any = _UNSET,
-        disclosure: Any = _UNSET,
+        priority: PriorityArg = _UNSET,
+        disclosure: DisclosureArg = _UNSET,
     ) -> None:
         """Update Edge metadata (priority, disclosure) without touching Memory.
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -37,7 +37,15 @@ from typing import TYPE_CHECKING, Optional, Union
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path, escape_like_literal
+from .models import (
+    ROOT_NODE_UUID,
+    SHARED_NAMESPACE,
+    Edge,
+    Memory,
+    Node,
+    Path,
+    escape_like_literal,
+)
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
@@ -110,9 +118,6 @@ class MemoryRecord:
     uri: str
     content: str
     loaded_namespace: str
-
-
-SHARED_NAMESPACE = "__shared__"
 
 
 class MemoryEngine:
@@ -286,41 +291,56 @@ class MemoryEngine:
 
         return memory.id, node_uuid
 
-    @staticmethod
     async def _resolve_parent_node_uuid(
-        s: AsyncSession, parsed: MemoryURI, namespace: str
+        self, s: AsyncSession, parsed: MemoryURI, namespace: str
     ) -> str:
         """Resolve the parent node UUID for a new path, with shared fallback.
 
         Top-level URIs (``core://agent``, ``analysis://sc-de``) attach to
         ROOT. Nested URIs require the parent path to exist either in the
-        current namespace or in ``__shared__``. Falling back to shared lets
-        a per-user write attach under a globally-known structural parent.
+        current namespace or in ``__shared__`` — falling back to shared
+        lets a per-user write attach under a globally-known parent.
         """
         parent_uri = parsed.parent()
         if parent_uri is None or parent_uri.is_root:
             return ROOT_NODE_UUID
 
-        for ns in (namespace, "__shared__"):
-            parent_path = (
+        uuid = await self._resolve_node_for_uri(s, parent_uri, namespace)
+        if uuid is None:
+            raise ValueError(
+                f"Parent path {parent_uri} does not exist in namespace "
+                f"{namespace!r} or '__shared__' — create the parent first."
+            )
+        return uuid
+
+    @staticmethod
+    async def _resolve_node_for_uri(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> Optional[str]:
+        """Look up the node UUID for ``parsed`` in ``(namespace, __shared__)``.
+
+        Returns the first match's ``child_uuid`` (which is the conceptual
+        node id), or ``None`` if neither namespace has the path. Used by
+        both the write-side parent resolver and the read-side listing
+        parent resolver — see CONTEXT.md for why the loop order matters
+        (per-namespace match wins over a shared one).
+        """
+        for ns in (namespace, SHARED_NAMESPACE):
+            path_row = (
                 await s.execute(
                     select(Path).where(
                         Path.namespace == ns,
-                        Path.domain == parent_uri.domain,
-                        Path.path == parent_uri.path,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
                     )
                 )
             ).scalar_one_or_none()
-            if parent_path is None:
+            if path_row is None:
                 continue
-            parent_edge = await s.get(Edge, parent_path.edge_id)
-            if parent_edge is not None:
-                return parent_edge.child_uuid
-
-        raise ValueError(
-            f"Parent path {parent_uri} does not exist in namespace "
-            f"{namespace!r} or '__shared__' — create the parent first."
-        )
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is not None:
+                return edge.child_uuid
+        return None
 
     async def upsert_versioned(
         self,
@@ -622,24 +642,15 @@ class MemoryEngine:
     async def _resolve_listing_parent(
         self, s: AsyncSession, parsed: MemoryURI, namespace: str
     ) -> Optional[str]:
-        """Return the parent's child_uuid, or None if the parent doesn't exist.
+        """Return the parent's child_uuid, or ``None`` if the path is missing.
 
-        For root URIs (path=""), returns ROOT_NODE_UUID directly. For
-        non-root URIs, looks the path up in ``namespace`` first, then
-        ``__shared__``. Listing through a missing parent returns no children.
+        For root URIs (path=""), returns ``ROOT_NODE_UUID`` directly.
+        Listing through a missing parent returns no children — strict
+        listings don't fail loudly, they just produce nothing.
         """
         if parsed.is_root:
             return ROOT_NODE_UUID
-
-        for ns in (namespace, SHARED_NAMESPACE):
-            parent_path = await self._fetch_path(s, ns, parsed)
-            if parent_path is None:
-                continue
-            parent_edge = await s.get(Edge, parent_path.edge_id)
-            if parent_edge is not None:
-                return parent_edge.child_uuid
-
-        return None
+        return await self._resolve_node_for_uri(s, parsed, namespace)
 
     async def _materialize_listing(
         self,
@@ -650,28 +661,43 @@ class MemoryEngine:
     ) -> list[MemoryRef]:
         """Turn a list of Path rows into MemoryRef objects.
 
-        Skips rows whose node has no active memory (a deprecated chain
-        with no successor — surfaces nothing rather than a half-result).
+        Shared by ``list_children`` and ``get_subtree``. Active-memory
+        lookup is batched to a single query so a 1000-row subtree pays
+        for 2 queries (one for paths, one for memories) instead of 1001.
+        Rows whose node has no active memory (a deprecated chain with no
+        successor) are silently skipped — surface nothing rather than a
+        half-result.
         """
+        if not path_rows:
+            return []
+
+        unique_uuids = {edge_id_to_child_uuid[p.edge_id] for p in path_rows}
+        memory_rows = (
+            await s.execute(
+                select(Memory.node_uuid, Memory.id).where(
+                    Memory.node_uuid.in_(unique_uuids),
+                    Memory.deprecated == False,  # noqa: E712
+                )
+            )
+        ).all()
+
+        # Pick max id per node — newest active wins on the rare path with
+        # multiple non-deprecated rows (shouldn't happen post-3a but the
+        # code is defensive at minimal cost).
+        active_by_node: dict[str, int] = {}
+        for node_uuid, mid in memory_rows:
+            if mid > active_by_node.get(node_uuid, -1):
+                active_by_node[node_uuid] = mid
+
         results: list[MemoryRef] = []
         for path_row in path_rows:
             child_uuid = edge_id_to_child_uuid[path_row.edge_id]
-            memory = (
-                await s.execute(
-                    select(Memory)
-                    .where(
-                        Memory.node_uuid == child_uuid,
-                        Memory.deprecated == False,  # noqa: E712
-                    )
-                    .order_by(Memory.id.desc())
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-            if memory is None:
+            memory_id = active_by_node.get(child_uuid)
+            if memory_id is None:
                 continue
             results.append(
                 MemoryRef(
-                    memory_id=memory.id,
+                    memory_id=memory_id,
                     node_uuid=child_uuid,
                     namespace=namespace,
                     uri=f"{path_row.domain}://{path_row.path}",

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -131,6 +131,18 @@ class MemoryEngine:
         self._db = db
         self._search = search
 
+    @property
+    def db(self) -> "DatabaseManager":
+        """The underlying ``DatabaseManager`` — exposed read-only so the
+        client and review layers can run their own short queries without
+        reaching into a private attribute."""
+        return self._db
+
+    @property
+    def search(self) -> "SearchIndexer":
+        """The underlying ``SearchIndexer``."""
+        return self._search
+
     # ------------------------------------------------------------------
     # Write verbs (PR #3a)
     # ------------------------------------------------------------------

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -575,7 +575,109 @@ class MemoryEngine:
     async def list_children(
         self, uri: str | MemoryURI, *, namespace: str
     ) -> list[MemoryRef]:
-        raise NotImplementedError("PR #3b")
+        """List direct children of ``uri`` strictly inside ``namespace``.
+
+        Strict semantics: a child only appears if it has a Path in
+        ``namespace``. Shared children of the same parent are intentionally
+        invisible — use ReviewLog.browse_shared (PR #4b) to see those.
+
+        The parent itself can live in ``namespace`` or in ``__shared__``;
+        we resolve the parent through the same fallback the writer uses,
+        so per-user children of shared parents (e.g., ``core://agent/style``
+        under shared ``core://agent``) list correctly.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            parent_uuid = await self._resolve_listing_parent(s, parsed, namespace)
+            if parent_uuid is None:
+                return []
+
+            child_edges = (
+                await s.execute(
+                    select(Edge).where(Edge.parent_uuid == parent_uuid)
+                )
+            ).scalars().all()
+            if not child_edges:
+                return []
+
+            edge_id_to_child_uuid = {e.id: e.child_uuid for e in child_edges}
+            edge_ids = list(edge_id_to_child_uuid)
+
+            path_rows = (
+                await s.execute(
+                    select(Path)
+                    .where(
+                        Path.namespace == namespace,
+                        Path.edge_id.in_(edge_ids),
+                    )
+                    .order_by(Path.path)
+                )
+            ).scalars().all()
+
+            return await self._materialize_listing(
+                s, path_rows, edge_id_to_child_uuid, namespace
+            )
+
+    async def _resolve_listing_parent(
+        self, s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> Optional[str]:
+        """Return the parent's child_uuid, or None if the parent doesn't exist.
+
+        For root URIs (path=""), returns ROOT_NODE_UUID directly. For
+        non-root URIs, looks the path up in ``namespace`` first, then
+        ``__shared__``. Listing through a missing parent returns no children.
+        """
+        if parsed.is_root:
+            return ROOT_NODE_UUID
+
+        for ns in (namespace, SHARED_NAMESPACE):
+            parent_path = await self._fetch_path(s, ns, parsed)
+            if parent_path is None:
+                continue
+            parent_edge = await s.get(Edge, parent_path.edge_id)
+            if parent_edge is not None:
+                return parent_edge.child_uuid
+
+        return None
+
+    async def _materialize_listing(
+        self,
+        s: AsyncSession,
+        path_rows: list[Path],
+        edge_id_to_child_uuid: dict[int, str],
+        namespace: str,
+    ) -> list[MemoryRef]:
+        """Turn a list of Path rows into MemoryRef objects.
+
+        Skips rows whose node has no active memory (a deprecated chain
+        with no successor — surfaces nothing rather than a half-result).
+        """
+        results: list[MemoryRef] = []
+        for path_row in path_rows:
+            child_uuid = edge_id_to_child_uuid[path_row.edge_id]
+            memory = (
+                await s.execute(
+                    select(Memory)
+                    .where(
+                        Memory.node_uuid == child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    )
+                    .order_by(Memory.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if memory is None:
+                continue
+            results.append(
+                MemoryRef(
+                    memory_id=memory.id,
+                    node_uuid=child_uuid,
+                    namespace=namespace,
+                    uri=f"{path_row.domain}://{path_row.path}",
+                )
+            )
+        return results
 
     async def get_subtree(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -8,19 +8,24 @@ only layer that touches those tables directly.
 
 Above it sits ``MemoryClient`` (strategy: which namespace, version vs.
 overwrite); below it sits the ORM. The legacy ``GraphService`` is
-unaffected during PR #3a — see ``docs/2026-05-09-memory-refactor-plan.md``
+unaffected during PR #3a/#3b — see ``docs/2026-05-09-memory-refactor-plan.md``
 for the full migration path.
 
-Verbs landed in this PR (PR #3a):
+Write verbs (PR #3a):
     - upsert(uri, content, namespace, ...)
     - upsert_versioned(uri, content, namespace, ...)
     - patch_edge_metadata(uri, namespace, ...)
 
-Verbs reserved for PR #3b:
-    - recall(uri, namespace, ...)
-    - search(query, namespace, ...)
-    - list_children(uri, namespace)
-    - get_subtree(uri, namespace, ...)
+Read verbs (PR #3b):
+    - recall(uri, namespace, ...)             — single-row fetch with shared fallback
+    - search(query, namespace, ...)           — FTS over (namespace, __shared__)
+    - list_children(uri, namespace)           — strict-namespace children
+    - get_subtree(uri, namespace, ...)        — flat listing under a prefix
+
+Read-fallback policy (CONTEXT.md): ``recall`` and ``search`` fall back to
+``__shared__`` so per-user contexts can see globally-shared content;
+``list_children`` and ``get_subtree`` are strict so a user's listing
+doesn't get polluted by shared structure they didn't ask for.
 """
 
 from __future__ import annotations
@@ -88,6 +93,26 @@ class VersionedMemoryRef:
     node_uuid: str
     namespace: str
     uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecord:
+    """Materialized result of ``recall``.
+
+    ``namespace`` is the namespace the caller asked for; ``loaded_namespace``
+    is the namespace the row actually came from. They differ when the read
+    fell back to ``__shared__`` because the per-user namespace had no match.
+    """
+
+    memory_id: int
+    node_uuid: str
+    namespace: str
+    uri: str
+    content: str
+    loaded_namespace: str
+
+
+SHARED_NAMESPACE = "__shared__"
 
 
 class MemoryEngine:
@@ -451,8 +476,83 @@ class MemoryEngine:
         *,
         namespace: str,
         fallback_to_shared: bool = True,
-    ) -> Optional[Any]:
-        raise NotImplementedError("PR #3b")
+    ) -> Optional[MemoryRecord]:
+        """Fetch the active memory at ``(namespace, uri)``.
+
+        Returns ``None`` if no active memory exists. When the per-namespace
+        lookup misses and ``fallback_to_shared=True`` (the default), falls
+        back to ``__shared__`` — this is how per-user contexts see
+        globally-shared content like ``core://agent``.
+
+        ``MemoryRecord.loaded_namespace`` records which namespace produced
+        the row (the caller-supplied one or ``__shared__``).
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        canonical = str(parsed)
+
+        async with self._db.session() as s:
+            record = await self._recall_in_namespace(s, parsed, canonical, namespace)
+            if record is not None:
+                return record
+
+            if (
+                fallback_to_shared
+                and namespace != SHARED_NAMESPACE
+            ):
+                shared = await self._recall_in_namespace(
+                    s, parsed, canonical, SHARED_NAMESPACE
+                )
+                if shared is not None:
+                    # Echo the caller's requested namespace; tag origin separately.
+                    return MemoryRecord(
+                        memory_id=shared.memory_id,
+                        node_uuid=shared.node_uuid,
+                        namespace=namespace,
+                        uri=canonical,
+                        content=shared.content,
+                        loaded_namespace=SHARED_NAMESPACE,
+                    )
+
+        return None
+
+    async def _recall_in_namespace(
+        self,
+        s: AsyncSession,
+        parsed: MemoryURI,
+        canonical: str,
+        namespace: str,
+    ) -> Optional[MemoryRecord]:
+        """Fetch the active memory for ``(namespace, parsed)`` or ``None``."""
+        path_row = await self._fetch_path(s, namespace, parsed)
+        if path_row is None:
+            return None
+
+        edge = await s.get(Edge, path_row.edge_id)
+        if edge is None:
+            return None
+
+        memory = (
+            await s.execute(
+                select(Memory)
+                .where(
+                    Memory.node_uuid == edge.child_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .order_by(Memory.id.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if memory is None:
+            return None
+
+        return MemoryRecord(
+            memory_id=memory.id,
+            node_uuid=edge.child_uuid,
+            namespace=namespace,
+            uri=canonical,
+            content=memory.content,
+            loaded_namespace=namespace,
+        )
 
     async def search(
         self,

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -34,10 +34,10 @@ import uuid as uuidlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path
+from .models import ROOT_NODE_UUID, Edge, Memory, Node, Path, escape_like_literal
 from .uri import MemoryURI
 
 if TYPE_CHECKING:
@@ -686,4 +686,40 @@ class MemoryEngine:
         namespace: str,
         limit: int = 100,
     ) -> list[MemoryRef]:
-        raise NotImplementedError("PR #3b")
+        """Flat list of MemoryRef under ``(namespace, uri)`` up to ``limit``.
+
+        Includes the prefix URI itself plus all descendants. Strict
+        namespace — no shared fallback. Sorted lexicographically by path
+        for deterministic output. A root URI (``analysis://``) lists every
+        path in the namespace under that domain.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._db.session() as s:
+            stmt = select(Path).where(
+                Path.namespace == namespace,
+                Path.domain == parsed.domain,
+            )
+            if not parsed.is_root:
+                base = parsed.path
+                safe = escape_like_literal(base)
+                stmt = stmt.where(
+                    or_(
+                        Path.path == base,
+                        Path.path.like(f"{safe}/%", escape="\\"),
+                    )
+                )
+            stmt = stmt.order_by(Path.path).limit(limit)
+            path_rows = (await s.execute(stmt)).scalars().all()
+            if not path_rows:
+                return []
+
+            edge_ids = [p.edge_id for p in path_rows]
+            edges = (
+                await s.execute(select(Edge).where(Edge.id.in_(edge_ids)))
+            ).scalars().all()
+            edge_id_to_child = {e.id: e.child_uuid for e in edges}
+
+            return await self._materialize_listing(
+                s, list(path_rows), edge_id_to_child, namespace
+            )

--- a/omicsclaw/memory/glossary.py
+++ b/omicsclaw/memory/glossary.py
@@ -10,7 +10,8 @@ Aho-Corasick-based content scanning for keyword highlighting.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, Any, List, TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from sqlalchemy import select, delete, and_, func
 from sqlalchemy.exc import IntegrityError
@@ -21,12 +22,26 @@ from .models import (
     Path,
     Memory,
     GlossaryKeyword,
+    SHARED_NAMESPACE,
     serialize_row,
 )
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
     from .search import SearchIndexer
+
+
+@dataclass(frozen=True)
+class _KeywordUniverse:
+    """Snapshot of the glossary keywords visible from a given namespace.
+
+    ``fingerprint`` is a (count, max_id, max_created_at) triple used to
+    detect that the cache is stale; ``keywords`` is the de-duplicated
+    keyword list to feed Aho-Corasick.
+    """
+
+    keywords: List[str]
+    fingerprint: tuple
 
 
 class GlossaryService:
@@ -40,13 +55,21 @@ class GlossaryService:
     def __init__(self, db: "DatabaseManager", search_indexer: "SearchIndexer"):
         self._session = db.session
         self._search = search_indexer
-        self._automaton = None
-        self._fingerprint = None
+        # Per-namespace automaton cache. Key is the namespace string or
+        # the literal "__all__" for the legacy unscoped scan.
+        self._automatons: Dict[str, Any] = {}
+        self._fingerprints: Dict[str, tuple] = {}
 
     async def add_glossary_keyword(
-        self, keyword: str, node_uuid: str
+        self, keyword: str, node_uuid: str, namespace: str = SHARED_NAMESPACE
     ) -> Dict[str, Any]:
-        """Bind a glossary keyword to a node."""
+        """Bind a glossary keyword to a node inside ``namespace``.
+
+        ``namespace`` defaults to ``__shared__`` so legacy callers that
+        haven't migrated keep writing into the global partition. Pass an
+        explicit namespace to scope a keyword to one user/surface; or use
+        ``add_glossary_shared`` for clarity.
+        """
         keyword = keyword.strip()
         if not keyword:
             raise ValueError("Glossary keyword cannot be empty")
@@ -56,13 +79,18 @@ class GlossaryService:
             if not node:
                 raise ValueError(f"Node '{node_uuid}' not found")
 
-            entry = GlossaryKeyword(keyword=keyword, node_uuid=node_uuid)
+            entry = GlossaryKeyword(
+                keyword=keyword, node_uuid=node_uuid, namespace=namespace
+            )
             session.add(entry)
 
             try:
                 await session.flush()
             except IntegrityError:
-                raise ValueError(f"Keyword '{keyword}' is already bound to this node")
+                raise ValueError(
+                    f"Keyword '{keyword}' is already bound to this node "
+                    f"in namespace '{namespace}'"
+                )
 
             await self._search.refresh_search_documents_for_node(
                 node_uuid, session=session
@@ -74,20 +102,41 @@ class GlossaryService:
                 "id": entry.id,
                 "keyword": keyword,
                 "node_uuid": node_uuid,
+                "namespace": namespace,
                 "rows_before": {"glossary_keywords": []},
                 "rows_after": {"glossary_keywords": [row_after]},
             }
 
-    async def remove_glossary_keyword(
+    async def add_glossary_shared(
         self, keyword: str, node_uuid: str
     ) -> Dict[str, Any]:
-        """Remove a glossary keyword binding."""
+        """Bind a globally-visible glossary keyword (namespace=__shared__).
+
+        Sugar for ``add_glossary_keyword(..., namespace=SHARED_NAMESPACE)``,
+        intended for callers that want to be explicit about the global
+        scope rather than relying on the default.
+        """
+        return await self.add_glossary_keyword(
+            keyword, node_uuid, namespace=SHARED_NAMESPACE
+        )
+
+    async def remove_glossary_keyword(
+        self, keyword: str, node_uuid: str, namespace: str = SHARED_NAMESPACE
+    ) -> Dict[str, Any]:
+        """Remove a glossary keyword binding within one namespace.
+
+        Default ``__shared__`` matches the legacy callsite, which had no
+        namespace concept. Removal is now namespace-scoped — pass an
+        explicit namespace to remove a per-user binding without touching
+        shared or other-user bindings of the same (keyword, node_uuid).
+        """
         keyword = keyword.strip()
         async with self._session() as session:
             existing = await session.execute(
                 select(GlossaryKeyword).where(
                     GlossaryKeyword.keyword == keyword,
                     GlossaryKeyword.node_uuid == node_uuid,
+                    GlossaryKeyword.namespace == namespace,
                 )
             )
             entry = existing.scalar_one_or_none()
@@ -173,86 +222,112 @@ class GlossaryService:
             ]
 
     async def find_glossary_in_content(
-        self, content: str
+        self,
+        content: str,
+        namespace: Optional[str] = None,
     ) -> Dict[str, List[Dict[str, str]]]:
         """Scan content for glossary keywords using Aho-Corasick.
 
-        Uses a DB-level fingerprint to detect staleness.
-        Returns dict of keyword -> list of {node_uuid, uri} for matches found.
+        When ``namespace`` is provided, restricts the keyword universe to
+        ``(namespace, __shared__)`` — that's how the search reindexer
+        avoids cross-namespace keyword leaks. ``namespace=None`` preserves
+        the legacy "match anything in the DB" behaviour.
+
+        The Aho-Corasick automaton is built per namespace key and cached
+        with a DB-level fingerprint so repeated scans don't repeatedly
+        rebuild. ``namespace=None`` still uses the same cache slot.
         """
         try:
             import ahocorasick
         except ImportError:
             # ahocorasick not installed — fall back to simple substring matching
-            return await self._find_glossary_simple(content)
+            return await self._find_glossary_simple(content, namespace=namespace)
 
-        async with self._session() as session:
-            fp_row = await session.execute(
-                select(
-                    func.count(GlossaryKeyword.id),
-                    func.coalesce(func.max(GlossaryKeyword.id), 0),
-                    func.max(GlossaryKeyword.created_at),
-                )
-            )
-            current_fp = tuple(fp_row.one())
+        keyword_universe = await self._fetch_keyword_universe(namespace)
 
-        if current_fp[0] == 0:
-            self._automaton = None
-            self._fingerprint = current_fp
-            return {}
-
-        if current_fp != self._fingerprint:
-            async with self._session() as session:
-                kw_result = await session.execute(
-                    select(GlossaryKeyword.keyword).distinct()
-                )
-                all_keywords = [row[0] for row in kw_result.all()]
-
-            if not all_keywords:
-                self._automaton = None
+        # Cache the automaton keyed by namespace so different scopes don't
+        # invalidate each other's caches every call.
+        cache_key = namespace if namespace is not None else "__all__"
+        cached_fp = self._fingerprints.get(cache_key)
+        if keyword_universe.fingerprint != cached_fp:
+            if not keyword_universe.keywords:
+                self._automatons[cache_key] = None
             else:
                 automaton = ahocorasick.Automaton()
-                for kw in all_keywords:
+                for kw in keyword_universe.keywords:
                     automaton.add_word(kw, kw)
                 automaton.make_automaton()
-                self._automaton = automaton
+                self._automatons[cache_key] = automaton
+            self._fingerprints[cache_key] = keyword_universe.fingerprint
 
-            self._fingerprint = current_fp
-
-        if self._automaton is None:
+        automaton = self._automatons.get(cache_key)
+        if automaton is None:
             return {}
 
         found_keywords: set = set()
-        for _, kw in self._automaton.iter(content):
+        for _, kw in automaton.iter(content):
             found_keywords.add(kw)
 
         if not found_keywords:
             return {}
 
-        return await self._resolve_keyword_nodes(found_keywords)
+        return await self._resolve_keyword_nodes(found_keywords, namespace=namespace)
 
     async def _find_glossary_simple(
-        self, content: str
+        self,
+        content: str,
+        namespace: Optional[str] = None,
     ) -> Dict[str, List[Dict[str, str]]]:
         """Fallback: simple substring matching when ahocorasick is unavailable."""
-        async with self._session() as session:
-            kw_result = await session.execute(
-                select(GlossaryKeyword.keyword).distinct()
-            )
-            all_keywords = [row[0] for row in kw_result.all()]
-
-        found_keywords = {kw for kw in all_keywords if kw in content}
+        keyword_universe = await self._fetch_keyword_universe(namespace)
+        found_keywords = {
+            kw for kw in keyword_universe.keywords if kw in content
+        }
         if not found_keywords:
             return {}
+        return await self._resolve_keyword_nodes(found_keywords, namespace=namespace)
 
-        return await self._resolve_keyword_nodes(found_keywords)
+    async def _fetch_keyword_universe(
+        self, namespace: Optional[str]
+    ) -> "_KeywordUniverse":
+        """Pull the keywords + fingerprint visible from ``namespace``.
+
+        ``namespace=None`` returns every keyword (legacy behaviour).
+        Otherwise restricts to ``(namespace, __shared__)``.
+        """
+        async with self._session() as session:
+            stmt_count = select(
+                func.count(GlossaryKeyword.id),
+                func.coalesce(func.max(GlossaryKeyword.id), 0),
+                func.max(GlossaryKeyword.created_at),
+            )
+            stmt_keys = select(GlossaryKeyword.keyword).distinct()
+            if namespace is not None:
+                ns_filter = GlossaryKeyword.namespace.in_(
+                    [namespace, SHARED_NAMESPACE]
+                )
+                stmt_count = stmt_count.where(ns_filter)
+                stmt_keys = stmt_keys.where(ns_filter)
+
+            fp_row = await session.execute(stmt_count)
+            fingerprint = tuple(fp_row.one())
+
+            kw_result = await session.execute(stmt_keys)
+            keywords = [row[0] for row in kw_result.all()]
+
+        return _KeywordUniverse(keywords=keywords, fingerprint=fingerprint)
 
     async def _resolve_keyword_nodes(
-        self, found_keywords: set
+        self, found_keywords: set, namespace: Optional[str] = None
     ) -> Dict[str, List[Dict[str, str]]]:
-        """Resolve found keywords to their node UUIDs and URIs."""
+        """Resolve found keywords to their node UUIDs and URIs.
+
+        If ``namespace`` is provided, only resolves keywords scoped to
+        ``(namespace, __shared__)`` so a user-scoped scan can't leak the
+        existence of a foreign-namespace keyword.
+        """
         async with self._session() as session:
-            result = await session.execute(
+            stmt = (
                 select(
                     GlossaryKeyword.keyword,
                     GlossaryKeyword.node_uuid,
@@ -265,6 +340,11 @@ class GlossaryService:
                 .where(GlossaryKeyword.keyword.in_(found_keywords))
                 .order_by(GlossaryKeyword.keyword, Path.domain, Path.path)
             )
+            if namespace is not None:
+                stmt = stmt.where(
+                    GlossaryKeyword.namespace.in_([namespace, SHARED_NAMESPACE])
+                )
+            result = await session.execute(stmt)
 
             matches: Dict[str, Dict[str, str]] = defaultdict(dict)
             for keyword, node_uuid, domain, path in result.all():

--- a/omicsclaw/memory/graph.py
+++ b/omicsclaw/memory/graph.py
@@ -28,8 +28,10 @@ from sqlalchemy import (
     not_,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from .engine import MemoryEngine
 from .models import (
     ROOT_NODE_UUID,
+    SHARED_NAMESPACE,
     Node,
     Memory,
     Edge,
@@ -67,6 +69,11 @@ class GraphService:
         self.session = db.session
         self._optional_session = db._optional_session
         self._search = search
+        # Transitional shim (PR #3c): the mutating verbs delegate to
+        # MemoryEngine with namespace='__shared__', preserving the legacy
+        # observable behaviour. PR #6 deletes the shim entirely once
+        # callers have moved to MemoryClient/MemoryEngine directly.
+        self._engine = MemoryEngine(db, search)
 
     @staticmethod
     def _decode_legacy(content: str) -> str:
@@ -900,7 +907,14 @@ class GraphService:
         Create a new memory under a parent path.
 
         Creates: Node -> Memory -> Edge (parent->child) -> Path.
+
+        PR #3c shim: delegates the actual write to ``MemoryEngine.upsert_versioned``
+        with ``namespace='__shared__'``. The path-computation policy
+        (auto-numbering when ``title`` is omitted, the duplicate-path check)
+        stays here because it has no engine equivalent. PR #6 removes the
+        shim once callers move to ``MemoryClient`` / ``MemoryEngine`` directly.
         """
+        # Pre-flight: resolve parent, compute final path, reject duplicates.
         async with self.session() as session:
             if not parent_path:
                 parent_uuid = ROOT_NODE_UUID
@@ -922,43 +936,56 @@ class GraphService:
                 )
 
             existing = await session.execute(
-                select(Path).where(Path.domain == domain, Path.path == final_path)
+                select(Path).where(
+                    Path.namespace == SHARED_NAMESPACE,
+                    Path.domain == domain,
+                    Path.path == final_path,
+                )
             )
             if existing.scalar_one_or_none():
                 raise ValueError(f"Path '{domain}://{final_path}' already exists")
 
-            new_uuid = str(uuid_lib.uuid4())
-            node = await self._ensure_node(session, new_uuid)
-            memory = await self._insert_memory(session, new_uuid, content)
+        # Delegate the row-creating part to MemoryEngine. Engine produces
+        # Node + Memory + Edge + Path inside ``__shared__`` and refreshes
+        # the search index. Returned ref carries memory_id and node_uuid.
+        ref = await self._engine.upsert_versioned(
+            f"{domain}://{final_path}",
+            content,
+            namespace=SHARED_NAMESPACE,
+            priority=priority,
+            disclosure=disclosure,
+        )
 
-            edge_name = title if title else final_path.rsplit("/", 1)[-1]
-            created = await self._create_edge_with_paths(
-                session,
-                parent_uuid,
-                new_uuid,
-                edge_name,
-                domain,
-                final_path,
-                priority,
-                disclosure,
-            )
+        # Re-fetch the four rows we just created so the caller's changeset
+        # bookkeeping (rows_after) gets the canonical serialised shape.
+        async with self.session() as session:
+            path_row = (
+                await session.execute(
+                    select(Path).where(
+                        Path.namespace == SHARED_NAMESPACE,
+                        Path.domain == domain,
+                        Path.path == final_path,
+                    )
+                )
+            ).scalar_one()
+            edge = await session.get(Edge, path_row.edge_id)
+            node = await session.get(Node, ref.node_uuid)
+            memory = await session.get(Memory, ref.new_memory_id)
 
-            await self._search.refresh_search_documents_for_node(new_uuid, session=session)
-
-            return {
-                "id": memory.id,
-                "node_uuid": new_uuid,
-                "domain": domain,
-                "path": final_path,
-                "uri": f"{domain}://{final_path}",
-                "priority": priority,
-                "rows_after": {
-                    "nodes": [serialize_row(node)],
-                    "memories": [serialize_memory_ref(memory)],
-                    "edges": [serialize_row(created["edge"])],
-                    "paths": [serialize_row(created["path"])],
-                },
-            }
+        return {
+            "id": ref.new_memory_id,
+            "node_uuid": ref.node_uuid,
+            "domain": domain,
+            "path": final_path,
+            "uri": f"{domain}://{final_path}",
+            "priority": priority,
+            "rows_after": {
+                "nodes": [serialize_row(node)],
+                "memories": [serialize_memory_ref(memory)],
+                "edges": [serialize_row(edge)],
+                "paths": [serialize_row(path_row)],
+            },
+        }
 
     async def update_memory(
         self,
@@ -971,8 +998,17 @@ class GraphService:
         """
         Update a memory.
 
-        Content change -> new Memory row with the same node_uuid.
+        Content change -> new Memory row with the same node_uuid (deprecation chain).
         Metadata change -> update the Edge directly.
+
+        PR #3c shim: delegates to ``MemoryEngine.upsert_versioned`` (when
+        content changes) or ``MemoryEngine.patch_edge_metadata`` (metadata
+        only) with ``namespace='__shared__'``. Pre-flight resolves the
+        path and snapshots ``rows_before``; post-flight re-fetches to
+        build ``rows_after``. The ``priority``/``disclosure`` defaults of
+        ``None`` mean "preserve" in the legacy contract — we translate
+        that into the engine's ``_UNSET`` sentinel by simply omitting
+        unset kwargs from the engine call.
         """
         if path == "":
             raise ValueError("Cannot update the root node.")
@@ -983,6 +1019,7 @@ class GraphService:
                 "At least one of content, priority, or disclosure must be set."
             )
 
+        # Pre-flight: snapshot the current edge + active memory.
         async with self.session() as session:
             result = await session.execute(
                 select(Memory, Edge, Path)
@@ -995,81 +1032,81 @@ class GraphService:
                         Memory.deprecated == False,
                     ),
                 )
-                .where(Path.domain == domain, Path.path == path)
+                .where(
+                    Path.namespace == SHARED_NAMESPACE,
+                    Path.domain == domain,
+                    Path.path == path,
+                )
                 .order_by(Memory.created_at.desc())
                 .limit(1)
             )
             row = result.first()
-
             if not row:
                 raise ValueError(
                     f"Path '{domain}://{path}' not found or memory is deprecated"
                 )
-
-            old_memory, edge, path_obj = row
+            old_memory, edge, _ = row
             old_id = old_memory.id
+            edge_id = edge.id
             node_uuid = edge.child_uuid
-
-            rows_before: Dict[str, list] = {}
-            rows_after: Dict[str, list] = {}
-
             edge_before = serialize_row(edge)
+            old_memory_ref = serialize_memory_ref(old_memory)
 
-            if priority is not None:
-                edge.priority = priority
-                session.add(edge)
-            if disclosure is not None:
-                edge.disclosure = disclosure
-                session.add(edge)
+        # Translate legacy "None means preserve" into engine's _UNSET via
+        # kwargs omission. Engine helpers preserve current values when an
+        # arg isn't supplied.
+        engine_kwargs: Dict[str, Any] = {}
+        if priority is not None:
+            engine_kwargs["priority"] = priority
+        if disclosure is not None:
+            engine_kwargs["disclosure"] = disclosure
 
-            edge_after = serialize_row(edge)
+        if content is not None:
+            ref = await self._engine.upsert_versioned(
+                f"{domain}://{path}",
+                content,
+                namespace=SHARED_NAMESPACE,
+                **engine_kwargs,
+            )
+            new_memory_id = ref.new_memory_id
+        else:
+            await self._engine.patch_edge_metadata(
+                f"{domain}://{path}",
+                namespace=SHARED_NAMESPACE,
+                **engine_kwargs,
+            )
+            new_memory_id = old_id
+
+        # Post-flight: re-fetch updated rows for changeset bookkeeping.
+        rows_before: Dict[str, list] = {}
+        rows_after: Dict[str, list] = {}
+
+        async with self.session() as session:
+            edge_after_obj = await session.get(Edge, edge_id)
+            edge_after = serialize_row(edge_after_obj)
             if edge_before != edge_after:
                 rows_before["edges"] = [edge_before]
                 rows_after["edges"] = [edge_after]
 
-            new_memory_id = old_id
-
             if content is not None:
-                rows_before["memories"] = [serialize_memory_ref(old_memory)]
-
-                new_memory = await self._insert_memory(
-                    session, node_uuid, content, deprecated=True
-                )
-                new_memory_id = new_memory.id
-                await self._deprecate_node_memories(
-                    session,
-                    node_uuid,
-                    successor_id=new_memory_id,
-                )
-                await session.execute(
-                    update(Memory)
-                    .where(Memory.id == new_memory_id)
-                    .values(deprecated=False, migrated_to=None)
-                )
-
-                await session.flush()
-                updated = await session.execute(
-                    select(Memory).where(Memory.id.in_([old_id, new_memory_id]))
-                )
+                rows_before["memories"] = [old_memory_ref]
+                old_after = await session.get(Memory, old_id)
+                new_after = await session.get(Memory, new_memory_id)
                 rows_after["memories"] = [
-                    serialize_memory_ref(m) for m in updated.scalars().all()
+                    serialize_memory_ref(old_after),
+                    serialize_memory_ref(new_after),
                 ]
 
-            if content is None:
-                session.add(path_obj)
-
-            await self._search.refresh_search_documents_for_node(node_uuid, session=session)
-
-            return {
-                "domain": domain,
-                "path": path,
-                "uri": f"{domain}://{path}",
-                "old_memory_id": old_id,
-                "new_memory_id": new_memory_id,
-                "node_uuid": node_uuid,
-                "rows_before": rows_before,
-                "rows_after": rows_after,
-            }
+        return {
+            "domain": domain,
+            "path": path,
+            "uri": f"{domain}://{path}",
+            "old_memory_id": old_id,
+            "new_memory_id": new_memory_id,
+            "node_uuid": node_uuid,
+            "rows_before": rows_before,
+            "rows_after": rows_after,
+        }
 
     async def rollback_to_memory(
         self, target_memory_id: int, session: Optional[AsyncSession] = None

--- a/omicsclaw/memory/graph.py
+++ b/omicsclaw/memory/graph.py
@@ -13,6 +13,20 @@ Graph-based memory storage with:
 
 All infrastructure (engine, session, migrations) lives in database.py.
 This module contains only graph-domain business logic.
+
+TODO(post-PR #6): retire this module per refactor plan §6.2. Five
+call sites still depend on its non-engine verbs:
+
+  * ``omicsclaw/app/server.py`` — ``/memory/update``,
+    ``/memory/children``, ``/memory/domains``
+  * ``omicsclaw/memory/memory_client.py`` — ``forget``, ``get_recent``
+
+Migrating these requires breaking-API surface work that was deferred
+out of PR #6's documentation-only scope. Once those callers move to
+``MemoryEngine`` / ``ReviewLog``, this whole file can be deleted.
+The shim's ``create_memory`` and ``update_memory`` already route
+through ``MemoryEngine.upsert_versioned`` (see PR #3c), so the
+remaining surface is small.
 """
 
 import uuid as uuid_lib

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -374,7 +374,7 @@ class MemoryClient:
         from .graph import GraphService
 
         assert self._engine is not None
-        graph = GraphService(self._engine.db, self._engine.search)
+        graph = GraphService(self._engine.db, self._engine.search_indexer)
         return await graph.get_recent_memories(limit=limit)
 
     async def forget(self, uri: str) -> Dict[str, Any]:
@@ -390,7 +390,7 @@ class MemoryClient:
 
         parsed = MemoryURI.parse(uri)
         assert self._engine is not None
-        graph = GraphService(self._engine.db, self._engine.search)
+        graph = GraphService(self._engine.db, self._engine.search_indexer)
         result = await graph.remove_path(path=parsed.path, domain=parsed.domain)
 
         try:

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -1,85 +1,120 @@
+"""MemoryClient — namespace-aware strategy layer over MemoryEngine.
+
+This is the layer above ``MemoryEngine``: it owns the **strategy** of
+"which namespace, versioned or overwrite" and decides which engine verb
+to call. ``MemoryEngine`` itself stays mechanical — it does not know
+about user identity or routing policy.
+
+Two construction modes:
+
+  - ``MemoryClient(engine=eng, namespace="tg/userA")``
+        Lightweight, share an engine across many clients (one per user
+        or per surface). This is the recommended form for new code.
+
+  - ``MemoryClient(database_url="sqlite+aiosqlite:///...")``
+        Backward-compat: builds an internal db + search + engine on
+        ``initialize()``. Used by the three pre-existing callers
+        (CompatMemoryStore, server.py boot, and the doc example).
+
+Routing for ``remember(uri, content)``:
+
+  - ``namespace_policy.resolve_namespace(uri, current=...)`` decides
+    where the row goes — shared (``core://agent``, ``core://kh/*``,
+    ``core://my_user_default``) or the client's current namespace.
+  - ``namespace_policy.should_version(uri)`` decides whether to call
+    ``engine.upsert_versioned`` (audit trail) or ``engine.upsert``
+    (overwrite).
+
+The audit-UI changeset capture (``snapshot.get_changeset_store``) still
+fires on every ``remember`` and ``forget`` so the Review pane keeps
+working unchanged for existing callers.
 """
-MemoryClient — High-level memory API for OmicsClaw multi-agent pipelines.
 
-Provides a simple, intuitive interface for agents to store and retrieve
-memories without needing to understand the underlying graph structure.
-
-Usage:
-    client = MemoryClient()
-    await client.initialize()
-
-    # Store a memory
-    await client.remember(
-        uri="project://current_research",
-        content="Studying TME in PDAC using spatial transcriptomics",
-        disclosure="When discussing this research project",
-    )
-
-    # Retrieve a memory
-    ctx = await client.recall("project://current_research")
-
-    # Search across memories
-    results = await client.search("spatial transcriptomics")
-
-    # Boot: load core identity and context
-    boot_ctx = await client.boot()
-"""
+from __future__ import annotations
 
 import os
-from typing import Optional, Dict, Any, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from .engine import MemoryEngine, MemoryRecord
+from .models import (
+    SHARED_NAMESPACE,
+    Edge,
+    Memory,
+    Node,
+    Path,
+    serialize_memory_ref,
+    serialize_row,
+)
+from .namespace_policy import resolve_namespace, should_version
+from .uri import MemoryURI
 
-def _parse_uri(uri: str) -> tuple:
-    """Parse a URI like 'domain://path' into (domain, path)."""
-    if "://" in uri:
-        domain, path = uri.split("://", 1)
-        return domain, path
-    return "core", uri
+if TYPE_CHECKING:
+    from .database import DatabaseManager
+    from .search import SearchIndexer
 
 
 class MemoryClient:
-    """High-level memory API for multi-agent pipelines.
+    """Namespace-aware strategy layer over MemoryEngine.
 
-    Wraps GraphService with a simple URI-based interface.
+    See module docstring for the construction modes and routing policy.
     """
 
-    def __init__(self, database_url: Optional[str] = None):
-        self._db_url = database_url
-        self._initialized = False
-        self._graph = None
-        self._search = None
-        self._db = None
+    def __init__(
+        self,
+        database_url: Optional[str] = None,
+        *,
+        engine: Optional[MemoryEngine] = None,
+        namespace: str = SHARED_NAMESPACE,
+    ):
+        if engine is not None and database_url is not None:
+            raise ValueError(
+                "Pass either engine or database_url, not both."
+            )
 
-    async def initialize(self):
-        """Initialize the database and services."""
+        self._namespace = namespace
+        self._engine: Optional[MemoryEngine] = engine
+        self._db_url = database_url
+        self._db: Optional["DatabaseManager"] = None
+        self._search: Optional["SearchIndexer"] = None
+        # If an engine was supplied, this client is ready to use; the
+        # legacy database_url path requires an explicit ``initialize()``.
+        self._initialized = engine is not None
+        self._owns_db = engine is None
+
+    @property
+    def namespace(self) -> str:
+        """The namespace this client writes/reads in by default."""
+        return self._namespace
+
+    async def initialize(self) -> None:
+        """Build the internal db/search/engine when constructed from a URL.
+
+        No-op when the engine was supplied at construction time.
+        """
         if self._initialized:
             return
 
         from .database import DatabaseManager
         from .search import SearchIndexer
-        from .glossary import GlossaryService
-        from .graph import GraphService
 
         self._db = DatabaseManager(self._db_url)
         await self._db.init_db()
-
         self._search = SearchIndexer(self._db)
-        glossary = GlossaryService(self._db, self._search)
-        self._graph = GraphService(self._db, self._search)
+        self._engine = MemoryEngine(self._db, self._search)
         self._initialized = True
 
-    async def _ensure_init(self):
+    async def _ensure_init(self) -> None:
         if not self._initialized:
             await self.initialize()
 
-    async def close(self):
-        """Close the database connection."""
-        if self._db:
+    async def close(self) -> None:
+        """Close the internal db connection if this client owns it."""
+        if self._owns_db and self._db is not None:
             await self._db.close()
         self._initialized = False
 
     # ------------------------------------------------------------------
-    # Core API
+    # Write verbs
     # ------------------------------------------------------------------
 
     async def remember(
@@ -89,103 +124,190 @@ class MemoryClient:
         priority: int = 0,
         disclosure: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Store or update a memory at the given URI.
+        """Store or update a memory at ``uri``.
 
-        If the URI already exists, the memory content is updated.
-        If not, a new memory is created.
+        Routes to ``upsert_versioned`` for ``core://agent``/``core://my_user``/
+        ``preference://*`` URIs, otherwise to overwrite-mode ``upsert``.
+        Routes to ``__shared__`` for the three shared prefixes; otherwise
+        the client's current namespace.
 
-        Args:
-            uri: Memory URI (e.g., "project://current_research")
-            content: Memory content text
-            priority: Priority (0 = normal)
-            disclosure: When to disclose this memory to the user
-
-        Returns:
-            Dict with memory details (id, node_uuid, uri, etc.)
+        Returns a dict with the canonical fields (id, node_uuid, uri,
+        domain, path, namespace) plus ``rows_after`` for the audit UI.
         """
         await self._ensure_init()
-        domain, path = _parse_uri(uri)
-
-        # Try to update existing
-        existing = await self._graph.get_memory_by_path(path, domain)
-        if existing and existing.get("id", 0) != 0:
-            result = await self._graph.update_memory(
-                path=path,
-                content=content,
-                priority=priority,
-                disclosure=disclosure,
-                domain=domain,
-            )
-        else:
-            # Create new — ensure parent path exists
-            if "/" in path:
-                parent_path = path.rsplit("/", 1)[0]
-                title = path.rsplit("/", 1)[1]
-                # Ensure parent chain exists
-                await self._ensure_parent_chain(domain, parent_path)
-            else:
-                parent_path = ""
-                title = path
-
-            result = await self._graph.create_memory(
-                parent_path=parent_path,
-                content=content,
-                priority=priority,
-                title=title,
-                disclosure=disclosure,
-                domain=domain,
-            )
-
-        # Record changes to ChangesetStore for Review & Audit UI
-        from .snapshot import get_changeset_store
-        store = get_changeset_store()
-        store.record_many(
-            before_state=result.get("rows_before", {}),
-            after_state=result.get("rows_after", {}),
+        parsed = MemoryURI.parse(uri)
+        target_ns = resolve_namespace(parsed, current=self._namespace)
+        return await self._dispatch_remember(
+            parsed, content, priority, disclosure, target_ns
         )
 
+    async def remember_shared(
+        self,
+        uri: str,
+        content: str,
+        priority: int = 0,
+        disclosure: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Force-write to the shared namespace regardless of URI prefix.
+
+        Use for explicit globally-visible writes (KnowHow seed, agent
+        defaults). Versioning policy still applies — a ``preference://``
+        URI written via ``remember_shared`` still creates a chain.
+        """
+        await self._ensure_init()
+        parsed = MemoryURI.parse(uri)
+        return await self._dispatch_remember(
+            parsed, content, priority, disclosure, SHARED_NAMESPACE
+        )
+
+    async def _dispatch_remember(
+        self,
+        parsed: MemoryURI,
+        content: str,
+        priority: int,
+        disclosure: Optional[str],
+        target_ns: str,
+    ) -> Dict[str, Any]:
+        """Route to the right engine verb and rebuild the legacy result dict."""
+        # Auto-vivify intermediate parents — engine writes are strict but
+        # the legacy MemoryClient contract was permissive (any nested URI
+        # creates the chain on demand).
+        await self._ensure_parent_chain(parsed, target_ns)
+
+        assert self._engine is not None  # _ensure_init guarantees this
+        if should_version(parsed):
+            ref = await self._engine.upsert_versioned(
+                parsed, content, namespace=target_ns,
+                priority=priority,
+                disclosure=disclosure,
+            )
+            memory_id = ref.new_memory_id
+            node_uuid = ref.node_uuid
+        else:
+            single_ref = await self._engine.upsert(
+                parsed, content, namespace=target_ns,
+                priority=priority,
+                disclosure=disclosure,
+            )
+            memory_id = single_ref.memory_id
+            node_uuid = single_ref.node_uuid
+
+        result = await self._materialize_result(
+            parsed, target_ns, memory_id, node_uuid, priority
+        )
+
+        # Audit UI: surface the write to the review changeset store. The
+        # store is a process-wide singleton so this works for the bot,
+        # the desktop server, and CLI calls alike.
+        try:
+            from .snapshot import get_changeset_store
+
+            store = get_changeset_store()
+            store.record_many(
+                before_state=result.get("rows_before", {}),
+                after_state=result.get("rows_after", {}),
+            )
+        except Exception:
+            # Audit recording is best-effort — never block a real write.
+            pass
+
         return result
+
+    async def _materialize_result(
+        self,
+        parsed: MemoryURI,
+        target_ns: str,
+        memory_id: int,
+        node_uuid: str,
+        priority: int,
+    ) -> Dict[str, Any]:
+        """Re-fetch the four written rows for the legacy result shape."""
+        assert self._engine is not None
+        db = self._engine._db  # accessing private — engine and client co-evolve
+        import sqlalchemy as sa
+
+        async with db.session() as s:
+            path_row = (
+                await s.execute(
+                    sa.select(Path).where(
+                        Path.namespace == target_ns,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
+                    )
+                )
+            ).scalar_one()
+            edge = await s.get(Edge, path_row.edge_id)
+            node = await s.get(Node, node_uuid)
+            memory = await s.get(Memory, memory_id)
+
+        return {
+            "id": memory_id,
+            "node_uuid": node_uuid,
+            "domain": parsed.domain,
+            "path": parsed.path,
+            "uri": str(parsed),
+            "namespace": target_ns,
+            "priority": priority,
+            "rows_before": {},
+            "rows_after": {
+                "nodes": [serialize_row(node)],
+                "memories": [serialize_memory_ref(memory)],
+                "edges": [serialize_row(edge)],
+                "paths": [serialize_row(path_row)],
+            },
+        }
+
+    async def _ensure_parent_chain(
+        self, parsed: MemoryURI, namespace: str
+    ) -> None:
+        """Walk up parent URIs and create container nodes for missing ones.
+
+        Engine writes refuse missing parents; the legacy MemoryClient
+        contract allowed nested URIs to be created on demand. We replicate
+        that by recursively calling ``upsert`` on each missing ancestor
+        with placeholder content. Top-level URIs (no slash) need nothing.
+        """
+        if "/" not in parsed.path:
+            return
+
+        parent = parsed.parent()
+        if parent is None or parent.is_root:
+            return
+
+        assert self._engine is not None
+        existing = await self._engine.recall(
+            parent, namespace=namespace, fallback_to_shared=True
+        )
+        if existing is not None:
+            return
+
+        # Walk further up first so the engine.upsert below has a parent.
+        await self._ensure_parent_chain(parent, namespace)
+
+        await self._engine.upsert(
+            parent,
+            f"Container node: {parent}",
+            namespace=namespace,
+        )
+
+    # ------------------------------------------------------------------
+    # Read verbs (delegate)
+    # ------------------------------------------------------------------
 
     async def recall(
-        self, uri: str
-    ) -> Optional[Dict[str, Any]]:
-        """Retrieve a memory by URI.
-
-        Args:
-            uri: Memory URI (e.g., "project://current_research")
-
-        Returns:
-            Memory dict with content, or None if not found.
-        """
+        self,
+        uri: str,
+        *,
+        fallback_to_shared: bool = True,
+    ) -> Optional[MemoryRecord]:
+        """Fetch the active memory at the URI in the client's namespace."""
         await self._ensure_init()
-        domain, path = _parse_uri(uri)
-        return await self._graph.get_memory_by_path(path, domain)
-
-    async def forget(self, uri: str) -> Dict[str, Any]:
-        """Remove a memory by URI.
-
-        The memory content is preserved but marked deprecated, allowing
-        rollback via the review interface.
-
-        Args:
-            uri: Memory URI to remove
-
-        Returns:
-            Dict with removal details
-        """
-        await self._ensure_init()
-        domain, path = _parse_uri(uri)
-        result = await self._graph.remove_path(path=path, domain=domain)
-        
-        # Record changes to ChangesetStore for Review & Audit UI
-        from .snapshot import get_changeset_store
-        store = get_changeset_store()
-        store.record_many(
-            before_state=result.get("rows_before", {}),
-            after_state=result.get("rows_after", {}),
+        assert self._engine is not None
+        return await self._engine.recall(
+            uri,
+            namespace=self._namespace,
+            fallback_to_shared=fallback_to_shared,
         )
-
-        return result
 
     async def search(
         self,
@@ -193,61 +315,41 @@ class MemoryClient:
         limit: int = 10,
         domain: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search across all memories.
-
-        Args:
-            query: Search query
-            limit: Max results
-            domain: Optional domain filter
-
-        Returns:
-            List of matching memory dicts
-        """
+        """FTS over the client's namespace (with shared fallback)."""
         await self._ensure_init()
-        return await self._search.search(query, limit=limit, domain=domain)
-
-    async def list_children(
-        self,
-        uri: str = "core://",
-    ) -> List[Dict[str, Any]]:
-        """List direct children of a memory node.
-
-        Args:
-            uri: Parent URI (e.g., "project://")
-
-        Returns:
-            List of child node dicts
-        """
-        await self._ensure_init()
-        domain, path = _parse_uri(uri)
-
-        if not path:
-            from .models import ROOT_NODE_UUID
-            return await self._graph.get_children(
-                node_uuid=ROOT_NODE_UUID,
-                context_domain=domain,
-            )
-
-        mem = await self._graph.get_memory_by_path(path, domain)
-        if not mem:
-            return []
-
-        return await self._graph.get_children(
-            node_uuid=mem["node_uuid"],
-            context_domain=domain,
-            context_path=path,
+        assert self._engine is not None
+        return await self._engine.search(
+            query, namespace=self._namespace, domain=domain, limit=limit
         )
 
+    async def list_children(self, uri: str = "core://") -> List[Any]:
+        """List direct children of ``uri`` strictly inside this namespace."""
+        await self._ensure_init()
+        assert self._engine is not None
+        return await self._engine.list_children(uri, namespace=self._namespace)
+
+    async def get_subtree(
+        self, uri: str, *, limit: int = 100
+    ) -> List[Any]:
+        """Flat listing under (current namespace, uri)."""
+        await self._ensure_init()
+        assert self._engine is not None
+        return await self._engine.get_subtree(
+            uri, namespace=self._namespace, limit=limit
+        )
+
+    # ------------------------------------------------------------------
+    # Composite verbs
+    # ------------------------------------------------------------------
+
     async def boot(self) -> str:
-        """Load core identity and user context for LLM boot prompt.
+        """Load the boot URIs (core://agent + core://my_user by default).
 
-        Reads all core:// memories and formats them into a context string.
-
-        Returns:
-            Formatted context string for LLM system prompt injection.
+        ``OMICSCLAW_MEMORY_CORE_URIS`` overrides the URI list. Each URI is
+        recalled with shared fallback, so a per-user ``core://my_user``
+        with no row falls through to whatever the shared default is.
         """
         await self._ensure_init()
-
         core_uris_str = os.getenv(
             "OMICSCLAW_MEMORY_CORE_URIS",
             "core://agent,core://my_user",
@@ -256,43 +358,50 @@ class MemoryClient:
 
         parts = []
         for uri in core_uris:
-            mem = await self.recall(uri)
-            if mem and mem.get("content"):
-                parts.append(f"[{uri}]\n{mem['content']}")
-
+            record = await self.recall(uri)
+            if record is not None and record.content:
+                parts.append(f"[{uri}]\n{record.content}")
         return "\n\n".join(parts) if parts else ""
 
-    async def get_recent(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get recently updated memories.
+    # ------------------------------------------------------------------
+    # Verbs still routed through the legacy GraphService
+    # (PR #4b ReviewLog will replace these.)
+    # ------------------------------------------------------------------
 
-        Returns:
-            List of recent memory dicts
+    async def get_recent(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return recently updated memories (no namespace filter — admin view)."""
+        await self._ensure_init()
+        from .graph import GraphService
+
+        assert self._engine is not None
+        graph = GraphService(self._engine._db, self._engine._search)
+        return await graph.get_recent_memories(limit=limit)
+
+    async def forget(self, uri: str) -> Dict[str, Any]:
+        """Remove a memory by URI.
+
+        Currently delegates to ``GraphService.remove_path`` — the engine
+        does not yet expose a delete verb (that lands in PR #4b
+        ``ReviewLog.cascade_delete``). Path lookup is scoped to the
+        client's namespace.
         """
         await self._ensure_init()
-        return await self._graph.get_recent_memories(limit=limit)
+        from .graph import GraphService
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+        parsed = MemoryURI.parse(uri)
+        assert self._engine is not None
+        graph = GraphService(self._engine._db, self._engine._search)
+        result = await graph.remove_path(path=parsed.path, domain=parsed.domain)
 
-    async def _ensure_parent_chain(self, domain: str, parent_path: str):
-        """Recursively ensure parent nodes exist up to the root."""
-        existing = await self._graph.get_memory_by_path(parent_path, domain)
-        if existing:
-            return
+        try:
+            from .snapshot import get_changeset_store
 
-        if "/" in parent_path:
-            grandparent = parent_path.rsplit("/", 1)[0]
-            title = parent_path.rsplit("/", 1)[1]
-            await self._ensure_parent_chain(domain, grandparent)
-        else:
-            grandparent = ""
-            title = parent_path
+            store = get_changeset_store()
+            store.record_many(
+                before_state=result.get("rows_before", {}),
+                after_state=result.get("rows_after", {}),
+            )
+        except Exception:
+            pass
 
-        await self._graph.create_memory(
-            parent_path=grandparent,
-            content=f"Container node: {domain}://{parent_path}",
-            priority=0,
-            title=title,
-            domain=domain,
-        )
+        return result

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -223,7 +223,7 @@ class MemoryClient:
     ) -> Dict[str, Any]:
         """Re-fetch the four written rows for the legacy result shape."""
         assert self._engine is not None
-        db = self._engine._db  # accessing private — engine and client co-evolve
+        db = self._engine.db
         import sqlalchemy as sa
 
         async with db.session() as s:
@@ -374,7 +374,7 @@ class MemoryClient:
         from .graph import GraphService
 
         assert self._engine is not None
-        graph = GraphService(self._engine._db, self._engine._search)
+        graph = GraphService(self._engine.db, self._engine.search)
         return await graph.get_recent_memories(limit=limit)
 
     async def forget(self, uri: str) -> Dict[str, Any]:
@@ -390,7 +390,7 @@ class MemoryClient:
 
         parsed = MemoryURI.parse(uri)
         assert self._engine is not None
-        graph = GraphService(self._engine._db, self._engine._search)
+        graph = GraphService(self._engine.db, self._engine.search)
         result = await graph.remove_path(path=parsed.path, domain=parsed.domain)
 
         try:

--- a/omicsclaw/memory/migrations/001_namespace.py
+++ b/omicsclaw/memory/migrations/001_namespace.py
@@ -1,0 +1,167 @@
+"""001_namespace: Add namespace partition to paths, search_documents, glossary_keywords.
+
+Idempotent — checks for the namespace column on ``paths`` before doing any
+work. Backfills namespace from the ``disclosure`` field of session and memory
+records (best-effort; rows without parseable disclosure stay at ``__shared__``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+VERSION = "001_namespace"
+DESCRIPTION = "Add namespace partition to paths, search_documents, glossary_keywords"
+
+# Disclosure formats produced by compat.py:
+#   "Memory from session <platform>:<user_id>:<session_uuid>"
+#   "Session for user <user_id> on <platform>"
+_DISCLOSURE_MEMORY_RE = re.compile(r"Memory from session (\S+?):(\S+?):")
+_DISCLOSURE_SESSION_RE = re.compile(r"Session for user (\S+) on (\S+)")
+
+
+async def _column_exists(s, table: str, column: str) -> bool:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.all())
+
+
+def _parse_disclosure_namespace(disclosure: str | None) -> str | None:
+    """Extract ``f"{platform}/{user_id}"`` from a disclosure string, if possible."""
+    if not disclosure:
+        return None
+    m = _DISCLOSURE_MEMORY_RE.search(disclosure)
+    if m:
+        platform, user_id = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    m = _DISCLOSURE_SESSION_RE.search(disclosure)
+    if m:
+        user_id, platform = m.group(1), m.group(2)
+        return f"{platform}/{user_id}"
+    return None
+
+
+async def _backfill_namespace_from_disclosure(s) -> None:
+    """Update ``namespace`` on paths + search_documents based on disclosure data."""
+    result = await s.execute(
+        sa.text(
+            "SELECT domain, path, disclosure FROM search_documents "
+            "WHERE disclosure IS NOT NULL"
+        )
+    )
+    for domain, path, disclosure in result.all():
+        ns = _parse_disclosure_namespace(disclosure)
+        if not ns:
+            continue
+        await s.execute(
+            sa.text(
+                "UPDATE paths SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "UPDATE search_documents SET namespace = :ns "
+                "WHERE namespace = '__shared__' AND domain = :d AND path = :p"
+            ),
+            {"ns": ns, "d": domain, "p": path},
+        )
+
+
+async def apply(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        # Idempotent guard — column already added means migration has been applied.
+        if await _column_exists(s, "paths", "namespace"):
+            return
+
+        # 1. Rebuild paths with composite PK (namespace, domain, path)
+        await s.execute(sa.text("""
+            CREATE TABLE paths_new (
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO paths_new (namespace, domain, path, edge_id, created_at)
+            SELECT '__shared__', domain, path, edge_id, created_at FROM paths
+        """))
+        await s.execute(sa.text("DROP TABLE paths"))
+        await s.execute(sa.text("ALTER TABLE paths_new RENAME TO paths"))
+
+        # 2. Rebuild search_documents with composite PK
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents_new (
+                namespace    VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (namespace, domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_new
+                (namespace, domain, path, node_uuid, memory_id, uri,
+                 content, disclosure, search_terms, priority, updated_at)
+            SELECT '__shared__', domain, path, node_uuid, memory_id, uri,
+                   content, disclosure, search_terms, priority, updated_at
+            FROM search_documents
+        """))
+        await s.execute(sa.text("DROP TABLE search_documents"))
+        await s.execute(sa.text("ALTER TABLE search_documents_new RENAME TO search_documents"))
+
+        # 3. Rebuild glossary_keywords with namespace + new UNIQUE constraint
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords_new (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                namespace  VARCHAR(128) NOT NULL DEFAULT '__shared__',
+                created_at DATETIME,
+                UNIQUE (namespace, keyword, node_uuid)
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO glossary_keywords_new (id, keyword, node_uuid, namespace, created_at)
+            SELECT id, keyword, node_uuid, '__shared__', created_at FROM glossary_keywords
+        """))
+        await s.execute(sa.text("DROP TABLE glossary_keywords"))
+        await s.execute(sa.text("ALTER TABLE glossary_keywords_new RENAME TO glossary_keywords"))
+
+        # 4. Best-effort namespace backfill from disclosure metadata
+        await _backfill_namespace_from_disclosure(s)
+
+        # 5. Rebuild FTS5 virtual table with namespace column, repopulate from search_documents
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents_fts"))
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                namespace, domain, path, node_uuid, uri, content,
+                disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+        await s.execute(sa.text("""
+            INSERT INTO search_documents_fts (
+                rowid, namespace, domain, path, node_uuid, uri,
+                content, disclosure, search_terms
+            )
+            SELECT rowid, namespace, domain, path, node_uuid, uri,
+                   content, disclosure, search_terms
+            FROM search_documents
+        """))

--- a/omicsclaw/memory/migrations/__init__.py
+++ b/omicsclaw/memory/migrations/__init__.py
@@ -1,0 +1,11 @@
+"""Lightweight migrations framework for OmicsClaw memory schema.
+
+Each migration is a module exposing module-level ``VERSION`` (str),
+``DESCRIPTION`` (str), and ``async def apply(db: DatabaseManager) -> None``.
+The runner discovers them, applies pending ones in version-sorted order,
+and records applications in the ``_schema_version`` table.
+"""
+
+from omicsclaw.memory.migrations.runner import run_pending
+
+__all__ = ["run_pending"]

--- a/omicsclaw/memory/migrations/runner.py
+++ b/omicsclaw/memory/migrations/runner.py
@@ -1,0 +1,93 @@
+"""Lightweight migrations runner — see omicsclaw/memory/migrations/__init__.py."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Iterable, Protocol
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from omicsclaw.memory.database import DatabaseManager
+
+_DEFAULT_MIGRATIONS_PACKAGE = "omicsclaw.memory.migrations"
+
+
+class Migration(Protocol):
+    VERSION: str
+    DESCRIPTION: str
+
+    async def apply(self, db: "DatabaseManager") -> None: ...
+
+
+_SCHEMA_VERSION_DDL = sa.text(
+    "CREATE TABLE IF NOT EXISTS _schema_version ("
+    "  version TEXT PRIMARY KEY,"
+    "  applied_at TEXT NOT NULL"
+    ")"
+)
+
+
+async def _ensure_schema_version_table(db: "DatabaseManager") -> None:
+    async with db.session() as s:
+        await s.execute(_SCHEMA_VERSION_DDL)
+
+
+async def _get_applied_versions(db: "DatabaseManager") -> set[str]:
+    async with db.session() as s:
+        result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+        return {row[0] for row in result.all()}
+
+
+async def _record_applied(db: "DatabaseManager", version: str) -> None:
+    async with db.session() as s:
+        await s.execute(
+            sa.text(
+                "INSERT INTO _schema_version (version, applied_at) "
+                "VALUES (:v, :t)"
+            ),
+            {"v": version, "t": datetime.now(timezone.utc).isoformat()},
+        )
+
+
+def _discover_migrations(package: str = _DEFAULT_MIGRATIONS_PACKAGE) -> list[Migration]:
+    """Import every NNN_*.py module in ``package`` and return them as migrations."""
+    pkg = importlib.import_module(package)
+    found: list[Migration] = []
+    for info in pkgutil.iter_modules(pkg.__path__):
+        if not info.name[:1].isdigit():
+            continue
+        mod = importlib.import_module(f"{package}.{info.name}")
+        if all(hasattr(mod, attr) for attr in ("VERSION", "DESCRIPTION", "apply")):
+            found.append(mod)  # type: ignore[arg-type]
+    return found
+
+
+async def run_pending(
+    db: "DatabaseManager",
+    *,
+    migrations: Iterable[Migration] | None = None,
+) -> list[str]:
+    """Apply pending migrations in version-sorted order. Returns versions applied.
+
+    If ``migrations`` is None, discovers them from
+    ``omicsclaw.memory.migrations`` (numbered modules: ``001_*.py``).
+    """
+    if migrations is None:
+        migrations = _discover_migrations()
+
+    await _ensure_schema_version_table(db)
+    applied = await _get_applied_versions(db)
+
+    pending = [m for m in migrations if m.VERSION not in applied]
+    pending.sort(key=lambda m: m.VERSION)
+
+    versions_applied: list[str] = []
+    for m in pending:
+        await m.apply(db)
+        await _record_applied(db, m.VERSION)
+        versions_applied.append(m.VERSION)
+
+    return versions_applied

--- a/omicsclaw/memory/models.py
+++ b/omicsclaw/memory/models.py
@@ -142,14 +142,20 @@ class Edge(Base):
 
 
 class Path(Base):
-    """Materialized URI cache: (domain, path_string) → edge.
+    """Materialized URI cache: (namespace, domain, path_string) → edge.
 
     The source of truth for tree structure is the edges table.
-    Paths are a routing convenience for URI resolution.
+    Paths are a routing convenience for URI resolution. ``namespace``
+    partitions identical (domain, path) URIs across surfaces/users.
+    Default ``__shared__`` keeps legacy callers (GraphService) writing into
+    the same partition they always have.
     """
 
     __tablename__ = "paths"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     edge_id = Column(Integer, ForeignKey("edges.id"), nullable=True)
@@ -159,10 +165,11 @@ class Path(Base):
 
 
 class GlossaryKeyword(Base):
-    """Glossary keyword-to-node binding.
+    """Glossary keyword-to-node binding, partitioned by namespace.
 
     When a keyword appears in a memory's content, the frontend highlights
-    the keyword and links it to the associated node.
+    the keyword and links it to the associated node. Each namespace owns
+    its own keyword set; ``__shared__`` keywords are visible to all.
     """
 
     __tablename__ = "glossary_keywords"
@@ -174,20 +181,32 @@ class GlossaryKeyword(Base):
         ForeignKey("nodes.uuid", ondelete="CASCADE"),
         nullable=False,
     )
+    namespace = Column(
+        String(128), nullable=False, default="__shared__"
+    )
     created_at = Column(DateTime, default=datetime.utcnow)
 
     __table_args__ = (
-        UniqueConstraint("keyword", "node_uuid", name="uq_glossary_keyword_node"),
+        UniqueConstraint(
+            "namespace", "keyword", "node_uuid", name="uq_glossary_keyword_node"
+        ),
     )
 
     node = relationship("Node")
 
 
 class SearchDocument(Base):
-    """Derived search row for one reachable path of an active node."""
+    """Derived search row for one reachable path of an active node.
+
+    Composite PK ``(namespace, domain, path)`` matches Path's so the indexer
+    can refresh exactly one row per write target.
+    """
 
     __tablename__ = "search_documents"
 
+    namespace = Column(
+        String(128), primary_key=True, nullable=False, default="__shared__"
+    )
     domain = Column(String(64), primary_key=True, default="core")
     path = Column(String(512), primary_key=True)
     node_uuid = Column(

--- a/omicsclaw/memory/models.py
+++ b/omicsclaw/memory/models.py
@@ -33,6 +33,11 @@ Base = declarative_base()
 # Using a fixed UUID instead of NULL avoids SQLite's NULL != NULL uniqueness quirk.
 ROOT_NODE_UUID = "00000000-0000-0000-0000-000000000000"
 
+# Shared (cross-namespace) partition. Read fallback target for recall/search;
+# also the implicit default for legacy callers that don't pass ``namespace``.
+# Single source of truth — engine.py / search.py / migrations import from here.
+SHARED_NAMESPACE = "__shared__"
+
 
 # =============================================================================
 # Shared Utilities

--- a/omicsclaw/memory/namespace_policy.py
+++ b/omicsclaw/memory/namespace_policy.py
@@ -1,0 +1,51 @@
+"""Namespace + version policy — see docs/CONTEXT.md.
+
+Two independent classifications of a Memory URI:
+
+  resolve_namespace(uri, current=N)
+    → "__shared__" if uri matches a SHARED_PREFIXES entry, else N
+
+  should_version(uri)
+    → True if uri matches a VERSIONED_PREFIXES entry, else False
+
+Prefix semantics for both tables (`(domain, prefix)` tuples):
+  - empty prefix matches the whole domain (e.g., all of preference://*)
+  - non-empty prefix matches exact path OR "<prefix>/..." sub-paths
+  - "kh" does NOT match "khaki" — matching is by path-segment, not raw startswith
+"""
+
+from omicsclaw.memory.uri import MemoryURI
+
+SHARED = "__shared__"
+
+SHARED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "kh"),
+    ("core", "my_user_default"),
+)
+
+VERSIONED_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("core", "agent"),
+    ("core", "my_user"),
+    ("preference", ""),
+)
+
+
+def _matches_prefix(uri: MemoryURI, domain: str, prefix: str) -> bool:
+    if uri.domain != domain:
+        return False
+    if prefix == "":
+        return True
+    return uri.path == prefix or uri.path.startswith(prefix + "/")
+
+
+def _matches_any(uri: MemoryURI, prefixes: tuple[tuple[str, str], ...]) -> bool:
+    return any(_matches_prefix(uri, d, p) for d, p in prefixes)
+
+
+def resolve_namespace(uri: MemoryURI, *, current: str) -> str:
+    return SHARED if _matches_any(uri, SHARED_PREFIXES) else current
+
+
+def should_version(uri: MemoryURI) -> bool:
+    return _matches_any(uri, VERSIONED_PREFIXES)

--- a/omicsclaw/memory/review_log.py
+++ b/omicsclaw/memory/review_log.py
@@ -1,0 +1,423 @@
+# pyright: reportArgumentType=false, reportCallIssue=false, reportOperatorIssue=false
+
+"""ReviewLog — namespace-aware cold path for memory review and audit.
+
+Sits next to ``MemoryEngine``: where the engine is the **hot** path
+(reads + writes per request), ReviewLog is the **cold** path — the
+operations the desktop "Review & Audit" pane needs and the bot's
+``/forget`` command will eventually call:
+
+  * version-chain inspection / rollback
+  * orphan + GC
+  * browse_shared
+  * pending-changes list / approve / discard
+
+Constructed once per process; takes the same ``DatabaseManager`` and
+``MemoryEngine`` as the rest of the layer. Optionally takes a
+``ChangesetStore`` override for test isolation; in production it falls
+through to the global singleton from ``snapshot.get_changeset_store``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+import sqlalchemy as sa
+
+from .engine import MemoryEngine, MemoryRef
+from .models import (
+    Edge,
+    Memory,
+    Path,
+    SHARED_NAMESPACE,
+)
+from .namespace_policy import should_version
+from .uri import MemoryURI
+
+if TYPE_CHECKING:
+    from .database import DatabaseManager
+    from .snapshot import ChangesetStore
+
+
+class NoVersionHistoryError(RuntimeError):
+    """Raised when an operation requires a version chain but the URI is
+    overwrite-only (``dataset://``, ``analysis://``)."""
+
+
+@dataclass(frozen=True, slots=True)
+class VersionEntry:
+    """One row in a memory's version chain, ordered oldest → newest."""
+
+    memory_id: int
+    deprecated: bool
+    migrated_to: Optional[int]
+    content: str
+    created_at: Optional[datetime]
+    namespace: str
+    uri: str
+
+
+@dataclass(frozen=True, slots=True)
+class OrphanEntry:
+    """A deprecated Memory whose successor was deleted, leaving no active
+    head — the chain is broken at this row."""
+
+    memory_id: int
+    node_uuid: str
+    deprecated: bool
+    migrated_to: Optional[int]
+    namespace: Optional[str]
+    uri: Optional[str]
+    created_at: Optional[datetime]
+
+
+@dataclass(frozen=True, slots=True)
+class RollbackResult:
+    restored_memory_id: int
+    node_uuid: str
+    was_already_active: bool
+
+
+class ReviewLog:
+    """Namespace-aware cold-path operations.
+
+    All write verbs leave ``snapshot.ChangesetStore`` updated so the
+    review pane stays consistent with the live DB.
+    """
+
+    def __init__(
+        self,
+        db: "DatabaseManager",
+        engine: MemoryEngine,
+        *,
+        changeset_store: Optional["ChangesetStore"] = None,
+    ) -> None:
+        self._db = db
+        self._engine = engine
+        self._changeset_override = changeset_store
+
+    def _store(self) -> "ChangesetStore":
+        if self._changeset_override is not None:
+            return self._changeset_override
+        from .snapshot import get_changeset_store
+
+        return get_changeset_store()
+
+    # ------------------------------------------------------------------
+    # 4b.2 — version chain
+    # ------------------------------------------------------------------
+
+    async def list_version_chain(
+        self, uri: str | MemoryURI, *, namespace: str
+    ) -> list[VersionEntry]:
+        """Return the chain in age order (oldest → newest = active head).
+
+        Raises ``NoVersionHistoryError`` if the URI is overwrite-only —
+        ``dataset://`` and ``analysis://`` URIs structurally cannot have
+        a chain, so an empty-list return would be misleading. Returns
+        an empty list when the URI is versioned but currently has no
+        rows (path doesn't exist yet).
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        if not should_version(parsed):
+            raise NoVersionHistoryError(
+                f"URI {parsed} is not versioned — version chain not applicable."
+            )
+
+        async with self._db.session() as s:
+            path_row = await self._fetch_path(s, namespace, parsed)
+            if path_row is None:
+                return []
+
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                return []
+
+            rows = (
+                await s.execute(
+                    sa.select(Memory)
+                    .where(Memory.node_uuid == edge.child_uuid)
+                    .order_by(Memory.id)
+                )
+            ).scalars().all()
+
+            return [
+                VersionEntry(
+                    memory_id=r.id,
+                    deprecated=bool(r.deprecated),
+                    migrated_to=r.migrated_to,
+                    content=r.content,
+                    created_at=r.created_at,
+                    namespace=namespace,
+                    uri=str(parsed),
+                )
+                for r in rows
+            ]
+
+    async def rollback_to(
+        self, memory_id: int, *, namespace: str
+    ) -> RollbackResult:
+        """Make ``memory_id`` the active head of its chain.
+
+        Deprecates everything else on the same node and clears the
+        new active row's ``migrated_to`` pointer. Returns the rollback
+        result with ``was_already_active=True`` when the target is
+        already the head (idempotent).
+        """
+        async with self._db.session() as s:
+            target = await s.get(Memory, memory_id)
+            if target is None:
+                raise ValueError(f"Memory ID {memory_id} not found")
+
+            if not target.deprecated:
+                return RollbackResult(
+                    restored_memory_id=memory_id,
+                    node_uuid=target.node_uuid,
+                    was_already_active=True,
+                )
+
+            # Mark every other memory on this node deprecated with
+            # migrated_to pointing at the new active head.
+            await s.execute(
+                sa.update(Memory)
+                .where(
+                    Memory.node_uuid == target.node_uuid,
+                    Memory.id != memory_id,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .values(deprecated=True, migrated_to=memory_id)
+            )
+            await s.execute(
+                sa.update(Memory)
+                .where(Memory.id == memory_id)
+                .values(deprecated=False, migrated_to=None)
+            )
+
+            await self._engine.search_indexer.refresh_search_documents_for_node(
+                target.node_uuid, session=s
+            )
+
+        return RollbackResult(
+            restored_memory_id=memory_id,
+            node_uuid=target.node_uuid,
+            was_already_active=False,
+        )
+
+    # ------------------------------------------------------------------
+    # 4b.3 — orphans + GC
+    # ------------------------------------------------------------------
+
+    async def list_orphans(
+        self, *, namespace: Optional[str] = None
+    ) -> list[OrphanEntry]:
+        """Find deprecated memories whose successor row has been deleted.
+
+        ``namespace=None`` scans every partition (admin view). Otherwise
+        restricts to the given namespace via the path join.
+        """
+        async with self._db.session() as s:
+            stmt = (
+                sa.select(
+                    Memory.id,
+                    Memory.node_uuid,
+                    Memory.deprecated,
+                    Memory.migrated_to,
+                    Memory.created_at,
+                    Path.namespace,
+                    Path.domain,
+                    Path.path,
+                )
+                .select_from(Memory)
+                .outerjoin(Edge, Edge.child_uuid == Memory.node_uuid)
+                .outerjoin(Path, Path.edge_id == Edge.id)
+                .where(Memory.deprecated == True)  # noqa: E712
+            )
+            if namespace is not None:
+                stmt = stmt.where(Path.namespace == namespace)
+            rows = (await s.execute(stmt)).all()
+
+            # Distinct memory_ids (a memory with multiple Paths produces
+            # multiple rows) — we want one OrphanEntry per memory.
+            seen: set[int] = set()
+            entries: list[OrphanEntry] = []
+            for memory_id, node_uuid, deprecated, migrated_to, created_at, ns, domain, path in rows:
+                # Filter to true orphans: migrated_to either NULL or
+                # points at a memory that no longer exists.
+                if migrated_to is not None:
+                    successor = await s.get(Memory, migrated_to)
+                    if successor is not None and not successor.deprecated:
+                        continue
+                if memory_id in seen:
+                    continue
+                seen.add(memory_id)
+                uri = (
+                    f"{domain}://{path}"
+                    if domain is not None and path is not None
+                    else None
+                )
+                entries.append(
+                    OrphanEntry(
+                        memory_id=memory_id,
+                        node_uuid=node_uuid,
+                        deprecated=bool(deprecated),
+                        migrated_to=migrated_to,
+                        namespace=ns,
+                        uri=uri,
+                        created_at=created_at,
+                    )
+                )
+        return entries
+
+    async def cascade_delete(
+        self, uri: str | MemoryURI, *, namespace: str
+    ) -> dict:
+        """Delete a path + its edge + its node + every memory on the node.
+
+        Strict-namespace: only touches the row at ``(namespace, uri)``;
+        other namespaces' rows at the same URI are untouched. Returns a
+        summary dict with the counts removed.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        async with self._db.session() as s:
+            path_row = await self._fetch_path(s, namespace, parsed)
+            if path_row is None:
+                return {
+                    "deleted": False,
+                    "namespace": namespace,
+                    "uri": str(parsed),
+                }
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                return {
+                    "deleted": False,
+                    "namespace": namespace,
+                    "uri": str(parsed),
+                }
+
+            node_uuid = edge.child_uuid
+
+            # Delete the Path first (frees the structural alias).
+            await s.execute(
+                sa.delete(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+            # If no other Path references this edge, drop the edge,
+            # node, and memories.
+            other_paths = (
+                await s.execute(
+                    sa.select(sa.func.count())
+                    .select_from(Path)
+                    .where(Path.edge_id == edge.id)
+                )
+            ).scalar_one()
+            removed_memories = 0
+            if other_paths == 0:
+                await s.execute(sa.delete(Edge).where(Edge.id == edge.id))
+                # Remove memories on the node (no path reaches them now).
+                deleted = await s.execute(
+                    sa.delete(Memory).where(Memory.node_uuid == node_uuid)
+                )
+                removed_memories = deleted.rowcount or 0
+                # Refresh search index so the now-gone rows disappear.
+                await self._engine.search_indexer._delete_search_documents_for_node(
+                    s, node_uuid
+                )
+
+        return {
+            "deleted": True,
+            "namespace": namespace,
+            "uri": str(parsed),
+            "memories_removed": removed_memories,
+        }
+
+    async def gc_pathless_edges(
+        self, *, namespace: Optional[str] = None
+    ) -> int:
+        """Drop edges that have no Path row referencing them.
+
+        These accumulate from interrupted writes or manual DB pokes.
+        Returns the number of edges removed.
+        """
+        async with self._db.session() as s:
+            # Subquery: edge_ids that ARE referenced by at least one Path
+            referenced = sa.select(Path.edge_id).distinct()
+            if namespace is not None:
+                referenced = referenced.where(Path.namespace == namespace)
+            referenced_ids = (
+                await s.execute(referenced)
+            ).scalars().all()
+
+            stmt = sa.delete(Edge)
+            if referenced_ids:
+                stmt = stmt.where(Edge.id.notin_(referenced_ids))
+            removed = await s.execute(stmt)
+            return removed.rowcount or 0
+
+    # ------------------------------------------------------------------
+    # 4b.4 — browse_shared
+    # ------------------------------------------------------------------
+
+    async def browse_shared(
+        self, uri: str | MemoryURI = "core://"
+    ) -> list[MemoryRef]:
+        """List children of ``uri`` strictly inside ``__shared__``.
+
+        Used by the desktop UI when the user wants to see globally-known
+        content (KnowHow seeds, agent defaults). Sugar for
+        ``engine.list_children(uri, namespace='__shared__')``.
+        """
+        return await self._engine.list_children(uri, namespace=SHARED_NAMESPACE)
+
+    # ------------------------------------------------------------------
+    # 4b.5 — changesets
+    # ------------------------------------------------------------------
+
+    async def list_pending_changes(
+        self, *, namespace: Optional[str] = None
+    ) -> list[dict]:
+        """Return the rows pending review.
+
+        ``namespace`` is reserved for a future per-tenant filter; the
+        current ``ChangesetStore`` doesn't yet record namespace, so the
+        argument is accepted but not yet applied.
+        """
+        store = self._store()
+        return store.get_changed_rows()
+
+    async def approve_changes(
+        self, change_ids: Optional[list[str]] = None
+    ) -> int:
+        """Mark rows as integrated and remove them from the pending pool.
+
+        Without ``change_ids`` clears every pending row (common case for
+        the "approve all" UI button). Returns the count cleared.
+        """
+        store = self._store()
+        if change_ids:
+            return store.remove_keys(change_ids)
+        return store.clear_all()
+
+    async def discard_pending_changes(self) -> int:
+        """Drop every pending row without integrating. Returns count dropped."""
+        return self._store().discard_all()
+
+    # ------------------------------------------------------------------
+    # internal helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _fetch_path(s, namespace: str, parsed: MemoryURI) -> Optional[Path]:
+        return (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one_or_none()

--- a/omicsclaw/memory/review_log.py
+++ b/omicsclaw/memory/review_log.py
@@ -335,22 +335,27 @@ class ReviewLog:
             "memories_removed": removed_memories,
         }
 
-    async def gc_pathless_edges(
-        self, *, namespace: Optional[str] = None
-    ) -> int:
-        """Drop edges that have no Path row referencing them.
+    async def gc_pathless_edges(self) -> int:
+        """Drop edges that have no Path row referencing them, in any namespace.
 
         These accumulate from interrupted writes or manual DB pokes.
         Returns the number of edges removed.
+
+        Note: this operates globally on purpose. Edges aren't namespaced
+        — they describe structural parent→child relationships between
+        nodes, and a single edge can be referenced by Paths from multiple
+        namespaces (the alias mechanism). A per-namespace GC would have
+        to delete edges that A's Paths don't reference, which would
+        silently destroy B's data. Global is the only safe scope.
         """
         async with self._db.session() as s:
-            # Subquery: edge_ids that ARE referenced by at least one Path
-            referenced = sa.select(Path.edge_id).distinct()
-            if namespace is not None:
-                referenced = referenced.where(Path.namespace == namespace)
-            referenced_ids = (
-                await s.execute(referenced)
+            referenced_rows = (
+                await s.execute(sa.select(Path.edge_id).distinct())
             ).scalars().all()
+            # SQL "x NOT IN (..., NULL, ...)" returns UNKNOWN for every row,
+            # which makes the DELETE a no-op. Filter NULLs explicitly so a
+            # Path with edge_id IS NULL doesn't poison the subquery.
+            referenced_ids = [eid for eid in referenced_rows if eid is not None]
 
             stmt = sa.delete(Edge)
             if referenced_ids:
@@ -377,14 +382,13 @@ class ReviewLog:
     # 4b.5 — changesets
     # ------------------------------------------------------------------
 
-    async def list_pending_changes(
-        self, *, namespace: Optional[str] = None
-    ) -> list[dict]:
-        """Return the rows pending review.
+    async def list_pending_changes(self) -> list[dict]:
+        """Return the rows pending review across all namespaces.
 
-        ``namespace`` is reserved for a future per-tenant filter; the
-        current ``ChangesetStore`` doesn't yet record namespace, so the
-        argument is accepted but not yet applied.
+        The current ``ChangesetStore`` doesn't record namespace per row,
+        so a per-namespace filter would silently drop everything. PR #5
+        will add the column once surfaces wire namespace through the
+        record-many call; until then this is global.
         """
         store = self._store()
         return store.get_changed_rows()

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -373,26 +373,54 @@ class SearchIndexer:
     # -----------------------------------------------------------------
 
     async def search(
-        self, query: str, limit: int = 10, domain: Optional[str] = None
+        self,
+        query: str,
+        limit: int = 10,
+        domain: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Search memories by path and content using the derived FTS index."""
+        """Search memories by path and content using the derived FTS index.
+
+        When ``namespace`` is provided, results are restricted to that
+        namespace plus the shared partition; per-namespace hits are sorted
+        ahead of shared ones. ``namespace=None`` preserves legacy
+        unfiltered behavior for callers that haven't migrated.
+        """
         async with self._session() as session:
             candidate_limit = max(limit * 5, 50)
             params: Dict[str, Any] = {"candidate_limit": candidate_limit}
+
             domain_clause = ""
             if domain is not None:
                 params["domain"] = domain
                 domain_clause = "AND sd.domain = :domain"
 
+            namespace_clause, namespace_order = "", ""
+            if namespace is not None:
+                params["current_ns"] = namespace
+                params["shared_ns"] = SHARED_NAMESPACE
+                namespace_clause = (
+                    "AND sd.namespace IN (:current_ns, :shared_ns)"
+                )
+                namespace_order = (
+                    "CASE WHEN sd.namespace = :current_ns THEN 0 ELSE 1 END ASC,"
+                )
+
             if self.db_type == "sqlite":
                 # Try FTS5 first, fall back to LIKE search
                 try:
                     return await self._search_sqlite_fts(
-                        session, query, params, domain_clause, limit
+                        session,
+                        query,
+                        params,
+                        domain_clause,
+                        namespace_clause,
+                        namespace_order,
+                        limit,
                     )
                 except Exception:
                     return await self._search_sqlite_like(
-                        session, query, limit, domain
+                        session, query, limit, domain, namespace
                     )
             else:
                 normalized = expand_query_terms(query)
@@ -411,6 +439,7 @@ class SearchIndexer:
                             sd.priority,
                             sd.content,
                             sd.disclosure,
+                            sd.namespace AS namespace,
                             ts_rank_cd(
                                 to_tsvector(
                                     'simple',
@@ -432,7 +461,8 @@ class SearchIndexer:
                                 coalesce(sd.search_terms, '')
                               ) @@ websearch_to_tsquery('simple', :ts_query)
                           {domain_clause}
-                        ORDER BY score DESC, sd.priority ASC, char_length(sd.path) ASC
+                          {namespace_clause}
+                        ORDER BY {namespace_order} score DESC, sd.priority ASC, char_length(sd.path) ASC
                         LIMIT :candidate_limit
                         """
                     ),
@@ -447,6 +477,8 @@ class SearchIndexer:
         query: str,
         params: Dict[str, Any],
         domain_clause: str,
+        namespace_clause: str,
+        namespace_order: str,
         limit: int,
     ) -> List[Dict[str, Any]]:
         """Search using SQLite FTS5."""
@@ -466,6 +498,7 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
+                    sd.namespace AS namespace,
                     -- 8 bm25 weights, one per FTS column in declaration order:
                     -- namespace, domain, path, node_uuid, uri, content,
                     -- disclosure, search_terms. namespace gets 0.0 because
@@ -479,7 +512,8 @@ class SearchIndexer:
                  AND search_documents_fts.path      = sd.path
                 WHERE search_documents_fts MATCH :match_query
                   {domain_clause}
-                ORDER BY score ASC, sd.priority ASC, length(sd.path) ASC
+                  {namespace_clause}
+                ORDER BY {namespace_order} score ASC, sd.priority ASC, length(sd.path) ASC
                 LIMIT :candidate_limit
                 """
             ),
@@ -493,6 +527,7 @@ class SearchIndexer:
         query: str,
         limit: int,
         domain: Optional[str],
+        namespace: Optional[str],
     ) -> List[Dict[str, Any]]:
         """Fallback search using LIKE when FTS5 is unavailable."""
         safe_query = f"%{escape_like_literal(query)}%"
@@ -502,6 +537,17 @@ class SearchIndexer:
         if domain:
             params["domain"] = domain
             domain_clause = "AND sd.domain = :domain"
+
+        namespace_clause, namespace_order = "", ""
+        if namespace is not None:
+            params["current_ns"] = namespace
+            params["shared_ns"] = SHARED_NAMESPACE
+            namespace_clause = (
+                "AND sd.namespace IN (:current_ns, :shared_ns)"
+            )
+            namespace_order = (
+                "CASE WHEN sd.namespace = :current_ns THEN 0 ELSE 1 END ASC,"
+            )
 
         result = await session.execute(
             text(
@@ -514,11 +560,13 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
+                    sd.namespace AS namespace,
                     0 AS score
                 FROM search_documents AS sd
                 WHERE (sd.content LIKE :query ESCAPE '\\' OR sd.path LIKE :query ESCAPE '\\')
                   {domain_clause}
-                ORDER BY sd.priority ASC, length(sd.path) ASC
+                  {namespace_clause}
+                ORDER BY {namespace_order} sd.priority ASC, length(sd.path) ASC
                 LIMIT :limit
                 """
             ),
@@ -537,6 +585,7 @@ class SearchIndexer:
             seen_nodes.add(row["node_uuid"])
             matches.append(
                 {
+                    "namespace": row.get("namespace"),
                     "domain": row["domain"],
                     "path": row["path"],
                     "uri": row["uri"],

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -18,6 +18,7 @@ from .models import (
     Path,
     GlossaryKeyword,
     SearchDocument,
+    SHARED_NAMESPACE,
     escape_like_literal,
 )
 from .search_terms import build_document_search_terms, expand_query_terms
@@ -25,8 +26,6 @@ from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
-
-SHARED_NAMESPACE = "__shared__"
 
 
 class SearchIndexer:

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -105,11 +105,13 @@ class SearchIndexer:
 
         path_rows = (
             await session.execute(
-                select(Path.domain, Path.path, Edge.priority, Edge.disclosure)
+                select(
+                    Path.namespace, Path.domain, Path.path, Edge.priority, Edge.disclosure
+                )
                 .select_from(Path)
                 .join(Edge, Path.edge_id == Edge.id)
                 .where(Edge.child_uuid == node_uuid)
-                .order_by(Path.domain, Path.path)
+                .order_by(Path.namespace, Path.domain, Path.path)
             )
         ).all()
         if not path_rows:
@@ -127,6 +129,7 @@ class SearchIndexer:
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
+                    "namespace": row.namespace,
                     "domain": row.domain,
                     "path": row.path,
                     "node_uuid": node_uuid,
@@ -182,9 +185,9 @@ class SearchIndexer:
                     text(
                         """
                         INSERT INTO search_documents_fts (
-                            domain, path, node_uuid, uri, content, disclosure, search_terms
+                            namespace, domain, path, node_uuid, uri, content, disclosure, search_terms
                         ) VALUES (
-                            :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
+                            :namespace, :domain, :path, :node_uuid, :uri, :content, coalesce(:disclosure, ''), :search_terms
                         )
                         """
                     ),

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -466,11 +466,17 @@ class SearchIndexer:
                     sd.priority,
                     sd.content,
                     sd.disclosure,
-                    bm25(search_documents_fts, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
+                    -- 8 bm25 weights, one per FTS column in declaration order:
+                    -- namespace, domain, path, node_uuid, uri, content,
+                    -- disclosure, search_terms. namespace gets 0.0 because
+                    -- the JOIN already filters it; domain/node_uuid stay 0.0
+                    -- so they don't influence ranking.
+                    bm25(search_documents_fts, 0.0, 0.0, 2.5, 0.0, 2.0, 1.0, 1.0, 0.75) AS score
                 FROM search_documents AS sd
                 JOIN search_documents_fts
-                  ON search_documents_fts.domain = sd.domain
-                 AND search_documents_fts.path = sd.path
+                  ON search_documents_fts.namespace = sd.namespace
+                 AND search_documents_fts.domain    = sd.domain
+                 AND search_documents_fts.path      = sd.path
                 WHERE search_documents_fts MATCH :match_query
                   {domain_clause}
                 ORDER BY score ASC, sd.priority ASC, length(sd.path) ASC

--- a/omicsclaw/memory/search.py
+++ b/omicsclaw/memory/search.py
@@ -21,9 +21,12 @@ from .models import (
     escape_like_literal,
 )
 from .search_terms import build_document_search_terms, expand_query_terms
+from .uri import MemoryURI
 
 if TYPE_CHECKING:
     from .database import DatabaseManager
+
+SHARED_NAMESPACE = "__shared__"
 
 
 class SearchIndexer:
@@ -117,15 +120,29 @@ class SearchIndexer:
         if not path_rows:
             return []
 
-        keyword_rows = await session.execute(
-            select(GlossaryKeyword.keyword)
-            .where(GlossaryKeyword.node_uuid == node_uuid)
-            .order_by(GlossaryKeyword.keyword)
-        )
-        glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+        # Glossary keywords are partitioned by namespace; for each search
+        # row we include only keywords visible from its namespace, i.e. the
+        # row's own namespace plus the global ``__shared__`` namespace.
+        keyword_rows = (
+            await session.execute(
+                select(GlossaryKeyword.keyword, GlossaryKeyword.namespace)
+                .where(GlossaryKeyword.node_uuid == node_uuid)
+                .order_by(GlossaryKeyword.namespace, GlossaryKeyword.keyword)
+            )
+        ).all()
+        keyword_by_ns: Dict[str, List[str]] = {}
+        for kw, ns in keyword_rows:
+            if not kw:
+                continue
+            keyword_by_ns.setdefault(ns, []).append(kw)
 
         documents = []
+        shared_keywords = keyword_by_ns.get(SHARED_NAMESPACE, [])
         for row in path_rows:
+            visible = list(keyword_by_ns.get(row.namespace, []))
+            if row.namespace != SHARED_NAMESPACE:
+                visible.extend(shared_keywords)
+            glossary_text = " ".join(visible)
             uri = f"{row.domain}://{row.path}"
             documents.append(
                 {
@@ -199,11 +216,114 @@ class SearchIndexer:
     async def refresh_search_documents_for_node(
         self, node_uuid: str, session: Optional[AsyncSession] = None
     ) -> None:
-        """Rebuild derived search rows for one node."""
+        """Rebuild derived search rows for one node (all namespaces).
+
+        Used when a node's content or structural metadata changed and every
+        path pointing at it needs to be reindexed.
+        """
         async with self._optional_session(session) as session:
             documents = await self._build_search_documents_for_node(session, node_uuid)
             await self._delete_search_documents_for_node(session, node_uuid)
             await self._insert_search_documents(session, documents)
+
+    async def refresh_search_documents_for(
+        self,
+        namespace: str,
+        uri: str | MemoryURI,
+        session: Optional[AsyncSession] = None,
+    ) -> None:
+        """Surgically rebuild ONE search row at (namespace, domain, path).
+
+        Useful when a write touches only a single (namespace, uri) and we
+        don't want to disturb sibling rows for the same node in other
+        namespaces. No-op if the path doesn't exist or has no active memory.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+
+        async with self._optional_session(session) as s:
+            path_row = (
+                await s.execute(
+                    select(Path).where(
+                        Path.namespace == namespace,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
+                    )
+                )
+            ).scalar_one_or_none()
+            if path_row is None:
+                return
+
+            edge = await s.get(Edge, path_row.edge_id)
+            if edge is None:
+                return
+
+            memory = (
+                await s.execute(
+                    select(Memory)
+                    .where(
+                        Memory.node_uuid == edge.child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    )
+                    .order_by(Memory.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if memory is None:
+                return
+
+            keyword_rows = (
+                await s.execute(
+                    select(GlossaryKeyword.keyword)
+                    .where(
+                        GlossaryKeyword.node_uuid == edge.child_uuid,
+                        GlossaryKeyword.namespace.in_(
+                            [namespace, SHARED_NAMESPACE]
+                        ),
+                    )
+                    .order_by(GlossaryKeyword.keyword)
+                )
+            ).all()
+            glossary_text = " ".join(row[0] for row in keyword_rows if row[0])
+
+            uri_str = f"{parsed.domain}://{parsed.path}"
+            doc = {
+                "namespace": namespace,
+                "domain": parsed.domain,
+                "path": parsed.path,
+                "node_uuid": edge.child_uuid,
+                "memory_id": memory.id,
+                "uri": uri_str,
+                "content": memory.content,
+                "disclosure": edge.disclosure,
+                "search_terms": build_document_search_terms(
+                    parsed.path,
+                    uri_str,
+                    memory.content,
+                    edge.disclosure,
+                    glossary_text,
+                ),
+                "priority": edge.priority,
+            }
+
+            if self.db_type == "sqlite":
+                try:
+                    await s.execute(
+                        text(
+                            "DELETE FROM search_documents_fts "
+                            "WHERE namespace = :ns AND domain = :d AND path = :p"
+                        ),
+                        {"ns": namespace, "d": parsed.domain, "p": parsed.path},
+                    )
+                except Exception:
+                    pass
+            await s.execute(
+                delete(SearchDocument).where(
+                    SearchDocument.namespace == namespace,
+                    SearchDocument.domain == parsed.domain,
+                    SearchDocument.path == parsed.path,
+                )
+            )
+            await self._insert_search_documents(s, [doc])
 
     async def get_node_uuids_for_prefix(
         self, session: AsyncSession, domain: str, base_path: str

--- a/omicsclaw/memory/snapshot.py
+++ b/omicsclaw/memory/snapshot.py
@@ -346,14 +346,6 @@ class ChangesetStore:
             os.remove(p)
 
 
-def _parse_uri(uri: str):
-    if "://" in uri:
-        domain, path = uri.split("://", 1)
-    else:
-        domain, path = "core", uri
-    return domain, path
-
-
 # Global singleton
 _store: Optional[ChangesetStore] = None
 

--- a/omicsclaw/memory/uri.py
+++ b/omicsclaw/memory/uri.py
@@ -1,0 +1,61 @@
+"""MemoryURI value object — see docs/CONTEXT.md → "Memory URI"."""
+
+from dataclasses import dataclass
+
+DEFAULT_DOMAIN = "core"
+SCHEME_SEPARATOR = "://"
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryURI:
+    """Stable identifier for a memory location, independent of row id.
+
+    Invariants (enforced in ``__post_init__``):
+      - ``domain`` is non-empty, contains no ``://``, no control chars
+      - ``path`` contains no ``://`` (slashes are fine; they delimit segments)
+
+    Construct via ``parse(raw)`` for ``"domain://path"`` strings, or
+    via ``root(domain)`` for the root URI of a domain.
+    """
+
+    domain: str
+    path: str
+
+    def __post_init__(self) -> None:
+        if not self.domain:
+            raise ValueError("MemoryURI domain must be non-empty")
+        if SCHEME_SEPARATOR in self.domain:
+            raise ValueError(f"MemoryURI domain must not contain '://': {self.domain!r}")
+        if any(ord(c) < 0x20 for c in self.domain):
+            raise ValueError(f"MemoryURI domain must not contain control characters: {self.domain!r}")
+        if SCHEME_SEPARATOR in self.path:
+            raise ValueError(f"MemoryURI path must not contain '://': {self.path!r}")
+
+    @classmethod
+    def parse(cls, raw: str) -> "MemoryURI":
+        if SCHEME_SEPARATOR in raw:
+            domain, path = raw.split(SCHEME_SEPARATOR, 1)
+        else:
+            domain, path = DEFAULT_DOMAIN, raw
+        return cls(domain=domain, path=path)
+
+    @classmethod
+    def root(cls, domain: str = DEFAULT_DOMAIN) -> "MemoryURI":
+        return cls(domain=domain, path="")
+
+    def __str__(self) -> str:
+        return f"{self.domain}{SCHEME_SEPARATOR}{self.path}"
+
+    @property
+    def is_root(self) -> bool:
+        return self.path == ""
+
+    def child(self, name: str) -> "MemoryURI":
+        new_path = f"{self.path}/{name}" if self.path else name
+        return MemoryURI(domain=self.domain, path=new_path)
+
+    def parent(self) -> "MemoryURI | None":
+        if self.is_root:
+            return None
+        head, _, _ = self.path.rpartition("/")
+        return MemoryURI(domain=self.domain, path=head)

--- a/scripts/migrate_dry_run.py
+++ b/scripts/migrate_dry_run.py
@@ -1,0 +1,154 @@
+"""Dry-run for OmicsClaw memory schema migrations.
+
+Copies a memory.db to a temp location and runs all pending migrations against
+the copy, printing a diff (table row counts before/after, namespace
+distribution after, count of disclosures we couldn't parse). Exit code 0
+only if the migration ran cleanly and row counts are preserved.
+
+The original memory.db is never touched.
+
+Usage:
+
+    python scripts/migrate_dry_run.py
+        # Defaults to ~/.config/omicsclaw/memory.db
+
+    python scripts/migrate_dry_run.py --db-path /path/to/memory.db
+
+Recommended workflow before deploying a new migration:
+
+    1. cp ~/.config/omicsclaw/memory.db ~/.config/omicsclaw/memory.db.pre-NNN.bak
+    2. python scripts/migrate_dry_run.py
+    3. Inspect output; rollback recipe is `cp memory.db.pre-NNN.bak memory.db`
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import sqlalchemy as sa
+
+
+_TABLES = ("nodes", "memories", "edges", "paths", "search_documents", "glossary_keywords")
+
+
+async def _row_counts(db) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    async with db.session() as s:
+        for table in _TABLES:
+            try:
+                result = await s.execute(sa.text(f"SELECT COUNT(*) FROM {table}"))
+                counts[table] = result.scalar_one()
+            except Exception as e:
+                counts[table] = -1  # table missing in this state
+    return counts
+
+
+async def _namespace_distribution(db) -> dict[str, int]:
+    """After migration, count rows per namespace across paths."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT namespace, COUNT(*) FROM paths GROUP BY namespace ORDER BY 2 DESC"
+            )
+        )
+        return {row[0]: row[1] for row in result.all()}
+
+
+async def _unparseable_disclosures(db) -> int:
+    """Count search_documents rows that have a non-empty disclosure but
+    still ended up in __shared__ (likely unparseable)."""
+    async with db.session() as s:
+        result = await s.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM search_documents "
+                "WHERE namespace = '__shared__' "
+                "AND disclosure IS NOT NULL "
+                "AND TRIM(disclosure) <> ''"
+            )
+        )
+        return result.scalar_one()
+
+
+async def main_async(db_path: Path) -> int:
+    if not db_path.exists():
+        print(f"ERROR: source DB not found at {db_path}", file=sys.stderr)
+        return 2
+
+    # Copy to a temp file so the original is untouched
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+        copy_path = Path(tmp.name)
+    shutil.copy2(db_path, copy_path)
+    print(f"Copied {db_path} -> {copy_path}")
+    print(f"Source size:  {db_path.stat().st_size:,} bytes")
+
+    # Defer DatabaseManager import so the script remains usable even with a
+    # partial install; if memory deps are missing it will surface here.
+    from omicsclaw.memory.database import DatabaseManager
+
+    url = f"sqlite+aiosqlite:///{copy_path}"
+    db = DatabaseManager(url)
+    try:
+        before = await _row_counts(db)
+        print(f"\nRow counts BEFORE migration:")
+        for tbl, n in before.items():
+            print(f"  {tbl:24s} {n:>8d}")
+
+        # init_db runs all pending migrations via the runner
+        await db.init_db()
+
+        after = await _row_counts(db)
+        print(f"\nRow counts AFTER migration:")
+        for tbl, n in after.items():
+            change = "" if before[tbl] == after[tbl] else f"  ← was {before[tbl]}"
+            print(f"  {tbl:24s} {n:>8d}{change}")
+
+        ns_dist = await _namespace_distribution(db)
+        print(f"\nNamespace distribution (paths) after migration:")
+        for ns, n in ns_dist.items():
+            print(f"  {ns:32s} {n:>8d}")
+
+        unparseable = await _unparseable_disclosures(db)
+        print(f"\nUnparseable disclosures: {unparseable}")
+
+        # Assertions
+        ok = True
+        for tbl in _TABLES:
+            if before[tbl] >= 0 and before[tbl] != after[tbl]:
+                print(
+                    f"\n❌ Row count changed for {tbl}: {before[tbl]} -> {after[tbl]}",
+                    file=sys.stderr,
+                )
+                ok = False
+
+        if ok:
+            print("\n✅ Migration applied cleanly. Row counts preserved.")
+            return 0
+        return 1
+    finally:
+        await db.close()
+        try:
+            copy_path.unlink()
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    default = Path.home() / ".config" / "omicsclaw" / "memory.db"
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=default,
+        help=f"Path to source memory.db (default: {default})",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args.db_path))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_memory_cross_surface.py
+++ b/tests/integration/test_memory_cross_surface.py
@@ -1,0 +1,167 @@
+"""Cross-surface namespace integration tests (PR #5 §5.5).
+
+Each surface (CLI workspace path, Desktop launch_id, Bot platform/user)
+gets its own namespace; they share one engine and one DB. These tests
+prove the partition boundaries hold across the full surface set.
+
+Scenarios:
+  - CLI write in workspace_A is invisible from Bot tg/user42 (and vice versa)
+  - CLI remember_shared write IS visible from Bot recall (read fallback)
+  - Desktop ReviewLog.rollback affects only desktop's namespace; CLI sees
+    its own untouched chain
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def shared_engine(tmp_path, monkeypatch):
+    """One DB, one engine, three surface clients on top."""
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{tmp_path}/cross.db"
+    )
+
+    from omicsclaw.memory import (
+        cli_namespace_from_workspace,
+        close_db,
+        desktop_namespace,
+        get_engine_db,
+        get_memory_client,
+        get_review_log,
+    )
+
+    await close_db()
+    await get_engine_db().init_db()
+
+    cli_a_ns = cli_namespace_from_workspace(str(tmp_path / "workspace_a"))
+    cli_b_ns = cli_namespace_from_workspace(str(tmp_path / "workspace_b"))
+
+    monkeypatch.setenv("OMICSCLAW_DESKTOP_LAUNCH_ID", "test-launch-1")
+    desktop_ns = desktop_namespace()
+
+    cli_a = get_memory_client(namespace=cli_a_ns)
+    cli_b = get_memory_client(namespace=cli_b_ns)
+    desktop = get_memory_client(namespace=desktop_ns)
+    review = get_review_log()
+
+    yield {
+        "cli_a": cli_a,
+        "cli_b": cli_b,
+        "desktop": desktop,
+        "review": review,
+        "cli_a_ns": cli_a_ns,
+        "cli_b_ns": cli_b_ns,
+        "desktop_ns": desktop_ns,
+        "tmp_path": tmp_path,
+    }
+
+    await close_db()
+
+
+@pytest.mark.asyncio
+async def test_cli_write_invisible_from_bot_namespace(shared_engine, tmp_path):
+    """CLI writes in its workspace namespace; bot in tg/user42 doesn't see it."""
+    from omicsclaw.memory.compat import CompatMemoryStore, DatasetMemory
+
+    cli_a = shared_engine["cli_a"]
+    await cli_a.remember(
+        "dataset://my_local.h5ad",
+        "CLI A's local dataset",
+    )
+
+    # The bot uses its own CompatMemoryStore (not the same MemoryClient
+    # instance); but they share the same DB by env var.
+    bot = CompatMemoryStore()
+    await bot.initialize()
+    try:
+        session = await bot.create_session("user42", "telegram")
+        await bot.save_memory(
+            session.session_id, DatasetMemory(file_path="bot_local.h5ad")
+        )
+
+        bot_mem = await bot.get_memories(session.session_id, "dataset")
+        bot_paths = {m.file_path for m in bot_mem}
+        assert "my_local.h5ad" not in bot_paths
+        assert "bot_local.h5ad" in bot_paths
+    finally:
+        await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_cli_remember_shared_visible_via_bot_recall(shared_engine):
+    """remember_shared writes to __shared__; recall from any namespace
+    sees it via fallback."""
+    from omicsclaw.memory.compat import CompatMemoryStore
+
+    cli_a = shared_engine["cli_a"]
+    await cli_a.remember_shared(
+        "core://agent",
+        "you are a global helpful agent",
+    )
+
+    bot = CompatMemoryStore()
+    await bot.initialize()
+    try:
+        session = await bot.create_session("user42", "telegram")
+        # Bot's session-scoped client falls back to __shared__ on recall.
+        client = await bot._client_for_session(session.session_id)
+        record = await client.recall("core://agent")
+        assert record is not None
+        assert record.content == "you are a global helpful agent"
+        assert record.loaded_namespace == "__shared__"
+    finally:
+        await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_desktop_rollback_does_not_affect_cli_chain(shared_engine):
+    """Desktop and CLI both have their own preference://style chain.
+    Rolling back desktop's chain leaves CLI's untouched."""
+    cli_a = shared_engine["cli_a"]
+    desktop = shared_engine["desktop"]
+    review = shared_engine["review"]
+
+    # CLI builds its own chain.
+    cli_v1 = await cli_a.remember("preference://style", "cli v1")
+    cli_v2 = await cli_a.remember("preference://style", "cli v2")
+
+    # Desktop builds its own chain (separate namespace).
+    dt_v1 = await desktop.remember("preference://style", "desktop v1")
+    dt_v2 = await desktop.remember("preference://style", "desktop v2")
+
+    # Roll back the desktop chain to v1.
+    await review.rollback_to(
+        dt_v1["id"], namespace=shared_engine["desktop_ns"]
+    )
+
+    # Desktop now reads v1; CLI still reads its own v2.
+    desktop_record = await desktop.recall("preference://style")
+    cli_record = await cli_a.recall("preference://style")
+
+    assert desktop_record is not None
+    assert cli_record is not None
+    assert desktop_record.content == "desktop v1"
+    assert cli_record.content == "cli v2"
+
+
+@pytest.mark.asyncio
+async def test_two_cli_workspaces_isolate_their_writes(shared_engine):
+    """Two CLI sessions in different workspace dirs don't see each
+    other's per-workspace memories."""
+    cli_a = shared_engine["cli_a"]
+    cli_b = shared_engine["cli_b"]
+
+    await cli_a.remember("analysis://run_42", "ws_a's analysis")
+    await cli_b.remember("analysis://run_42", "ws_b's analysis")
+
+    a_record = await cli_a.recall("analysis://run_42", fallback_to_shared=False)
+    b_record = await cli_b.recall("analysis://run_42", fallback_to_shared=False)
+
+    assert a_record is not None
+    assert b_record is not None
+    assert a_record.content == "ws_a's analysis"
+    assert b_record.content == "ws_b's analysis"
+    assert a_record.namespace != b_record.namespace

--- a/tests/memory/test_compat_namespace.py
+++ b/tests/memory/test_compat_namespace.py
@@ -1,0 +1,207 @@
+"""Tests for CompatMemoryStore namespace injection (PR #4a Task 4a.2).
+
+The plan §4a.2 contract:
+  - save_memory(session_id, mem) extracts (platform, user_id) from the
+    session and writes to namespace = f"{platform}/{user_id}".
+  - Sessions themselves stay in __shared__ so a session_id can be
+    resolved to its user/platform globally.
+  - All existing CompatMemoryStore tests continue to pass.
+
+This is the production data path for Telegram/Feishu bots — a leak here
+would mean user A could see user B's memories. Tests below explicitly
+prove that isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.compat import (
+    CompatMemoryStore,
+    DatasetMemory,
+    PreferenceMemory,
+)
+from omicsclaw.memory.models import Path
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    store = CompatMemoryStore(database_url=f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await store.initialize()
+    yield store
+    await store.close()
+
+
+# ----------------------------------------------------------------------
+# Session storage stays shared
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_is_stored_in_shared_namespace(store):
+    """Session storage stays globally addressable so any worker can
+    resolve a session_id to its (user, platform) without knowing where
+    to look."""
+    session = await store.create_session("user42", "telegram")
+
+    async with store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "session",
+                    Path.path == session.session_id,
+                )
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_get_session_round_trips(store):
+    session = await store.create_session("user42", "telegram")
+    fetched = await store.get_session(session.session_id)
+    assert fetched is not None
+    assert fetched.user_id == "user42"
+    assert fetched.platform == "telegram"
+
+
+# ----------------------------------------------------------------------
+# Memory storage uses session-derived namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_memory_uses_session_derived_namespace(store):
+    """A DatasetMemory saved under a tg session lands in tg/<user_id>."""
+    session = await store.create_session("user42", "telegram")
+    await store.save_memory(
+        session.session_id, DatasetMemory(file_path="pbmc.h5ad")
+    )
+
+    async with store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(Path.domain == "dataset")
+            )
+        ).scalars().all()
+        namespaces = [r.namespace for r in rows]
+
+    assert "telegram/user42" in namespaces
+
+
+@pytest.mark.asyncio
+async def test_save_memory_isolates_users_on_same_platform(store):
+    """The leak-prevention test: two telegram users save the same
+    dataset URI; each only sees their own row."""
+    sa_session = await store.create_session("alice", "telegram")
+    sb_session = await store.create_session("bob", "telegram")
+
+    await store.save_memory(
+        sa_session.session_id, DatasetMemory(file_path="alpha.h5ad")
+    )
+    await store.save_memory(
+        sb_session.session_id, DatasetMemory(file_path="beta.h5ad")
+    )
+
+    a_memories = await store.get_memories(sa_session.session_id, "dataset")
+    b_memories = await store.get_memories(sb_session.session_id, "dataset")
+
+    a_files = {m.file_path for m in a_memories}
+    b_files = {m.file_path for m in b_memories}
+
+    assert a_files == {"alpha.h5ad"}
+    assert b_files == {"beta.h5ad"}
+
+
+@pytest.mark.asyncio
+async def test_save_memory_isolates_users_across_platforms(store):
+    """A telegram user and a feishu user should not see each other's data."""
+    tg = await store.create_session("user1", "telegram")
+    fs = await store.create_session("user1", "feishu")
+
+    await store.save_memory(
+        tg.session_id, DatasetMemory(file_path="tg_only.h5ad")
+    )
+    await store.save_memory(
+        fs.session_id, DatasetMemory(file_path="fs_only.h5ad")
+    )
+
+    tg_mem = await store.get_memories(tg.session_id, "dataset")
+    fs_mem = await store.get_memories(fs.session_id, "dataset")
+
+    assert {m.file_path for m in tg_mem} == {"tg_only.h5ad"}
+    assert {m.file_path for m in fs_mem} == {"fs_only.h5ad"}
+
+
+@pytest.mark.asyncio
+async def test_save_preference_lands_in_user_namespace_versioned(store):
+    """preference://* should be versioned in the user's namespace."""
+    session = await store.create_session("user42", "telegram")
+    await store.save_memory(
+        session.session_id,
+        PreferenceMemory(domain="qc", key="cutoff", value=0.5),
+    )
+
+    async with store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "preference",
+                    Path.path == "qc/cutoff",
+                )
+            )
+        ).scalars().all()
+
+    # Exactly one Path at qc/cutoff (composite PK guarantees this) and
+    # it lives in the user's namespace.
+    assert len(rows) == 1
+    assert rows[0].namespace == "telegram/user42"
+
+
+@pytest.mark.asyncio
+async def test_search_memories_filters_by_session_namespace(store):
+    """search_memories(session_id, query) only finds the session's own
+    memories — never another user's."""
+    sa_session = await store.create_session("alice", "telegram")
+    sb_session = await store.create_session("bob", "telegram")
+
+    await store.save_memory(
+        sa_session.session_id,
+        DatasetMemory(file_path="alpha-secret.h5ad"),
+    )
+    await store.save_memory(
+        sb_session.session_id,
+        DatasetMemory(file_path="beta-secret.h5ad"),
+    )
+
+    a_hits = await store.search_memories(sa_session.session_id, "secret")
+    a_files = {m.file_path for m in a_hits}
+
+    assert "alpha-secret.h5ad" in a_files
+    assert "beta-secret.h5ad" not in a_files
+
+
+@pytest.mark.asyncio
+async def test_save_memory_with_unknown_session_falls_back_to_shared(store):
+    """If the session can't be resolved, write goes to __shared__ — not silently
+    lost. (Defensive default; in practice the bot always creates a session
+    first, so this is the recovery path for log replay or test harnesses.)"""
+    await store.save_memory(
+        "nonexistent-session-id", DatasetMemory(file_path="orphan.h5ad")
+    )
+
+    async with store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "dataset", Path.path == "orphan.h5ad"
+                )
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].namespace == "__shared__"

--- a/tests/memory/test_glossary_namespace.py
+++ b/tests/memory/test_glossary_namespace.py
@@ -1,0 +1,191 @@
+"""Tests for namespace-aware GlossaryService (PR #3c Task 3c.1).
+
+The existing public API stays backward-compatible: ``add_glossary_keyword``
+without ``namespace`` still writes to ``__shared__`` so legacy callers
+(server.py, api/browse.py) keep working unchanged. New callers can pass
+an explicit namespace to scope a keyword to one user/surface, and use
+``add_glossary_shared`` for the explicit shared variant.
+
+``find_glossary_in_content`` gains an optional ``namespace`` filter so
+the search reindexer can scope content scans to (current, ``__shared__``).
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.glossary import GlossaryService
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    eng = MemoryEngine(db, search)
+    glossary = GlossaryService(db, search)
+    yield eng, glossary, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# add_glossary_keyword — namespace parameter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_keyword_default_namespace_is_shared(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword("alpha", ref.node_uuid)
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("alpha", "__shared__")]
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_keyword_with_explicit_namespace(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="tg/userA")
+
+    await glossary.add_glossary_keyword(
+        "user-A-only", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("user-A-only", "tg/userA")]
+
+
+@pytest.mark.asyncio
+async def test_add_glossary_shared_helper(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_shared("globally-known", ref.node_uuid)
+
+    keywords = await _all_keywords_with_namespace(db, ref.node_uuid)
+    assert keywords == [("globally-known", "__shared__")]
+
+
+@pytest.mark.asyncio
+async def test_same_keyword_can_exist_in_multiple_namespaces(env):
+    """Composite UNIQUE on (namespace, keyword, node_uuid) means the same
+    (keyword, node_uuid) can co-exist across namespaces."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword(
+        "shared-token", ref.node_uuid, namespace="__shared__"
+    )
+    await glossary.add_glossary_keyword(
+        "shared-token", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = sorted(
+        await _all_keywords_with_namespace(db, ref.node_uuid)
+    )
+    assert keywords == [
+        ("shared-token", "__shared__"),
+        ("shared-token", "tg/userA"),
+    ]
+
+
+# ----------------------------------------------------------------------
+# remove_glossary_keyword — namespace-scoped
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_glossary_keyword_namespace_scoped(env):
+    """Removing in one namespace must not delete the same keyword in others."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+
+    await glossary.add_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userB"
+    )
+
+    await glossary.remove_glossary_keyword(
+        "ambiguous", ref.node_uuid, namespace="tg/userA"
+    )
+
+    keywords = sorted(
+        await _all_keywords_with_namespace(db, ref.node_uuid)
+    )
+    assert keywords == [("ambiguous", "tg/userB")]
+
+
+# ----------------------------------------------------------------------
+# find_glossary_in_content — namespace filter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_glossary_in_content_filters_to_namespace_plus_shared(env):
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+    await glossary.add_glossary_keyword(
+        "userA-tag", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "userB-tag", ref.node_uuid, namespace="tg/userB"
+    )
+    await glossary.add_glossary_keyword(
+        "global-tag", ref.node_uuid, namespace="__shared__"
+    )
+
+    matches = await glossary.find_glossary_in_content(
+        "userA-tag userB-tag global-tag",
+        namespace="tg/userA",
+    )
+
+    assert "userA-tag" in matches
+    assert "global-tag" in matches
+    assert "userB-tag" not in matches
+
+
+@pytest.mark.asyncio
+async def test_find_glossary_in_content_no_namespace_returns_all(env):
+    """Backward-compatible call (namespace=None) sees every keyword."""
+    eng, glossary, db = env
+    ref = await eng.upsert("core://agent", "x", namespace="__shared__")
+    await glossary.add_glossary_keyword(
+        "userA-tag", ref.node_uuid, namespace="tg/userA"
+    )
+    await glossary.add_glossary_keyword(
+        "global-tag", ref.node_uuid, namespace="__shared__"
+    )
+
+    matches = await glossary.find_glossary_in_content(
+        "userA-tag global-tag"
+    )
+
+    assert "userA-tag" in matches
+    assert "global-tag" in matches
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+async def _all_keywords_with_namespace(db, node_uuid):
+    import sqlalchemy as sa
+
+    from omicsclaw.memory.models import GlossaryKeyword
+
+    async with db.session() as s:
+        result = await s.execute(
+            sa.select(GlossaryKeyword.keyword, GlossaryKeyword.namespace).where(
+                GlossaryKeyword.node_uuid == node_uuid
+            )
+        )
+        return [(row[0], row[1]) for row in result.all()]

--- a/tests/memory/test_init_db_runs_migrations.py
+++ b/tests/memory/test_init_db_runs_migrations.py
@@ -1,0 +1,45 @@
+"""Tests that DatabaseManager.init_db() invokes the migrations runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        # Capture version count after first init
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            count_after_first = result.scalar_one()
+
+        # Second init must not raise and must not re-apply anything
+        await db.init_db()
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT COUNT(*) FROM _schema_version"))
+            assert result.scalar_one() == count_after_first
+    finally:
+        await db.close()

--- a/tests/memory/test_memory_client.py
+++ b/tests/memory/test_memory_client.py
@@ -1,0 +1,294 @@
+"""Tests for the rewritten MemoryClient (PR #4a Task 4a.1).
+
+Constructor: ``MemoryClient(engine=..., namespace="...")``. The legacy
+``MemoryClient(database_url=...)`` form still works for the three
+existing callers (bot, server.py, CompatMemoryStore) and defaults
+``namespace`` to ``__shared__``.
+
+Routing policy (delegated to ``namespace_policy``):
+  - ``core://agent``, ``core://kh/*``, ``core://my_user_default`` → ``__shared__``
+  - everything else → the client's current namespace
+  - ``core://agent``, ``core://my_user``, ``preference://*`` → versioned upsert
+  - everything else → overwrite upsert
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.memory_client import MemoryClient
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    engine = MemoryEngine(db, search)
+    yield engine, db
+    await db.close()
+
+
+@pytest_asyncio.fixture
+async def client_a(env):
+    engine, _ = env
+    yield MemoryClient(engine=engine, namespace="tg/userA")
+
+
+# ----------------------------------------------------------------------
+# remember — routing via namespace_policy
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remember_dataset_writes_to_current_namespace(client_a, env):
+    """dataset:// is per-user — write goes into the client's namespace."""
+    engine, _ = env
+    await client_a.remember("dataset://pbmc.h5ad", "user A's data")
+
+    record = await engine.recall(
+        "dataset://pbmc.h5ad", namespace="tg/userA", fallback_to_shared=False
+    )
+    assert record is not None
+    assert record.content == "user A's data"
+
+
+@pytest.mark.asyncio
+async def test_remember_dataset_overwrites_no_chain(client_a, env):
+    """dataset:// uses overwrite mode — re-remembering does not create a chain."""
+    engine, db = env
+    await client_a.remember("dataset://pbmc.h5ad", "v1")
+    await client_a.remember("dataset://pbmc.h5ad", "v2")
+
+    import sqlalchemy as sa
+
+    from omicsclaw.memory.models import Memory, Path
+
+    async with db.session() as s:
+        path = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "dataset",
+                    Path.path == "pbmc.h5ad",
+                )
+            )
+        ).scalar_one()
+        from omicsclaw.memory.models import Edge
+
+        edge = await s.get(Edge, path.edge_id)
+        memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == edge.child_uuid)
+            )
+        ).scalars().all()
+    assert len(memories) == 1
+    assert memories[0].content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_remember_core_agent_writes_shared_and_versions(client_a, env):
+    """core://agent is shared+versioned — first write to __shared__, second
+    creates a deprecation chain in __shared__."""
+    engine, db = env
+    await client_a.remember("core://agent", "v1")
+    await client_a.remember("core://agent", "v2")
+
+    import sqlalchemy as sa
+
+    from omicsclaw.memory.models import Memory, Path
+
+    async with db.session() as s:
+        path = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "__shared__",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        from omicsclaw.memory.models import Edge
+
+        edge = await s.get(Edge, path.edge_id)
+        memories = (
+            await s.execute(
+                sa.select(Memory)
+                .where(Memory.node_uuid == edge.child_uuid)
+                .order_by(Memory.id)
+            )
+        ).scalars().all()
+
+    assert len(memories) == 2
+    assert memories[0].content == "v1"
+    assert memories[0].deprecated is True
+    assert memories[1].content == "v2"
+    assert memories[1].deprecated is False
+
+
+@pytest.mark.asyncio
+async def test_remember_preference_versioned_in_user_namespace(client_a, env):
+    """preference://* is per-user but versioned (so a user can audit changes)."""
+    engine, db = env
+    await client_a.remember("preference://style", "v1")
+    await client_a.remember("preference://style", "v2")
+
+    import sqlalchemy as sa
+
+    from omicsclaw.memory.models import Edge, Memory, Path
+
+    async with db.session() as s:
+        path = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "preference",
+                    Path.path == "style",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path.edge_id)
+        memories = (
+            await s.execute(
+                sa.select(Memory)
+                .where(Memory.node_uuid == edge.child_uuid)
+                .order_by(Memory.id)
+            )
+        ).scalars().all()
+
+    assert len(memories) == 2
+    assert memories[0].deprecated is True
+
+
+@pytest.mark.asyncio
+async def test_remember_shared_forces_shared_namespace(client_a, env):
+    """remember_shared writes to __shared__ regardless of URI prefix."""
+    engine, _ = env
+    await client_a.remember_shared(
+        "dataset://global_ref.h5ad", "everyone sees this"
+    )
+
+    record = await engine.recall(
+        "dataset://global_ref.h5ad",
+        namespace="__shared__",
+        fallback_to_shared=False,
+    )
+    assert record is not None
+    assert record.content == "everyone sees this"
+
+    # Not visible from another namespace if fallback is off.
+    other = await engine.recall(
+        "dataset://global_ref.h5ad",
+        namespace="tg/userB",
+        fallback_to_shared=False,
+    )
+    assert other is None
+
+
+# ----------------------------------------------------------------------
+# recall / search / list_children — namespace pass-through
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_uses_current_namespace_with_fallback(client_a, env):
+    engine, _ = env
+    await engine.upsert("core://agent", "shared", namespace="__shared__")
+
+    record = await client_a.recall("core://agent")
+
+    assert record is not None
+    assert record.content == "shared"
+    assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_search_filters_to_current_namespace_plus_shared(client_a, env):
+    engine, _ = env
+    await engine.upsert("dataset://A", "user A's data", namespace="tg/userA")
+    await engine.upsert("dataset://B", "user B's data", namespace="tg/userB")
+    await engine.upsert("core://agent", "shared agent", namespace="__shared__")
+
+    hits = await client_a.search("user")
+
+    uris = {h["uri"] for h in hits}
+    assert "dataset://A" in uris
+    assert "dataset://B" not in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_strict_to_current_namespace(client_a, env):
+    engine, _ = env
+    await engine.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    await engine.upsert(
+        "analysis://sc-de/run_1", "user A child", namespace="tg/userA"
+    )
+    await engine.upsert("analysis://sc-de", "shared parent", namespace="__shared__")
+    await engine.upsert(
+        "analysis://sc-de/shared_child", "shared child", namespace="__shared__"
+    )
+
+    children = await client_a.list_children("analysis://sc-de")
+    uris = sorted(c.uri for c in children)
+
+    assert uris == ["analysis://sc-de/run_1"]
+
+
+# ----------------------------------------------------------------------
+# boot — load core identity URIs for LLM context
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boot_loads_default_core_uris(client_a, env, monkeypatch):
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_CORE_URIS", "core://agent,core://my_user"
+    )
+    engine, _ = env
+    await engine.upsert(
+        "core://agent", "you are a helpful agent", namespace="__shared__"
+    )
+    await engine.upsert("core://my_user", "user A profile", namespace="tg/userA")
+
+    boot = await client_a.boot()
+
+    assert "you are a helpful agent" in boot
+    assert "user A profile" in boot
+
+
+# ----------------------------------------------------------------------
+# Constructor variants
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_constructor_with_database_url(tmp_path):
+    """Legacy callers passing database_url still work; default namespace
+    is __shared__ so they keep writing into the legacy partition."""
+    url = f"sqlite+aiosqlite:///{tmp_path}/legacy.db"
+    client = MemoryClient(database_url=url)
+    try:
+        await client.initialize()
+        await client.remember("dataset://x.h5ad", "legacy write")
+
+        record = await client.recall("dataset://x.h5ad")
+        assert record is not None
+        assert record.content == "legacy write"
+    finally:
+        await client.close()
+
+
+def test_constructor_rejects_both_url_and_engine():
+    with pytest.raises(ValueError, match="Pass either"):
+        MemoryClient(database_url="sqlite:///x", engine=object())  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_engine_constructor_uses_supplied_namespace(env):
+    engine, _ = env
+    client = MemoryClient(engine=engine, namespace="app/desktop_user")
+    assert client.namespace == "app/desktop_user"

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -331,6 +331,22 @@ async def test_upsert_versioned_chain_can_have_3_links(engine):
 
 
 @pytest.mark.asyncio
+async def test_upsert_refuses_to_silently_rebuild_orphan_path(engine):
+    """If the active memory has been deactivated leaving a deprecated tail
+    behind, upsert (overwrite) must raise rather than silently fabricate
+    a new active memory — that would break the chain's audit lineage."""
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True  # simulated corruption: active row lost
+
+    with pytest.raises(RuntimeError, match="no active memory"):
+        await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+
+@pytest.mark.asyncio
 async def test_upsert_versioned_returns_namespace_isolated(engine):
     eng, db = engine
 

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -233,3 +233,111 @@ async def test_upsert_accepts_memory_uri_object(engine):
         namespace="tg/userA",
     )
     assert ref.uri == "core://agent"
+
+
+# ----------------------------------------------------------------------
+# upsert_versioned (deprecation chain mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_first_write_no_chain(engine):
+    eng, db = engine
+
+    ref = await eng.upsert_versioned(
+        "core://agent", "v1", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, VersionedMemoryRef)
+    assert ref.old_memory_id is None
+    assert ref.new_memory_id > 0
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.new_memory_id)
+        assert memory.deprecated is False
+        assert memory.migrated_to is None
+        assert memory.content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_creates_chain_on_second_write(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    assert second.old_memory_id == first.new_memory_id
+    assert second.new_memory_id != first.new_memory_id
+    assert second.node_uuid == first.node_uuid
+
+    async with db.session() as s:
+        old = await s.get(Memory, first.new_memory_id)
+        new = await s.get(Memory, second.new_memory_id)
+
+        assert old.deprecated is True
+        assert old.migrated_to == second.new_memory_id
+
+        assert new.deprecated is False
+        assert new.migrated_to is None
+        assert new.content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_old_search_doc_replaced(engine):
+    eng, db = engine
+
+    first = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalars().all()
+        # Exactly one search_documents row at (namespace, domain, path) — the
+        # composite PK guarantees that, but we also assert it points at the
+        # new memory_id, not the deprecated one.
+        assert len(rows) == 1
+        assert rows[0].memory_id == second.new_memory_id
+        assert rows[0].content == "v2"
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_chain_can_have_3_links(engine):
+    eng, db = engine
+
+    r1 = await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    r2 = await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+    r3 = await eng.upsert_versioned("core://agent", "v3", namespace="tg/userA")
+
+    async with db.session() as s:
+        m1 = await s.get(Memory, r1.new_memory_id)
+        m2 = await s.get(Memory, r2.new_memory_id)
+        m3 = await s.get(Memory, r3.new_memory_id)
+
+        assert m1.deprecated is True and m1.migrated_to == r2.new_memory_id
+        assert m2.deprecated is True and m2.migrated_to == r3.new_memory_id
+        assert m3.deprecated is False and m3.migrated_to is None
+
+        # All three memories share the same node_uuid (the conceptual entity).
+        assert m1.node_uuid == m2.node_uuid == m3.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_versioned_returns_namespace_isolated(engine):
+    eng, db = engine
+
+    a = await eng.upsert_versioned("core://agent", "for A", namespace="tg/userA")
+    b = await eng.upsert_versioned("core://agent", "for B", namespace="tg/userB")
+
+    # Different namespaces → independent chains, independent nodes.
+    assert a.node_uuid != b.node_uuid
+    assert a.old_memory_id is None
+    assert b.old_memory_id is None  # B's first write also has no chain

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -341,3 +341,146 @@ async def test_upsert_versioned_returns_namespace_isolated(engine):
     assert a.node_uuid != b.node_uuid
     assert a.old_memory_id is None
     assert b.old_memory_id is None  # B's first write also has no chain
+
+
+# ----------------------------------------------------------------------
+# patch_edge_metadata
+# ----------------------------------------------------------------------
+
+
+async def _get_edge_for(eng, uri: str, namespace: str):
+    """Helper: load the edge backing (namespace, uri)."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    parsed = MemoryURI.parse(uri)
+    async with eng._db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).scalar_one()
+        return await s.get(Edge, path_row.edge_id)
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_priority(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=9
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 9
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_disclosure(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", disclosure="hidden from search"
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.disclosure == "hidden from search"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_updates_both(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    await eng.patch_edge_metadata(
+        "core://agent",
+        namespace="tg/userA",
+        priority=3,
+        disclosure="why this exists",
+    )
+
+    edge = await _get_edge_for(eng, "core://agent", "tg/userA")
+    assert edge.priority == 3
+    assert edge.disclosure == "why this exists"
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_does_not_touch_memory(engine):
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        before = (await s.get(Memory, ref.memory_id)).content
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=1
+    )
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        # Same content; same row id (no new memory created).
+        assert memory.content == before
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == ref.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_refreshes_search_doc(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "content", namespace="tg/userA", priority=0)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=7
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.priority == 7
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_namespace_isolated(engine):
+    eng, db = engine
+    await eng.upsert("core://agent", "A", namespace="tg/userA", priority=1)
+    await eng.upsert("core://agent", "B", namespace="tg/userB", priority=1)
+
+    await eng.patch_edge_metadata(
+        "core://agent", namespace="tg/userA", priority=99
+    )
+
+    edge_a = await _get_edge_for(eng, "core://agent", "tg/userA")
+    edge_b = await _get_edge_for(eng, "core://agent", "tg/userB")
+    assert edge_a.priority == 99
+    assert edge_b.priority == 1  # B unchanged
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_raises_if_path_missing(engine):
+    eng, _ = engine
+    with pytest.raises(LookupError, match="not found"):
+        await eng.patch_edge_metadata(
+            "core://nonexistent", namespace="tg/userA", priority=1
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_edge_metadata_requires_at_least_one_field(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "x", namespace="tg/userA")
+    with pytest.raises(ValueError, match="at least one"):
+        await eng.patch_edge_metadata("core://agent", namespace="tg/userA")

--- a/tests/memory/test_memory_engine.py
+++ b/tests/memory/test_memory_engine.py
@@ -1,0 +1,235 @@
+"""Tests for MemoryEngine — namespace-aware hot-path writes.
+
+PR #3a covers the three write verbs (upsert, upsert_versioned,
+patch_edge_metadata). Read verbs are reserved for PR #3b.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine, MemoryRef, VersionedMemoryRef
+from omicsclaw.memory.models import Edge, Memory, Path, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# upsert (overwrite mode)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_path_and_memory(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "you are a helpful agent", namespace="tg/userA"
+    )
+
+    assert isinstance(ref, MemoryRef)
+    assert ref.namespace == "tg/userA"
+    assert ref.uri == "core://agent"
+    assert ref.memory_id > 0
+    assert ref.node_uuid
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert path_row.edge_id is not None
+
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.child_uuid == ref.node_uuid
+        assert edge.name == "agent"
+
+        memory = await s.get(Memory, ref.memory_id)
+        assert memory.content == "you are a helpful agent"
+        assert memory.deprecated is False
+        assert memory.node_uuid == ref.node_uuid
+
+
+@pytest.mark.asyncio
+async def test_upsert_idempotent_same_namespace_updates_content(engine):
+    eng, db = engine
+
+    first = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+    second = await eng.upsert("core://agent", "v2", namespace="tg/userA")
+
+    # Same memory row — overwrite mode does NOT create a new Memory.
+    assert first.memory_id == second.memory_id
+    assert first.node_uuid == second.node_uuid
+
+    async with db.session() as s:
+        memory = await s.get(Memory, second.memory_id)
+        assert memory.content == "v2"
+
+        # Exactly one Memory row total for this node.
+        all_memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == second.node_uuid)
+            )
+        ).scalars().all()
+        assert len(all_memories) == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_different_namespace_creates_separate_path(engine):
+    eng, db = engine
+
+    a = await eng.upsert("core://agent", "voice for A", namespace="tg/userA")
+    b = await eng.upsert("core://agent", "voice for B", namespace="tg/userB")
+
+    # Independent paths, independent nodes/memories.
+    assert a.namespace != b.namespace
+    assert a.node_uuid != b.node_uuid
+    assert a.memory_id != b.memory_id
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "core", Path.path == "agent"
+                )
+            )
+        ).scalars().all()
+        namespaces = sorted(r.namespace for r in rows)
+        assert namespaces == ["tg/userA", "tg/userB"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_refreshes_search_document(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent", "search me", namespace="tg/userA", priority=5
+    )
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA",
+                    SearchDocument.domain == "core",
+                    SearchDocument.path == "agent",
+                )
+            )
+        ).scalar_one()
+        assert sd.content == "search me"
+        assert sd.memory_id == ref.memory_id
+        assert sd.node_uuid == ref.node_uuid
+        assert sd.uri == "core://agent"
+        assert sd.priority == 5
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_requires_parent(engine):
+    eng, _ = engine
+
+    with pytest.raises(ValueError, match="Parent path"):
+        await eng.upsert(
+            "analysis://sc-de/run_42",
+            "results",
+            namespace="tg/userA",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_nested_path_works_when_parent_exists(engine):
+    eng, db = engine
+
+    parent = await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    child = await eng.upsert(
+        "analysis://sc-de/run_42", "results", namespace="tg/userA"
+    )
+
+    assert child.node_uuid != parent.node_uuid
+
+    async with db.session() as s:
+        edge = (
+            await s.execute(
+                sa.select(Edge).where(Edge.child_uuid == child.node_uuid)
+            )
+        ).scalar_one()
+        assert edge.parent_uuid == parent.node_uuid
+        assert edge.name == "run_42"
+
+
+@pytest.mark.asyncio
+async def test_upsert_priority_and_disclosure_on_create(engine):
+    eng, db = engine
+
+    ref = await eng.upsert(
+        "core://agent",
+        "content",
+        namespace="tg/userA",
+        priority=7,
+        disclosure="user-set",
+    )
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 7
+        assert edge.disclosure == "user-set"
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_clobber_priority_when_omitted_on_update(engine):
+    """Re-calling upsert without priority should preserve the edge's priority."""
+    eng, db = engine
+
+    await eng.upsert("core://agent", "v1", namespace="tg/userA", priority=42)
+    await eng.upsert("core://agent", "v2", namespace="tg/userA")  # priority omitted
+
+    async with db.session() as s:
+        path_row = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "core",
+                    Path.path == "agent",
+                )
+            )
+        ).scalar_one()
+        edge = await s.get(Edge, path_row.edge_id)
+        assert edge.priority == 42
+
+
+@pytest.mark.asyncio
+async def test_upsert_accepts_memory_uri_object(engine):
+    """upsert should accept either a string or a MemoryURI."""
+    from omicsclaw.memory.uri import MemoryURI
+
+    eng, db = engine
+    ref = await eng.upsert(
+        MemoryURI(domain="core", path="agent"),
+        "content",
+        namespace="tg/userA",
+    )
+    assert ref.uri == "core://agent"

--- a/tests/memory/test_memory_engine_integration.py
+++ b/tests/memory/test_memory_engine_integration.py
@@ -1,0 +1,193 @@
+"""End-to-end + cross-namespace integration tests for MemoryEngine.
+
+Exercise the full upsert → recall → search → list_children → get_subtree
+loop under realistic multi-tenant scenarios. These tests are the
+checkpoint guardrails referenced in the plan §3b — if they regress,
+namespace isolation has cracked somewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# Plan checkpoint scenarios
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_across_three_namespaces(engine):
+    """Upsert and recall round-trip independently for three users."""
+    eng, _ = engine
+    namespaces = ("tg/userA", "tg/userB", "app/desktop_user")
+    for ns in namespaces:
+        await eng.upsert(
+            "preference://style",
+            f"{ns}'s style",
+            namespace=ns,
+        )
+
+    for ns in namespaces:
+        record = await eng.recall("preference://style", namespace=ns)
+        assert record is not None
+        assert record.content == f"{ns}'s style"
+        assert record.loaded_namespace == ns
+
+
+@pytest.mark.asyncio
+async def test_cross_namespace_isolation_without_fallback(engine):
+    """A write in ns/A is invisible from ns/B when fallback is disabled."""
+    eng, _ = engine
+    await eng.upsert(
+        "dataset://pbmc.h5ad", "user A's secret", namespace="tg/userA"
+    )
+
+    # Each surface gets a clean view without fallback.
+    for other_ns in ("tg/userB", "app/desktop_user"):
+        record = await eng.recall(
+            "dataset://pbmc.h5ad",
+            namespace=other_ns,
+            fallback_to_shared=False,
+        )
+        assert record is None
+
+        hits = await eng.search("secret", namespace=other_ns)
+        assert all(h["uri"] != "dataset://pbmc.h5ad" for h in hits)
+
+        children = await eng.list_children(
+            "dataset://", namespace=other_ns
+        )
+        assert all(
+            c.uri != "dataset://pbmc.h5ad" for c in children
+        )
+
+
+@pytest.mark.asyncio
+async def test_shared_content_visible_via_recall_fallback(engine):
+    """Globally-shared content (core://agent) is visible from any namespace."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent",
+        "you are a helpful agent",
+        namespace="__shared__",
+    )
+
+    for ns in ("tg/userA", "tg/userB", "app/desktop_user"):
+        record = await eng.recall("core://agent", namespace=ns)
+        assert record is not None
+        assert record.content == "you are a helpful agent"
+        assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_user_override_shadows_shared_in_recall(engine):
+    """When a per-user write exists, it shadows the shared one for that user."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared default", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent", "user A override", namespace="tg/userA"
+    )
+
+    a = await eng.recall("core://agent", namespace="tg/userA")
+    b = await eng.recall("core://agent", namespace="tg/userB")
+
+    assert a.content == "user A override"
+    assert a.loaded_namespace == "tg/userA"
+    assert b.content == "shared default"
+    assert b.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_search_combines_namespace_and_shared(engine):
+    """Search returns both per-namespace and shared hits."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "helpful agent (shared)", namespace="__shared__"
+    )
+    await eng.upsert(
+        "preference://style",
+        "user A wants helpful style",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("helpful", namespace="tg/userA", limit=10)
+    uris = {h["uri"] for h in hits}
+
+    assert "core://agent" in uris
+    assert "preference://style" in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_does_not_combine_with_shared(engine):
+    """Strict listing — shared subtree is invisible to per-user list_children."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared parent", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+
+    user_children = await eng.list_children(
+        "core://agent", namespace="tg/userA"
+    )
+    shared_children = await eng.list_children(
+        "core://agent", namespace="__shared__"
+    )
+
+    assert user_children == []
+    assert {c.uri for c in shared_children} == {"core://agent/voice"}
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_strict_to_namespace(engine):
+    """Subtree listing is strict — does not blend in shared content."""
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "shared", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/style", "user A style", namespace="tg/userA"
+    )
+
+    subtree = await eng.get_subtree("core://agent", namespace="tg/userA")
+    uris = sorted(r.uri for r in subtree)
+
+    # Only the user's own writes — no shared parent, no shared voice.
+    assert uris == ["core://agent/style"]
+
+
+@pytest.mark.asyncio
+async def test_versioned_chain_recall_returns_active_head(engine):
+    """After three versioned writes, recall returns the active head only."""
+    eng, _ = engine
+    await eng.upsert_versioned("core://agent", "v1", namespace="tg/userA")
+    await eng.upsert_versioned("core://agent", "v2", namespace="tg/userA")
+    r3 = await eng.upsert_versioned(
+        "core://agent", "v3", namespace="tg/userA"
+    )
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+    assert record is not None
+    assert record.content == "v3"
+    assert record.memory_id == r3.new_memory_id

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -263,3 +263,125 @@ async def test_search_orders_namespace_before_shared(engine):
     a_idx = uris.index("preference://style")
     shared_idx = uris.index("core://agent")
     assert a_idx < shared_idx
+
+
+# ----------------------------------------------------------------------
+# list_children — strict-namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_direct_children_in_namespace(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_42", "child A", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_99", "child B", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+
+    uris = sorted(c.uri for c in children)
+    assert uris == ["analysis://sc-de/run_42", "analysis://sc-de/run_99"]
+    assert all(c.namespace == "tg/userA" for c in children)
+
+
+@pytest.mark.asyncio
+async def test_list_children_does_not_include_grandchildren(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_42", "child", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_42/sub", "grandchild", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+    uris = [c.uri for c in children]
+
+    assert "analysis://sc-de/run_42" in uris
+    assert "analysis://sc-de/run_42/sub" not in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_strict_excludes_shared_children(engine):
+    """When the parent is shared and a child also lives in __shared__, that
+    shared child must NOT appear in a per-user listing — strict semantics."""
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared parent", namespace="__shared__")
+    await eng.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+    await eng.upsert(
+        "core://agent/style",
+        "user A's style override",
+        namespace="tg/userA",
+    )
+
+    children = await eng.list_children("core://agent", namespace="tg/userA")
+    uris = sorted(c.uri for c in children)
+
+    assert uris == ["core://agent/style"]
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_empty_when_no_children(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "parent only", namespace="tg/userA")
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+    assert children == []
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_empty_when_parent_missing(engine):
+    eng, _ = engine
+    children = await eng.list_children(
+        "analysis://nonexistent", namespace="tg/userA"
+    )
+    assert children == []
+
+
+@pytest.mark.asyncio
+async def test_list_children_root_lists_top_level(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "top1", namespace="tg/userA")
+    await eng.upsert("analysis://sc-velocity", "top2", namespace="tg/userA")
+
+    from omicsclaw.memory.uri import MemoryURI
+
+    children = await eng.list_children(
+        MemoryURI(domain="analysis", path=""), namespace="tg/userA"
+    )
+    uris = sorted(c.uri for c in children)
+
+    assert "analysis://sc-de" in uris
+    assert "analysis://sc-velocity" in uris
+
+
+@pytest.mark.asyncio
+async def test_list_children_returns_active_memory_ref(engine):
+    eng, db = engine
+    parent = await eng.upsert("analysis://sc-de", "parent", namespace="tg/userA")
+    child = await eng.upsert(
+        "analysis://sc-de/run_42", "child", namespace="tg/userA"
+    )
+
+    children = await eng.list_children(
+        "analysis://sc-de", namespace="tg/userA"
+    )
+
+    assert len(children) == 1
+    ref = children[0]
+    assert isinstance(ref, MemoryRef)
+    assert ref.memory_id == child.memory_id
+    assert ref.node_uuid == child.node_uuid

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -385,3 +385,131 @@ async def test_list_children_returns_active_memory_ref(engine):
     assert isinstance(ref, MemoryRef)
     assert ref.memory_id == child.memory_id
     assert ref.node_uuid == child.node_uuid
+
+
+# ----------------------------------------------------------------------
+# get_subtree — flat listing under a prefix
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_returns_root_and_descendants(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_1", "child1", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_1/sub", "grand", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "analysis://sc-de/run_2", "child2", namespace="tg/userA"
+    )
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert uris == [
+        "analysis://sc-de",
+        "analysis://sc-de/run_1",
+        "analysis://sc-de/run_1/sub",
+        "analysis://sc-de/run_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_excludes_other_namespaces(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "user A's", namespace="tg/userA")
+    await eng.upsert(
+        "analysis://sc-de/run_1", "user A's child", namespace="tg/userA"
+    )
+    await eng.upsert("analysis://sc-de", "user B's", namespace="tg/userB")
+    await eng.upsert(
+        "analysis://sc-de/run_99", "user B's child", namespace="tg/userB"
+    )
+    await eng.upsert("analysis://sc-de", "shared", namespace="__shared__")
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = sorted(r.uri for r in subtree)
+    namespaces = {r.namespace for r in subtree}
+
+    assert uris == ["analysis://sc-de", "analysis://sc-de/run_1"]
+    assert namespaces == {"tg/userA"}
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_excludes_paths_outside_prefix(engine):
+    """Sibling paths that share a prefix substring (not a directory prefix)
+    must not be included — e.g. ``sc-de-bonus`` is not under ``sc-de``."""
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "x", namespace="tg/userA")
+    await eng.upsert("analysis://sc-de/run_1", "y", namespace="tg/userA")
+    await eng.upsert("analysis://sc-de-bonus", "z", namespace="tg/userA")
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert "analysis://sc-de-bonus" not in uris
+    assert "analysis://sc-de/run_1" in uris
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_respects_limit(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    for i in range(10):
+        await eng.upsert(
+            f"analysis://sc-de/run_{i}", f"r{i}", namespace="tg/userA"
+        )
+
+    subtree = await eng.get_subtree(
+        "analysis://sc-de", namespace="tg/userA", limit=3
+    )
+    assert len(subtree) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_returns_empty_when_no_match(engine):
+    eng, _ = engine
+    subtree = await eng.get_subtree(
+        "analysis://nope", namespace="tg/userA"
+    )
+    assert subtree == []
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_root_uri_lists_namespace_in_domain(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "x", namespace="tg/userA")
+    await eng.upsert("analysis://sc-velocity", "y", namespace="tg/userA")
+    await eng.upsert("dataset://pbmc.h5ad", "z", namespace="tg/userA")
+
+    from omicsclaw.memory.uri import MemoryURI
+
+    subtree = await eng.get_subtree(
+        MemoryURI(domain="analysis", path=""), namespace="tg/userA"
+    )
+    uris = sorted(r.uri for r in subtree)
+
+    assert uris == ["analysis://sc-de", "analysis://sc-velocity"]
+    assert all(r.uri.startswith("analysis://") for r in subtree)
+
+
+@pytest.mark.asyncio
+async def test_get_subtree_skips_paths_with_no_active_memory(engine):
+    eng, db = engine
+    await eng.upsert("analysis://sc-de", "root", namespace="tg/userA")
+    ref = await eng.upsert(
+        "analysis://sc-de/run_1", "child", namespace="tg/userA"
+    )
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True
+
+    subtree = await eng.get_subtree("analysis://sc-de", namespace="tg/userA")
+    uris = [r.uri for r in subtree]
+
+    assert "analysis://sc-de" in uris
+    assert "analysis://sc-de/run_1" not in uris

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -150,3 +150,116 @@ async def test_recall_accepts_memory_uri_object(engine):
     )
     assert record is not None
     assert record.uri == "core://agent"
+
+
+# ----------------------------------------------------------------------
+# search — namespace-combined FTS
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_finds_in_namespace(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "analysis://sc-de", "perform differential expression", namespace="tg/userA"
+    )
+
+    hits = await eng.search("differential", namespace="tg/userA")
+
+    assert any(hit["uri"] == "analysis://sc-de" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_finds_shared_content(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent",
+        "you are a helpful spatial omics agent",
+        namespace="__shared__",
+    )
+
+    hits = await eng.search("spatial omics", namespace="tg/userA")
+
+    assert any(hit["uri"] == "core://agent" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_leak_across_namespaces(engine):
+    """Critical: writes in ns/A must not appear in searches from ns/B."""
+    eng, _ = engine
+    await eng.upsert(
+        "dataset://pbmc.h5ad",
+        "user A's secret dataset",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("secret", namespace="tg/userB")
+
+    assert all(hit["uri"] != "dataset://pbmc.h5ad" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_respects_domain_filter(engine):
+    eng, _ = engine
+    await eng.upsert(
+        "analysis://sc-de", "differential expression", namespace="tg/userA"
+    )
+    await eng.upsert(
+        "dataset://pbmc.h5ad", "differential dataset", namespace="tg/userA"
+    )
+
+    hits = await eng.search(
+        "differential", namespace="tg/userA", domain="analysis"
+    )
+
+    assert all(hit["domain"] == "analysis" for hit in hits)
+
+
+@pytest.mark.asyncio
+async def test_search_respects_limit(engine):
+    eng, _ = engine
+    for i in range(5):
+        await eng.upsert(
+            f"analysis://run_{i}",
+            f"differential expression run {i}",
+            namespace="tg/userA",
+        )
+
+    hits = await eng.search("differential", namespace="tg/userA", limit=2)
+
+    assert len(hits) <= 2
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_for_no_match(engine):
+    eng, _ = engine
+    await eng.upsert("analysis://sc-de", "alpha", namespace="tg/userA")
+
+    hits = await eng.search("zeta-not-present", namespace="tg/userA")
+
+    assert hits == []
+
+
+@pytest.mark.asyncio
+async def test_search_orders_namespace_before_shared(engine):
+    """Per-namespace hits should outrank __shared__ hits with comparable score.
+
+    Both rows match the same query token; the namespace's row should appear
+    in the result list before the shared one.
+    """
+    eng, _ = engine
+    await eng.upsert(
+        "core://agent", "you are a helpful agent", namespace="__shared__"
+    )
+    await eng.upsert(
+        "preference://style",
+        "user A prefers helpful agents",
+        namespace="tg/userA",
+    )
+
+    hits = await eng.search("helpful", namespace="tg/userA", limit=10)
+
+    uris = [h["uri"] for h in hits]
+    a_idx = uris.index("preference://style")
+    shared_idx = uris.index("core://agent")
+    assert a_idx < shared_idx

--- a/tests/memory/test_memory_engine_read.py
+++ b/tests/memory/test_memory_engine_read.py
@@ -1,0 +1,152 @@
+"""Tests for MemoryEngine read verbs (PR #3b).
+
+Covers ``recall`` (with shared fallback), ``search`` (namespace-combined),
+``list_children`` (strict-namespace), ``get_subtree`` (flat listing), and
+the cross-namespace integration scenarios from the plan checkpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine, MemoryRecord, MemoryRef
+from omicsclaw.memory.models import Memory
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# recall — happy path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_record_when_present(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "you are an agent", namespace="tg/userA")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record is not None
+    assert isinstance(record, MemoryRecord)
+    assert record.content == "you are an agent"
+    assert record.namespace == "tg/userA"
+    assert record.loaded_namespace == "tg/userA"
+    assert record.uri == "core://agent"
+    assert record.memory_id > 0
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_none_when_missing(engine):
+    eng, _ = engine
+    record = await eng.recall("core://nope", namespace="tg/userA")
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_returns_none_when_only_deprecated_versions_exist(engine):
+    eng, db = engine
+    ref = await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        memory = await s.get(Memory, ref.memory_id)
+        memory.deprecated = True
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+    assert record is None
+
+
+# ----------------------------------------------------------------------
+# recall — shared fallback
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_falls_back_to_shared_when_default(engine):
+    eng, _ = engine
+    # Seed the same URI in __shared__ only.
+    await eng.upsert("core://agent", "shared content", namespace="__shared__")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record is not None
+    assert record.content == "shared content"
+    # Fields preserve the *requested* namespace; loaded_namespace tells the
+    # caller where the row actually came from.
+    assert record.namespace == "tg/userA"
+    assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_recall_strict_does_not_fall_back(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared content", namespace="__shared__")
+
+    record = await eng.recall(
+        "core://agent", namespace="tg/userA", fallback_to_shared=False
+    )
+
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_prefers_namespace_over_shared(engine):
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared", namespace="__shared__")
+    await eng.upsert("core://agent", "user A own", namespace="tg/userA")
+
+    record = await eng.recall("core://agent", namespace="tg/userA")
+
+    assert record.content == "user A own"
+    assert record.loaded_namespace == "tg/userA"
+
+
+@pytest.mark.asyncio
+async def test_recall_namespace_isolation(engine):
+    """Without fallback, a write in ns/A is invisible from ns/B."""
+    eng, _ = engine
+    await eng.upsert("dataset://pbmc.h5ad", "user A's dataset", namespace="tg/userA")
+
+    record = await eng.recall(
+        "dataset://pbmc.h5ad",
+        namespace="tg/userB",
+        fallback_to_shared=False,
+    )
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_recall_shared_recall_from_shared_returns_directly(engine):
+    """Reading from __shared__ shouldn't try to fall back to itself twice."""
+    eng, _ = engine
+    await eng.upsert("core://agent", "shared", namespace="__shared__")
+
+    record = await eng.recall("core://agent", namespace="__shared__")
+
+    assert record is not None
+    assert record.loaded_namespace == "__shared__"
+
+
+@pytest.mark.asyncio
+async def test_recall_accepts_memory_uri_object(engine):
+    from omicsclaw.memory.uri import MemoryURI
+
+    eng, _ = engine
+    await eng.upsert("core://agent", "x", namespace="tg/userA")
+
+    record = await eng.recall(
+        MemoryURI(domain="core", path="agent"), namespace="tg/userA"
+    )
+    assert record is not None
+    assert record.uri == "core://agent"

--- a/tests/memory/test_memory_uri.py
+++ b/tests/memory/test_memory_uri.py
@@ -1,0 +1,113 @@
+"""Tests for MemoryURI value object.
+
+See docs/CONTEXT.md → "Memory URI" for the contract this exercises.
+"""
+
+import pytest
+
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_parse_basic_uri():
+    uri = MemoryURI.parse("core://agent")
+    assert uri.domain == "core"
+    assert uri.path == "agent"
+
+
+def test_str_canonical_form():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    assert str(uri) == "dataset://pbmc.h5ad"
+
+
+def test_is_root_property():
+    assert MemoryURI(domain="core", path="").is_root is True
+    assert MemoryURI(domain="core", path="agent").is_root is False
+
+
+def test_child_appends_name_with_slash():
+    parent = MemoryURI(domain="analysis", path="sc-de")
+    assert parent.child("run_42") == MemoryURI(domain="analysis", path="sc-de/run_42")
+
+
+def test_child_of_root_has_no_leading_slash():
+    root = MemoryURI(domain="core", path="")
+    assert root.child("agent") == MemoryURI(domain="core", path="agent")
+
+
+def test_parent_strips_last_segment():
+    uri = MemoryURI(domain="analysis", path="sc-de/run_42")
+    assert uri.parent() == MemoryURI(domain="analysis", path="sc-de")
+
+
+def test_parent_of_single_segment_returns_root():
+    uri = MemoryURI(domain="dataset", path="pbmc.h5ad")
+    parent = uri.parent()
+    assert parent == MemoryURI(domain="dataset", path="")
+    assert parent.is_root
+
+
+def test_parent_of_root_returns_none():
+    root = MemoryURI(domain="core", path="")
+    assert root.parent() is None
+
+
+def test_parse_without_scheme_defaults_to_core():
+    uri = MemoryURI.parse("agent")
+    assert uri == MemoryURI(domain="core", path="agent")
+
+
+def test_parse_root_uri_with_empty_path():
+    uri = MemoryURI.parse("core://")
+    assert uri == MemoryURI(domain="core", path="")
+    assert uri.is_root
+
+
+def test_root_classmethod_creates_root_uri():
+    assert MemoryURI.root("dataset") == MemoryURI(domain="dataset", path="")
+    assert MemoryURI.root() == MemoryURI(domain="core", path="")
+    assert MemoryURI.root("dataset").is_root
+
+
+def test_parse_str_roundtrip():
+    for raw in (
+        "core://agent",
+        "dataset://pbmc.h5ad",
+        "analysis://sc-de/run_42",
+        "core://",
+    ):
+        assert str(MemoryURI.parse(raw)) == raw, f"roundtrip failed for {raw!r}"
+
+
+def test_uri_is_hashable_and_equal_by_value():
+    a = MemoryURI(domain="core", path="agent")
+    b = MemoryURI(domain="core", path="agent")
+    c = MemoryURI(domain="core", path="other")
+    assert a == b
+    assert a != c
+    assert hash(a) == hash(b)
+    assert len({a, b, c}) == 2  # set deduplicates a/b
+
+
+def test_empty_domain_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="", path="agent")
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI.parse("://agent")
+
+
+def test_domain_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain="core://nope", path="agent")
+
+
+def test_path_with_scheme_separator_rejected():
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI(domain="core", path="x://y")
+    with pytest.raises(ValueError, match="path"):
+        MemoryURI.parse("core://x://y")
+
+
+@pytest.mark.parametrize("bad_char", ["\n", "\t", "\x00", "\r"])
+def test_domain_with_control_chars_rejected(bad_char):
+    with pytest.raises(ValueError, match="domain"):
+        MemoryURI(domain=f"core{bad_char}", path="agent")

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -14,9 +14,56 @@ def _load_001():
 
 
 async def _build_legacy_schema(db: DatabaseManager) -> None:
-    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    """Create the pre-001 schema explicitly (no namespace column).
+
+    The current ORM models already include ``namespace``, so we can't simply
+    call ``Base.metadata.create_all`` and expect a legacy result. Instead:
+
+    1. ``create_all`` to set up unrelated tables (nodes, memories, edges).
+    2. Drop the three namespace-bearing tables and recreate them with the
+       pre-001 schema using raw SQL so the migration has real legacy rows
+       to act on.
+    """
     async with db.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+
+    async with db.session() as s:
+        await s.execute(sa.text("DROP TABLE IF EXISTS paths"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS search_documents"))
+        await s.execute(sa.text("DROP TABLE IF EXISTS glossary_keywords"))
+        await s.execute(sa.text("""
+            CREATE TABLE paths (
+                domain     VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path       VARCHAR(512) NOT NULL,
+                edge_id    INTEGER REFERENCES edges(id),
+                created_at DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE search_documents (
+                domain       VARCHAR(64)  NOT NULL DEFAULT 'core',
+                path         VARCHAR(512) NOT NULL,
+                node_uuid    VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                memory_id    INTEGER      NOT NULL REFERENCES memories(id) ON DELETE CASCADE,
+                uri          TEXT         NOT NULL,
+                content      TEXT         NOT NULL,
+                disclosure   TEXT,
+                search_terms TEXT         NOT NULL DEFAULT '',
+                priority     INTEGER      NOT NULL DEFAULT 0,
+                updated_at   DATETIME,
+                PRIMARY KEY (domain, path)
+            )
+        """))
+        await s.execute(sa.text("""
+            CREATE TABLE glossary_keywords (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword    TEXT         NOT NULL,
+                node_uuid  VARCHAR(36)  NOT NULL REFERENCES nodes(uuid) ON DELETE CASCADE,
+                created_at DATETIME,
+                UNIQUE (keyword, node_uuid)
+            )
+        """))
 
 
 async def _pk_columns_in_order(s, table: str) -> list[str]:

--- a/tests/memory/test_migration_001_namespace.py
+++ b/tests/memory/test_migration_001_namespace.py
@@ -1,0 +1,421 @@
+"""Tests for migration 001_namespace — schema rebuild + disclosure backfill."""
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.models import Base
+
+
+def _load_001():
+    return importlib.import_module("omicsclaw.memory.migrations.001_namespace")
+
+
+async def _build_legacy_schema(db: DatabaseManager) -> None:
+    """Create the pre-001 schema (current ORM models — no namespace column)."""
+    async with db.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def _pk_columns_in_order(s, table: str) -> list[str]:
+    result = await s.execute(sa.text(f"PRAGMA table_info({table})"))
+    rows = [(row[1], row[5]) for row in result.all() if row[5] > 0]
+    rows.sort(key=lambda x: x[1])
+    return [name for name, _ in rows]
+
+
+@pytest.mark.asyncio
+async def test_001_adds_namespace_column_to_paths(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_paths_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "paths") == ["namespace", "domain", "path"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_search_documents_pk_is_namespace_domain_path(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            assert await _pk_columns_in_order(s, "search_documents") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+            result = await s.execute(sa.text("PRAGMA table_info(search_documents)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_is_idempotent(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+        await mig.apply(db)  # second invocation must not raise or duplicate work
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert cols.count("namespace") == 1
+            assert await _pk_columns_in_order(s, "paths") == [
+                "namespace",
+                "domain",
+                "path",
+            ]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_idempotent_does_not_reset_post_migration_namespaces(tmp_path):
+    """Re-running 001 must preserve any namespace edits already applied."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a single legacy path
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('n1')"))
+            await s.execute(
+                sa.text(
+                    "INSERT INTO edges (id, parent_uuid, child_uuid, name) "
+                    "VALUES (1, 'n1', 'n1', 'test')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO paths (domain, path, edge_id) "
+                    "VALUES ('core', 'foo', 1)"
+                )
+            )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Caller updates namespace after migration
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "UPDATE paths SET namespace='tg/userA' "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+
+        # Re-running the migration must NOT reset that namespace
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='core' AND path='foo'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+async def _build_legacy_schema_with_fts(db: DatabaseManager) -> None:
+    """Legacy schema + the legacy FTS5 virtual table (no namespace col)."""
+    await _build_legacy_schema(db)
+    async with db.session() as s:
+        await s.execute(sa.text("""
+            CREATE VIRTUAL TABLE search_documents_fts USING fts5(
+                domain, path, node_uuid, uri, content, disclosure, search_terms,
+                content=search_documents,
+                content_rowid=rowid
+            )
+        """))
+
+
+@pytest.mark.asyncio
+async def test_001_rebuilds_fts5_with_namespace_column(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            # If namespace is a column on the FTS table, this query parses.
+            await s.execute(sa.text("SELECT namespace FROM search_documents_fts LIMIT 0"))
+    finally:
+        await db.close()
+
+
+async def _seed_path_with_disclosure(
+    db: DatabaseManager,
+    *,
+    domain: str,
+    path: str,
+    disclosure: str,
+) -> None:
+    """Seed nodes/edges/paths/memories/search_documents for one path row."""
+    async with db.session() as s:
+        await s.execute(sa.text("INSERT OR IGNORE INTO nodes (uuid) VALUES ('n1')"))
+        await s.execute(
+            sa.text(
+                "INSERT OR IGNORE INTO edges (id, parent_uuid, child_uuid, name) "
+                "VALUES (1, 'n1', 'n1', 'seed')"
+            )
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO paths (domain, path, edge_id) "
+                "VALUES (:d, :p, 1)"
+            ),
+            {"d": domain, "p": path},
+        )
+        await s.execute(
+            sa.text(
+                "INSERT INTO memories (node_uuid, content) "
+                "VALUES ('n1', 'test-content')"
+            )
+        )
+        result = await s.execute(sa.text("SELECT last_insert_rowid()"))
+        memory_id = result.scalar_one()
+        await s.execute(
+            sa.text(
+                "INSERT INTO search_documents "
+                "(domain, path, node_uuid, memory_id, uri, content, "
+                "disclosure, search_terms, priority) "
+                "VALUES (:d, :p, 'n1', :mid, :uri, 'test-content', :disc, :st, 0)"
+            ),
+            {
+                "d": domain,
+                "p": path,
+                "mid": memory_id,
+                "uri": f"{domain}://{path}",
+                "disc": disclosure,
+                "st": path,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_memory_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="sc-de/run42",
+            disclosure="Memory from session app:userA:abcdef",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM search_documents "
+                    "WHERE domain='analysis' AND path='sc-de/run42'"
+                )
+            )
+            assert result.scalar_one() == "app/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_backfills_namespace_from_session_disclosure(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="session",
+            path="abc123",
+            disclosure="Session for user userA on tg",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='session' AND path='abc123'"
+                )
+            )
+            assert result.scalar_one() == "tg/userA"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_falls_back_to_shared_when_disclosure_unparseable(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+        await _seed_path_with_disclosure(
+            db,
+            domain="analysis",
+            path="orphan",
+            disclosure="some garbage that doesn't match",
+        )
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT namespace FROM paths "
+                    "WHERE domain='analysis' AND path='orphan'"
+                )
+            )
+            assert result.scalar_one() == "__shared__"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_preserves_row_counts(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema_with_fts(db)
+
+        for i in range(5):
+            await _seed_path_with_disclosure(
+                db,
+                domain="analysis",
+                path=f"run_{i}",
+                disclosure=f"Memory from session app:user{i}:s{i}",
+            )
+
+        async def counts(s):
+            return {
+                tbl: (
+                    await s.execute(sa.text(f"SELECT COUNT(*) FROM {tbl}"))
+                ).scalar_one()
+                for tbl in ("paths", "search_documents", "memories", "nodes", "edges")
+            }
+
+        async with db.session() as s:
+            before = await counts(s)
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        async with db.session() as s:
+            after = await counts(s)
+
+        assert before == after
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_discovered_and_run_via_init_db(tmp_path):
+    """End-to-end: init_db on a fresh DB applies 001 via discovery."""
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await db.init_db()
+
+        async with db.session() as s:
+            # paths has namespace column post-migration
+            result = await s.execute(sa.text("PRAGMA table_info(paths)"))
+            cols = [row[1] for row in result.all()]
+            assert "namespace" in cols
+
+            # 001 was recorded by the runner
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert "001_namespace" in {row[0] for row in result.all()}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_001_glossary_keywords_has_namespace_in_unique_constraint(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await _build_legacy_schema(db)
+
+        # Seed a node so glossary FK is valid
+        async with db.session() as s:
+            await s.execute(sa.text("INSERT INTO nodes (uuid) VALUES ('node-1')"))
+
+        mig = _load_001()
+        await mig.apply(db)
+
+        # Same (keyword, node_uuid) but different namespace — both must succeed
+        async with db.session() as s:
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns1')"
+                )
+            )
+            await s.execute(
+                sa.text(
+                    "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                    "VALUES ('foo', 'node-1', 'ns2')"
+                )
+            )
+            result = await s.execute(
+                sa.text("SELECT COUNT(*) FROM glossary_keywords")
+            )
+            assert result.scalar_one() == 2
+
+        # Duplicate (namespace, keyword, node_uuid) — must fail
+        with pytest.raises(Exception):
+            async with db.session() as s:
+                await s.execute(
+                    sa.text(
+                        "INSERT INTO glossary_keywords (keyword, node_uuid, namespace) "
+                        "VALUES ('foo', 'node-1', 'ns1')"
+                    )
+                )
+    finally:
+        await db.close()

--- a/tests/memory/test_migration_runner.py
+++ b/tests/memory/test_migration_runner.py
@@ -1,0 +1,151 @@
+"""Tests for the lightweight migrations framework runner."""
+
+import pytest
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.migrations.runner import run_pending
+
+
+@pytest.mark.asyncio
+async def test_run_pending_creates_schema_version_table(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    try:
+        await run_pending(db, migrations=[])
+
+        async with db.session() as s:
+            result = await s.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='_schema_version'"
+                )
+            )
+            assert result.scalar_one_or_none() == "_schema_version"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_migration_and_records_version(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_calls: list[DatabaseManager] = []
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            apply_calls.append(d)
+
+    try:
+        versions = await run_pending(db, migrations=[Mig()])
+        assert versions == ["001_test"]
+        assert apply_calls == [db]
+
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001_test"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_skips_already_applied(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    apply_count = 0
+
+    class Mig:
+        VERSION = "001_test"
+        DESCRIPTION = "first"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            nonlocal apply_count
+            apply_count += 1
+
+    try:
+        v1 = await run_pending(db, migrations=[Mig()])
+        v2 = await run_pending(db, migrations=[Mig()])
+        assert v1 == ["001_test"]
+        assert v2 == []
+        assert apply_count == 1  # idempotent
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_pending_applies_in_version_sorted_order(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    order_seen: list[str] = []
+
+    def make_mig(v: str):
+        class M:
+            VERSION = v
+            DESCRIPTION = f"m{v}"
+
+            async def apply(self, d: DatabaseManager) -> None:
+                order_seen.append(v)
+        return M()
+
+    try:
+        # Caller passes in reversed order — runner must sort
+        versions = await run_pending(
+            db, migrations=[make_mig("003"), make_mig("001"), make_mig("002")]
+        )
+        assert versions == ["001", "002", "003"]
+        assert order_seen == ["001", "002", "003"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_migration_is_not_recorded(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+
+    class GoodMig:
+        VERSION = "001"
+        DESCRIPTION = "good"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            pass
+
+    class BadMig:
+        VERSION = "002"
+        DESCRIPTION = "bad"
+
+        async def apply(self, d: DatabaseManager) -> None:
+            raise RuntimeError("boom")
+
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await run_pending(db, migrations=[GoodMig(), BadMig()])
+
+        # 001 succeeded → recorded; 002 raised → NOT recorded
+        async with db.session() as s:
+            result = await s.execute(sa.text("SELECT version FROM _schema_version"))
+            assert {row[0] for row in result.all()} == {"001"}
+    finally:
+        await db.close()
+
+
+def test_discover_migrations_imports_numbered_modules(tmp_path, monkeypatch):
+    pkg_dir = tmp_path / "fake_mig_pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "001_alpha.py").write_text(
+        "VERSION = '001_alpha'\nDESCRIPTION = 'a'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    (pkg_dir / "002_beta.py").write_text(
+        "VERSION = '002_beta'\nDESCRIPTION = 'b'\n\n"
+        "async def apply(db):\n    pass\n"
+    )
+    # non-numbered modules in the package should be ignored
+    (pkg_dir / "helper.py").write_text("# not a migration\n")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    from omicsclaw.memory.migrations.runner import _discover_migrations
+    found = _discover_migrations("fake_mig_pkg")
+
+    versions = sorted(m.VERSION for m in found)
+    assert versions == ["001_alpha", "002_beta"]

--- a/tests/memory/test_namespace_helpers.py
+++ b/tests/memory/test_namespace_helpers.py
@@ -1,0 +1,133 @@
+"""Tests for surface-namespace helpers (PR #5).
+
+Each surface (CLI, Desktop, Bot) derives its namespace differently:
+
+  - CLI/TUI:    absolute workspace path (cwd or --workspace flag)
+  - Desktop:    OMICSCLAW_DESKTOP_LAUNCH_ID, falling back to "app/desktop_user"
+  - Bot:        f"{platform}/{user_id}" (already done in CompatMemoryStore)
+
+These helpers live in ``omicsclaw.memory`` so any surface can derive a
+namespace consistently. Bot's logic stays in CompatMemoryStore because
+it needs session lookup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ----------------------------------------------------------------------
+# CLI namespace derivation
+# ----------------------------------------------------------------------
+
+
+def test_cli_namespace_from_workspace_uses_absolute_path(tmp_path):
+    from omicsclaw.memory import cli_namespace_from_workspace
+
+    ns = cli_namespace_from_workspace(str(tmp_path))
+    assert ns == str(tmp_path.resolve())
+
+
+def test_cli_namespace_from_workspace_handles_relative_path(tmp_path, monkeypatch):
+    """A relative path is resolved against the current working directory."""
+    from omicsclaw.memory import cli_namespace_from_workspace
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "subdir").mkdir()
+
+    ns = cli_namespace_from_workspace("subdir")
+    assert ns == str((tmp_path / "subdir").resolve())
+
+
+def test_cli_namespace_defaults_to_cwd(tmp_path, monkeypatch):
+    """No argument → use the current working directory."""
+    from omicsclaw.memory import cli_namespace_from_workspace
+
+    monkeypatch.chdir(tmp_path)
+
+    ns = cli_namespace_from_workspace(None)
+    assert ns == str(tmp_path.resolve())
+
+
+def test_cli_namespace_strips_trailing_slash(tmp_path):
+    from omicsclaw.memory import cli_namespace_from_workspace
+
+    # Path("/foo/").resolve() drops the trailing slash, so this is just a
+    # documentation test that the helper produces canonical paths.
+    ns = cli_namespace_from_workspace(str(tmp_path) + "/")
+    assert not ns.endswith("/") or ns == "/"
+
+
+# ----------------------------------------------------------------------
+# Desktop namespace derivation
+# ----------------------------------------------------------------------
+
+
+def test_desktop_namespace_uses_launch_id_when_set(monkeypatch):
+    from omicsclaw.memory import desktop_namespace
+
+    monkeypatch.setenv("OMICSCLAW_DESKTOP_LAUNCH_ID", "launch-abc123")
+    assert desktop_namespace() == "app/launch-abc123"
+
+
+def test_desktop_namespace_default_when_no_launch_id(monkeypatch):
+    from omicsclaw.memory import desktop_namespace
+
+    monkeypatch.delenv("OMICSCLAW_DESKTOP_LAUNCH_ID", raising=False)
+    assert desktop_namespace() == "app/desktop_user"
+
+
+def test_desktop_namespace_strips_whitespace(monkeypatch):
+    from omicsclaw.memory import desktop_namespace
+
+    monkeypatch.setenv("OMICSCLAW_DESKTOP_LAUNCH_ID", "  launch-xyz  ")
+    assert desktop_namespace() == "app/launch-xyz"
+
+
+# ----------------------------------------------------------------------
+# Memory client factory
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_memory_client_returns_namespace_bound_client(tmp_path, monkeypatch):
+    """``get_memory_client(namespace=...)`` returns a lightweight MemoryClient
+    sharing the singleton engine, bound to the given namespace."""
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{tmp_path}/t.db"
+    )
+    from omicsclaw.memory import close_db, get_memory_client, get_memory_engine
+
+    engine = get_memory_engine()
+    await engine.db.init_db()
+
+    try:
+        client = get_memory_client(namespace="tg/userA")
+        assert client.namespace == "tg/userA"
+
+        # Two clients with different namespaces share the same engine.
+        client2 = get_memory_client(namespace="tg/userB")
+        assert client2.namespace == "tg/userB"
+        assert client._engine is client2._engine
+    finally:
+        await close_db()
+
+
+@pytest.mark.asyncio
+async def test_get_review_log_returns_singleton(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{tmp_path}/t.db"
+    )
+    from omicsclaw.memory import close_db, get_engine_db, get_review_log
+
+    db = get_engine_db()
+    await db.init_db()
+
+    try:
+        log1 = get_review_log()
+        log2 = get_review_log()
+        assert log1 is log2
+    finally:
+        await close_db()

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -1,0 +1,104 @@
+"""Tests for namespace_policy — see docs/CONTEXT.md namespace ownership table."""
+
+import pytest
+
+from omicsclaw.memory.namespace_policy import resolve_namespace, should_version
+from omicsclaw.memory.uri import MemoryURI
+
+
+def test_resolve_namespace_returns_shared_for_core_agent():
+    uri = MemoryURI.parse("core://agent")
+    assert resolve_namespace(uri, current="tg/A") == "__shared__"
+
+
+def test_resolve_namespace_returns_current_for_per_namespace_uri():
+    assert resolve_namespace(MemoryURI.parse("dataset://pbmc.h5ad"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("analysis://run_42"), current="tg/A") == "tg/A"
+    assert resolve_namespace(MemoryURI.parse("project://current"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_kh_prefix_is_shared():
+    # core://kh and any sub-path under it are shared
+    assert resolve_namespace(MemoryURI.parse("core://kh"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/qc_threshold"), current="X") == "__shared__"
+    assert resolve_namespace(MemoryURI.parse("core://kh/sc/marker"), current="X") == "__shared__"
+
+
+def test_resolve_namespace_false_prefix_does_not_match():
+    # 'kh' must not match 'khaki' (path-segment matching, not raw startswith)
+    assert resolve_namespace(MemoryURI.parse("core://khaki"), current="X") == "X"
+    assert resolve_namespace(MemoryURI.parse("core://agent_alt"), current="X") == "X"
+
+
+def test_resolve_namespace_my_user_is_per_namespace():
+    # core://my_user is per-user, not shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user"), current="tg/A") == "tg/A"
+
+
+def test_resolve_namespace_my_user_default_is_shared():
+    # core://my_user_default is the fallback template, shared
+    assert resolve_namespace(MemoryURI.parse("core://my_user_default"), current="tg/A") == "__shared__"
+
+
+def test_should_version_core_agent_true():
+    assert should_version(MemoryURI.parse("core://agent")) is True
+
+
+def test_should_version_false_for_non_versioned_domains():
+    assert should_version(MemoryURI.parse("dataset://pbmc.h5ad")) is False
+    assert should_version(MemoryURI.parse("analysis://sc-de/run_42")) is False
+    assert should_version(MemoryURI.parse("session://abc123")) is False
+    assert should_version(MemoryURI.parse("insight://cluster/3")) is False
+    assert should_version(MemoryURI.parse("project://current")) is False
+
+
+def test_should_version_core_my_user_true():
+    # core://my_user is per-namespace (Q3) but versioned (Q5) — both rules independent
+    assert should_version(MemoryURI.parse("core://my_user")) is True
+
+
+def test_should_version_all_preferences_true():
+    # whole `preference://` domain is versioned
+    assert should_version(MemoryURI.parse("preference://qc/cutoff")) is True
+    assert should_version(MemoryURI.parse("preference://global/theme")) is True
+    assert should_version(MemoryURI.parse("preference://anything_at_all")) is True
+
+
+def test_should_version_kh_and_my_user_default_false():
+    # core://kh is shared but NOT versioned (static system content)
+    assert should_version(MemoryURI.parse("core://kh")) is False
+    assert should_version(MemoryURI.parse("core://kh/qc_threshold")) is False
+    # core://my_user_default is the static fallback template, NOT versioned
+    assert should_version(MemoryURI.parse("core://my_user_default")) is False
+
+
+# ----------------------------------------------------------------------
+# CONTEXT.md namespace ownership table — full matrix
+# Lock the entire policy contract in one place. If a row needs to change,
+# update CONTEXT.md and SHARED_PREFIXES / VERSIONED_PREFIXES in lockstep.
+# ----------------------------------------------------------------------
+
+_PER_NS = "ns/X"  # opaque current namespace for matrix tests
+
+
+@pytest.mark.parametrize(
+    "uri_str,expected_ns,expected_version",
+    [
+        ("core://agent",            "__shared__", True),
+        ("core://kh",               "__shared__", False),
+        ("core://kh/qc_threshold",  "__shared__", False),
+        ("core://my_user_default",  "__shared__", False),
+        ("core://my_user",          _PER_NS,      True),
+        ("preference://qc/cutoff",  _PER_NS,      True),
+        ("preference://global/x",   _PER_NS,      True),
+        ("dataset://pbmc.h5ad",     _PER_NS,      False),
+        ("analysis://run_42",       _PER_NS,      False),
+        ("insight://cluster/3",     _PER_NS,      False),
+        ("project://current",       _PER_NS,      False),
+        ("session://abc123",        _PER_NS,      False),
+    ],
+)
+def test_context_md_table_full_matrix(uri_str, expected_ns, expected_version):
+    uri = MemoryURI.parse(uri_str)
+    assert resolve_namespace(uri, current=_PER_NS) == expected_ns
+    assert should_version(uri) is expected_version

--- a/tests/memory/test_review_log.py
+++ b/tests/memory/test_review_log.py
@@ -1,0 +1,361 @@
+"""Tests for ReviewLog cold-path operations (PR #4b).
+
+ReviewLog handles operations that don't sit on the hot write path:
+  - version-chain inspection / rollback (4b.2)
+  - orphan + GC (4b.3)
+  - browse_shared (4b.4)
+  - changeset list/approve/discard (4b.5)
+
+These are the operations the desktop "Review & Audit" pane needs, and
+the bot's /forget command will eventually call cascade_delete from here.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.models import Edge, Memory, Node, Path
+from omicsclaw.memory.review_log import (
+    NoVersionHistoryError,
+    OrphanEntry,
+    ReviewLog,
+    VersionEntry,
+)
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    engine = MemoryEngine(db, search)
+
+    # Per-test changeset store so tests don't pollute the global singleton.
+    from omicsclaw.memory.snapshot import ChangesetStore
+
+    changeset_store = ChangesetStore(snapshot_dir=str(tmp_path / "changesets"))
+    review = ReviewLog(db, engine, changeset_store=changeset_store)
+    yield engine, review, db, changeset_store
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# 4b.2 — version chain
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_version_chain_returns_chain_in_age_order(env):
+    engine, review, _, _ = env
+    await engine.upsert_versioned("core://agent", "v1", namespace="__shared__")
+    await engine.upsert_versioned("core://agent", "v2", namespace="__shared__")
+    await engine.upsert_versioned("core://agent", "v3", namespace="__shared__")
+
+    entries = await review.list_version_chain(
+        "core://agent", namespace="__shared__"
+    )
+
+    assert len(entries) == 3
+    assert all(isinstance(e, VersionEntry) for e in entries)
+    # Oldest (deprecated) first; newest (active) last.
+    assert [e.content for e in entries] == ["v1", "v2", "v3"]
+    assert [e.deprecated for e in entries] == [True, True, False]
+    assert entries[-1].migrated_to is None
+    assert entries[0].migrated_to == entries[1].memory_id
+    assert entries[1].migrated_to == entries[2].memory_id
+
+
+@pytest.mark.asyncio
+async def test_list_version_chain_raises_for_overwrite_only_uri(env):
+    """``dataset://`` is overwrite-only — there is no chain to list."""
+    engine, review, _, _ = env
+    await engine.upsert("dataset://pbmc.h5ad", "v1", namespace="tg/userA")
+
+    with pytest.raises(NoVersionHistoryError, match="not versioned"):
+        await review.list_version_chain(
+            "dataset://pbmc.h5ad", namespace="tg/userA"
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_version_chain_returns_empty_for_missing_path(env):
+    """An existent versioned URI with no chain row returns an empty list,
+    not an exception. Distinguishes "no history" from "this URI cannot
+    have history" (the overwrite case)."""
+    _, review, _, _ = env
+    entries = await review.list_version_chain(
+        "core://agent", namespace="__shared__"
+    )
+    assert entries == []
+
+
+@pytest.mark.asyncio
+async def test_rollback_to_makes_old_version_active(env):
+    engine, review, _, _ = env
+    r1 = await engine.upsert_versioned(
+        "core://agent", "v1", namespace="__shared__"
+    )
+    r2 = await engine.upsert_versioned(
+        "core://agent", "v2", namespace="__shared__"
+    )
+    r3 = await engine.upsert_versioned(
+        "core://agent", "v3", namespace="__shared__"
+    )
+
+    # Rollback to v1.
+    await review.rollback_to(r1.new_memory_id, namespace="__shared__")
+
+    # v1 is now active (deprecated=False); v2 and v3 are deprecated.
+    record = await engine.recall("core://agent", namespace="__shared__")
+    assert record is not None
+    assert record.content == "v1"
+    assert record.memory_id == r1.new_memory_id
+
+
+@pytest.mark.asyncio
+async def test_rollback_to_raises_when_memory_not_found(env):
+    _, review, _, _ = env
+    with pytest.raises(ValueError, match="not found"):
+        await review.rollback_to(99999, namespace="__shared__")
+
+
+@pytest.mark.asyncio
+async def test_rollback_to_noop_when_already_active(env):
+    engine, review, _, _ = env
+    r1 = await engine.upsert_versioned(
+        "core://agent", "v1", namespace="__shared__"
+    )
+    # Roll back to the active head — should be a no-op.
+    result = await review.rollback_to(r1.new_memory_id, namespace="__shared__")
+    assert result.was_already_active is True
+
+
+# ----------------------------------------------------------------------
+# 4b.3 — orphans + GC
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_orphans_finds_deprecated_memories_with_no_successor(env):
+    """An orphan is a deprecated memory whose successor was deleted —
+    the chain points nowhere active. We seed the state explicitly via
+    direct DB writes since the engine's normal API can't produce orphans."""
+    engine, review, db, _ = env
+    r1 = await engine.upsert_versioned(
+        "core://agent", "v1", namespace="__shared__"
+    )
+    r2 = await engine.upsert_versioned(
+        "core://agent", "v2", namespace="__shared__"
+    )
+
+    # Manually delete v2 to orphan v1.
+    async with db.session() as s:
+        await s.execute(sa.delete(Memory).where(Memory.id == r2.new_memory_id))
+
+    orphans = await review.list_orphans()
+
+    orphan_ids = {o.memory_id for o in orphans}
+    assert r1.new_memory_id in orphan_ids
+    assert all(isinstance(o, OrphanEntry) for o in orphans)
+
+
+@pytest.mark.asyncio
+async def test_list_orphans_filters_by_namespace(env):
+    """Orphans visible only in a specific namespace partition."""
+    engine, review, db, _ = env
+    r_a = await engine.upsert_versioned(
+        "core://agent", "for A", namespace="tg/userA"
+    )
+    await engine.upsert_versioned("core://agent", "for A v2", namespace="tg/userA")
+    r_b = await engine.upsert_versioned(
+        "core://agent", "for B", namespace="tg/userB"
+    )
+    await engine.upsert_versioned("core://agent", "for B v2", namespace="tg/userB")
+
+    async with db.session() as s:
+        # Orphan only A's chain by deleting A's active head.
+        a_active = (
+            await s.execute(
+                sa.select(Memory)
+                .where(
+                    Memory.deprecated == False,  # noqa: E712
+                    Memory.node_uuid == r_a.node_uuid,
+                )
+            )
+        ).scalar_one()
+        await s.execute(sa.delete(Memory).where(Memory.id == a_active.id))
+
+    a_orphans = await review.list_orphans(namespace="tg/userA")
+    b_orphans = await review.list_orphans(namespace="tg/userB")
+
+    assert any(o.memory_id == r_a.new_memory_id for o in a_orphans)
+    assert b_orphans == []
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_removes_node_and_paths(env):
+    engine, review, db, _ = env
+    await engine.upsert("dataset://pbmc.h5ad", "v1", namespace="tg/userA")
+
+    await review.cascade_delete(
+        "dataset://pbmc.h5ad", namespace="tg/userA"
+    )
+
+    record = await engine.recall(
+        "dataset://pbmc.h5ad",
+        namespace="tg/userA",
+        fallback_to_shared=False,
+    )
+    assert record is None
+
+    async with db.session() as s:
+        path_count = (
+            await s.execute(
+                sa.select(sa.func.count())
+                .select_from(Path)
+                .where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "dataset",
+                    Path.path == "pbmc.h5ad",
+                )
+            )
+        ).scalar_one()
+        assert path_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cascade_delete_respects_namespace(env):
+    """Deleting in ns/A doesn't touch ns/B's row at the same URI."""
+    engine, review, _, _ = env
+    await engine.upsert("dataset://pbmc.h5ad", "A", namespace="tg/userA")
+    await engine.upsert("dataset://pbmc.h5ad", "B", namespace="tg/userB")
+
+    await review.cascade_delete(
+        "dataset://pbmc.h5ad", namespace="tg/userA"
+    )
+
+    a = await engine.recall(
+        "dataset://pbmc.h5ad",
+        namespace="tg/userA",
+        fallback_to_shared=False,
+    )
+    b = await engine.recall(
+        "dataset://pbmc.h5ad",
+        namespace="tg/userB",
+        fallback_to_shared=False,
+    )
+    assert a is None
+    assert b is not None
+    assert b.content == "B"
+
+
+@pytest.mark.asyncio
+async def test_gc_pathless_edges_removes_edges_with_no_paths(env):
+    """An edge whose only Path was deleted is dead-weight; GC removes it."""
+    engine, review, db, _ = env
+    await engine.upsert("dataset://pbmc.h5ad", "v1", namespace="tg/userA")
+
+    async with db.session() as s:
+        edge_id_before = (
+            await s.execute(
+                sa.select(Path.edge_id).where(
+                    Path.namespace == "tg/userA",
+                    Path.domain == "dataset",
+                    Path.path == "pbmc.h5ad",
+                )
+            )
+        ).scalar_one()
+        # Manually delete the path row (simulating an orphan-edge state).
+        await s.execute(
+            sa.delete(Path).where(
+                Path.namespace == "tg/userA",
+                Path.domain == "dataset",
+                Path.path == "pbmc.h5ad",
+            )
+        )
+
+    removed = await review.gc_pathless_edges()
+    assert removed >= 1
+
+    async with db.session() as s:
+        edge_after = await s.get(Edge, edge_id_before)
+        assert edge_after is None
+
+
+# ----------------------------------------------------------------------
+# 4b.4 — browse_shared
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_browse_shared_lists_only_shared_partition(env):
+    engine, review, _, _ = env
+    await engine.upsert("core://agent", "shared root", namespace="__shared__")
+    await engine.upsert(
+        "core://agent/voice", "shared voice", namespace="__shared__"
+    )
+    await engine.upsert(
+        "core://agent/style", "user style", namespace="tg/userA"
+    )
+
+    children = await review.browse_shared("core://agent")
+    uris = sorted(c.uri for c in children)
+
+    assert uris == ["core://agent/voice"]
+
+
+@pytest.mark.asyncio
+async def test_browse_shared_root_lists_top_level_shared(env):
+    engine, review, _, _ = env
+    await engine.upsert("core://agent", "x", namespace="__shared__")
+    await engine.upsert("core://other", "y", namespace="__shared__")
+    await engine.upsert("dataset://A", "z", namespace="tg/userA")  # not shared
+
+    from omicsclaw.memory.uri import MemoryURI
+
+    children = await review.browse_shared(MemoryURI(domain="core", path=""))
+    uris = sorted(c.uri for c in children)
+
+    assert uris == ["core://agent", "core://other"]
+
+
+# ----------------------------------------------------------------------
+# 4b.5 — changesets
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_pending_changes_reads_changeset_store(env):
+    """ReviewLog reads from the changeset store passed to its constructor.
+    The fixture injects a per-test ChangesetStore so we don't pollute
+    the global singleton."""
+    _, review, _, store = env
+
+    store.record_many(
+        before_state={},
+        after_state={"nodes": [{"uuid": "test-uuid-1"}]},
+    )
+
+    pending = await review.list_pending_changes()
+    assert isinstance(pending, list)
+    assert len(pending) >= 1
+
+
+@pytest.mark.asyncio
+async def test_discard_pending_changes_clears_the_store(env):
+    _, review, _, store = env
+
+    store.record_many(
+        before_state={},
+        after_state={"nodes": [{"uuid": "test-uuid-2"}]},
+    )
+    assert store.get_change_count() >= 1
+
+    discarded = await review.discard_pending_changes()
+    assert discarded >= 1
+    assert store.get_change_count() == 0

--- a/tests/memory/test_review_log.py
+++ b/tests/memory/test_review_log.py
@@ -287,6 +287,43 @@ async def test_gc_pathless_edges_removes_edges_with_no_paths(env):
         assert edge_after is None
 
 
+@pytest.mark.asyncio
+async def test_gc_pathless_edges_preserves_edges_referenced_from_other_namespaces(env):
+    """An edge referenced by ANY namespace's Path must survive GC.
+
+    The previous design accepted a `namespace` parameter that silently
+    deleted edges referenced only by other namespaces — the data-loss
+    bug PR #4b's review caught. Test guards against the regression.
+    """
+    engine, review, db, _ = env
+    await engine.upsert("dataset://shared.h5ad", "A", namespace="tg/userA")
+    await engine.upsert("dataset://shared.h5ad", "B", namespace="tg/userB")
+
+    # Snapshot the two edge ids; both must survive GC.
+    async with db.session() as s:
+        edge_ids = [
+            row.edge_id
+            for row in (
+                await s.execute(
+                    sa.select(Path).where(
+                        Path.domain == "dataset",
+                        Path.path == "shared.h5ad",
+                    )
+                )
+            ).scalars().all()
+        ]
+
+    removed = await review.gc_pathless_edges()
+    # Other tests in this module may have left orphan edges around; we
+    # only assert that OUR two edges still exist.
+    async with db.session() as s:
+        for eid in edge_ids:
+            edge_after = await s.get(Edge, eid)
+            assert edge_after is not None, (
+                f"GC removed edge {eid} that was still referenced"
+            )
+
+
 # ----------------------------------------------------------------------
 # 4b.4 — browse_shared
 # ----------------------------------------------------------------------
@@ -358,4 +395,18 @@ async def test_discard_pending_changes_clears_the_store(env):
 
     discarded = await review.discard_pending_changes()
     assert discarded >= 1
+    assert store.get_change_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_approve_changes_clears_all_when_no_ids(env):
+    _, review, _, store = env
+    store.record_many(
+        before_state={},
+        after_state={"nodes": [{"uuid": "approve-uuid"}]},
+    )
+    assert store.get_change_count() >= 1
+
+    approved = await review.approve_changes()
+    assert approved >= 1
     assert store.get_change_count() == 0

--- a/tests/memory/test_search_indexer_namespace.py
+++ b/tests/memory/test_search_indexer_namespace.py
@@ -1,0 +1,160 @@
+"""Tests for SearchIndexer namespace-aware behavior (PR #3a Task 3a.5).
+
+Covers:
+  - SearchIndexer.refresh_search_documents_for(namespace, uri): surgical
+    single-row rebuild without touching other namespaces' rows.
+  - Glossary keyword join filter: only keywords in the current namespace
+    or ``__shared__`` should feed into search_terms for that namespace's
+    search rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.models import GlossaryKeyword, SearchDocument
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    yield MemoryEngine(db, search), search, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# Surgical refresh
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_creates_single_row(env):
+    eng, search, db = env
+    await eng.upsert("core://agent", "v1", namespace="tg/userA")
+
+    # Wipe the search row, then surgically refresh just this (namespace, uri).
+    async with db.session() as s:
+        await s.execute(sa.delete(SearchDocument))
+
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://agent"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].namespace == "tg/userA"
+        assert rows[0].path == "agent"
+        assert rows[0].content == "v1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_uri_is_noop_when_path_missing(env):
+    _, search, db = env
+    # Should not raise, just silently skip — the surgical refresh has nothing
+    # to rebuild if the (namespace, uri) doesn't exist.
+    await search.refresh_search_documents_for(
+        namespace="tg/userA", uri="core://nope"
+    )
+
+    async with db.session() as s:
+        rows = (
+            await s.execute(sa.select(SearchDocument))
+        ).scalars().all()
+        assert rows == []
+
+
+# ----------------------------------------------------------------------
+# Glossary namespace filter
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_glossary_keyword_filtered_by_namespace(env):
+    """A keyword bound to a node but in a foreign namespace must NOT appear
+    in that node's search row.
+
+    To exercise the filter we bind three keywords to the SAME node:
+      - one with namespace='tg/userA' (current)
+      - one with namespace='tg/userZ' (foreign — must be excluded)
+      - one with namespace='__shared__' (must be included)
+
+    Without the per-namespace glossary filter all three would appear in
+    ``search_terms``.
+    """
+    eng, search, db = env
+    ref = await eng.upsert("core://agent", "content", namespace="tg/userA")
+
+    async with db.session() as s:
+        s.add_all([
+            GlossaryKeyword(
+                keyword="alpha-current",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userA",
+            ),
+            GlossaryKeyword(
+                keyword="zeta-foreign",
+                node_uuid=ref.node_uuid,
+                namespace="tg/userZ",
+            ),
+            GlossaryKeyword(
+                keyword="shared-keyword",
+                node_uuid=ref.node_uuid,
+                namespace="__shared__",
+            ),
+        ])
+
+    await search.refresh_search_documents_for_node(ref.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+
+    assert "alpha-current" in sd.search_terms
+    assert "shared-keyword" in sd.search_terms
+    assert "zeta-foreign" not in sd.search_terms
+
+
+@pytest.mark.asyncio
+async def test_glossary_shared_keyword_appears_in_all_namespaces(env):
+    """A keyword with namespace='__shared__' should bleed into any per-user row."""
+    eng, search, db = env
+    ref_a = await eng.upsert("core://agent", "A", namespace="tg/userA")
+
+    # Bind a shared-namespace keyword to A's node — semantically odd in
+    # production, but it's what we'd see for core:// agents whose keywords
+    # are seeded globally.
+    async with db.session() as s:
+        s.add(
+            GlossaryKeyword(
+                keyword="shared-token",
+                node_uuid=ref_a.node_uuid,
+                namespace="__shared__",
+            )
+        )
+
+    await search.refresh_search_documents_for_node(ref_a.node_uuid)
+
+    async with db.session() as s:
+        sd = (
+            await s.execute(
+                sa.select(SearchDocument).where(
+                    SearchDocument.namespace == "tg/userA"
+                )
+            )
+        ).scalar_one()
+        assert "shared-token" in sd.search_terms

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2522,3 +2522,120 @@ async def test_memory_review_integrate_reports_missing_keys(monkeypatch, tmp_pat
         assert result["remaining"] == len(keys) - 1
     finally:
         await memory_pkg.close_db()
+
+
+# ----------------------------------------------------------------------
+# PR #5 — review routes wired to ReviewLog
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_review_rollback_uses_reviewlog(monkeypatch, tmp_path):
+    """POST /memory/review/rollback now routes through ReviewLog with the
+    desktop's launch-derived namespace. Older active versions roll back
+    cleanly; idempotent when already active."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.app.server import MemoryRollbackRequest
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(
+        monkeypatch, tmp_path
+    )
+
+    try:
+        # GraphService.create_memory + update_memory go to __shared__,
+        # so ensure the desktop namespace is __shared__ for this test.
+        monkeypatch.delenv("OMICSCLAW_DESKTOP_LAUNCH_ID", raising=False)
+        monkeypatch.setattr(
+            "omicsclaw.memory.desktop_namespace", lambda: "__shared__"
+        )
+        monkeypatch.setattr(server, "_memory_client", object())
+
+        await graph.create_memory(
+            parent_path="",
+            content="v1",
+            priority=0,
+            title="rollback-target",
+            domain="core",
+        )
+        update_result = await graph.update_memory(
+            path="rollback-target",
+            content="v2",
+            domain="core",
+        )
+
+        old_id = update_result["old_memory_id"]
+        new_id = update_result["new_memory_id"]
+        assert old_id != new_id
+
+        result = await server.memory_review_rollback(
+            MemoryRollbackRequest(target_memory_id=old_id)
+        )
+
+        assert result["ok"] is True
+        assert result["result"]["restored_memory_id"] == old_id
+        assert result["result"]["was_already_active"] is False
+
+        # Re-rolling should be a no-op.
+        again = await server.memory_review_rollback(
+            MemoryRollbackRequest(target_memory_id=old_id)
+        )
+        assert again["result"]["was_already_active"] is True
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_review_orphans_endpoint_returns_dataclass_dicts(
+    monkeypatch, tmp_path
+):
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(
+        monkeypatch, tmp_path
+    )
+
+    try:
+        monkeypatch.setattr(server, "_memory_client", object())
+
+        # No orphans yet — endpoint should return an empty list cleanly.
+        result = await server.memory_review_orphans(namespace="")
+        assert result["count"] == 0
+        assert result["orphans"] == []
+        assert result["namespace"] is None
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_review_version_chain_endpoint_rejects_overwrite_uri(
+    monkeypatch, tmp_path
+):
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+
+    _, _, memory_pkg = await _setup_memory_review_runtime(
+        monkeypatch, tmp_path
+    )
+
+    try:
+        monkeypatch.setattr(server, "_memory_client", object())
+        monkeypatch.setattr(
+            "omicsclaw.memory.desktop_namespace", lambda: "__shared__"
+        )
+
+        # ``dataset://`` is overwrite-only — endpoint should 400.
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as ei:
+            await server.memory_review_version_chain(
+                uri="dataset://x.h5ad",
+                namespace=None,
+            )
+        assert ei.value.status_code == 400
+    finally:
+        await memory_pkg.close_db()


### PR DESCRIPTION
## Summary

PR #6 of the [memory refactor](docs/2026-05-09-memory-refactor-plan.md) — **Phase 5 (cleanup) — final PR in the sequence**. Smaller-than-usual: most of the original §6 cleanup was either already absorbed into earlier PRs (PR #3c routing, PR #5 surface integration) or explicitly punted with a documented rationale. The deliverables here are: dead-code deletion, README + AGENTS memory section refresh, and an in-source TODO marking the remaining migration debt.

**Stacked on**: #125 → #126 → #127 → #128 → #129 → #130 → #131 → #132. Merge in order.

## What lands here

### Task 6.1 — `_parse_uri` removal
`omicsclaw/memory/snapshot.py` had a stale `_parse_uri` helper from before PR #1's `MemoryURI` value object. Repo-wide grep confirmed zero callers; deleted. Plan §6.1's "all `_parse_uri` references replaced with `MemoryURI.parse`" reads literally as replacement, but with zero callers the only correct outcome is removal.

### Task 6.3 — README + AGENTS.md memory section
- `README.md` gains a **🧠 Memory Architecture** section (before FAQ) describing the 3-layer model (MemoryClient / MemoryEngine / ReviewLog), the surface namespace table (CLI / Desktop / Bot / `__shared__`), and the asymmetric read-fallback policy.
- `AGENTS.md` Graph Memory System section refreshed: 3-layer table, namespace partition note, surface helpers code block, and a migration note pointing at the five remaining GraphService call sites.
- Both cross-reference `docs/CONTEXT.md` for vocabulary and decisions.

### `docs/CONTEXT.md` (local-only, not committed per repo convention)
Added three sections: **Surface namespace defaults** (table mapping each surface to its namespace string), **Resolved-by-default decisions** (per-launch DB choice, `oc interactive` from `~/`, asymmetric read-fallback rationale), and **Open questions** (`core://kh/*` seed bootstrap, `_auto_capture_dataset` policy).

### Visibility TODO
`omicsclaw/memory/graph.py` gets a top-of-file `TODO(post-PR #6)` block naming the five remaining call sites inline, so future maintainers grepping for "deprecated" / "TODO" see the retirement plan without digging through commit history.

## Explicitly punted

Plan §6.2 — "graph.py: delete or shrink to <100 lines" — is **not met** in this PR. `omicsclaw/memory/graph.py` is still ~1620 lines because three server endpoints (`/memory/update`, `/memory/children`, `/memory/domains`) and two MemoryClient methods (`forget`, `get_recent`) still depend on GraphService verbs that lack a clean MemoryEngine equivalent. Migrating those needs surface-changing API work that's out of cleanup scope. The boundary is documented in three places:

1. `omicsclaw/memory/graph.py` top-of-file TODO (in-source)
2. `docs/CONTEXT.md` Flagged ambiguities (architectural reference)
3. This PR description (release notes)

The CLI helper `cli_namespace_from_workspace` likewise stays as forward-prep with no production call site — the CLI's `/memory` slash command operates on file-based ScopedMemory, not graph memory. Wiring would be speculative scope creep.

## Test plan

- [x] `_parse_uri` deletion verified by grep (`grep -rn "_parse_uri" --include="*.py"` returns zero hits in non-test code).
- [x] **270/270 regression suite green** — `tests/memory/ + bot/test_session.py + test_autoagent_failure_memory.py + test_interactive_memory_command_support.py + test_memory_server_security.py + test_scoped_memory.py + test_app_server.py + integration/test_memory_cross_surface.py`.
- [x] **5-axis review** — APPROVED ship-with-followups; review feedback (AGENTS.md update, in-source TODO) folded into commit `a871e5f`.

## Refactor done

After this PR merges, the memory architecture is:

```
                 surface helpers (cli_namespace_from_workspace,
                                  desktop_namespace, ...)
                            ↓
         get_memory_client(namespace=...)  /  get_review_log()
                            ↓
              MemoryClient (strategy)  ←→  ReviewLog (cold)
                            ↓                    ↓
                         MemoryEngine (hot CRUD)
                                  ↓
                     SearchIndexer + ORM
                                  ↑
                  [ namespace partition via 001 migration ]
```

8 PRs (#125-#132), 190 new tests, ~3600 lines added across `omicsclaw/memory/`, ~1200 lines on the surfaces. Documentation in `docs/CONTEXT.md`, `docs/2026-05-09-memory-refactor-plan.md`, and now README/AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace-based memory isolation enabling separate memory stores across CLI workspaces, desktop, and bot surfaces with shared fallback.
  * Introduced memory review endpoints for version history inspection and orphan detection.
  * Added versioned memory support for audited chains of edits with rollback capability.

* **Documentation**
  * Added "Memory Architecture" section to README documenting namespace partitioning and three-layer system design.
  * Updated AGENTS.md with detailed graph memory system documentation including architecture and REST API capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->