### PR TITLE
fix(memory): close cross-namespace data-loss + info-leak holes in legacy GraphService entrypoints

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -1746,10 +1746,11 @@ async def chat_stream(req: ChatRequest):
 
             on_context_compacted = make_compaction_event_handler(queue)
 
+            from omicsclaw.memory import desktop_chat_user_id
             result = await core.llm_tool_loop(
                 chat_id=session_id,
                 user_content=user_content,
-                user_id="desktop_user",
+                user_id=desktop_chat_user_id(),
                 workspace=req.workspace,
                 pipeline_workspace=req.pipeline_workspace,
                 output_style=req.output_style,
@@ -2850,6 +2851,7 @@ async def memory_update(req: MemoryUpdateRequest):
             content=req.content,
             priority=req.priority,
             domain=req.domain,
+            namespace=_memory_client.namespace,
         )
         return {"ok": True, "path": req.path, "domain": req.domain, "result": result}
     except ValueError as exc:
@@ -2901,6 +2903,8 @@ async def memory_children(
             node_uuid=parent_uuid,
             context_domain=domain,
             context_path=path or None,
+            namespace=_memory_client.namespace,
+            include_shared=True,
         )
         return {"node_uuid": parent_uuid, "domain": domain, "children": children}
     except Exception as exc:
@@ -2918,7 +2922,11 @@ async def memory_domains():
 
     try:
         graph = _get_graph_service()
-        all_paths = await graph.get_all_paths(domain=None)
+        all_paths = await graph.get_all_paths(
+            domain=None,
+            namespace=_memory_client.namespace,
+            include_shared=True,
+        )
 
         # Group by domain and count
         domain_counts: dict[str, int] = {}
@@ -2947,7 +2955,17 @@ async def memory_recent(
         raise HTTPException(503, detail="Memory system not available")
 
     try:
-        results = await _memory_client.get_recent(limit=limit)
+        # Desktop UI mode: route through GraphService directly with
+        # include_shared=True so user-customized core://agent/* rows
+        # surface alongside per-namespace rows. The strict
+        # MemoryClient.get_recent is reserved for multi-tenant bot
+        # surfaces where shared bleed-through would be wrong.
+        graph = _get_graph_service()
+        results = await graph.get_recent_memories(
+            limit=limit,
+            namespace=_memory_client.namespace,
+            include_shared=True,
+        )
         return {"results": results, "count": len(results)}
     except Exception as exc:
         logger.exception("Memory recent error")

--- a/omicsclaw/memory/__init__.py
+++ b/omicsclaw/memory/__init__.py
@@ -167,7 +167,21 @@ def cli_namespace_from_workspace(workspace_dir: Optional[str]) -> str:
     return str(target.resolve())
 
 
-_DESKTOP_DEFAULT_NAMESPACE = "app/desktop_user"
+_DESKTOP_DEFAULT_USER_ID = "desktop_user"
+
+
+def desktop_chat_user_id() -> str:
+    """User-id portion of the Desktop chat agent loop's CompatMemoryStore session.
+
+    The chat path constructs its namespace as ``f"app/{user_id}"`` (see
+    ``CompatMemoryStore._client_for_session``). Returning the same id
+    component ``desktop_namespace()`` derives keeps the chat-write and
+    endpoint-read namespaces aligned, including under
+    ``OMICSCLAW_DESKTOP_LAUNCH_ID`` multi-launch deployments where
+    they would otherwise diverge.
+    """
+    launch_id = (os.getenv("OMICSCLAW_DESKTOP_LAUNCH_ID") or "").strip()
+    return launch_id or _DESKTOP_DEFAULT_USER_ID
 
 
 def desktop_namespace() -> str:
@@ -178,10 +192,7 @@ def desktop_namespace() -> str:
     is prefixed with ``app/`` so cross-surface collisions with bot
     namespaces (``telegram/...``, ``feishu/...``) are impossible.
     """
-    launch_id = (os.getenv("OMICSCLAW_DESKTOP_LAUNCH_ID") or "").strip()
-    if launch_id:
-        return f"app/{launch_id}"
-    return _DESKTOP_DEFAULT_NAMESPACE
+    return f"app/{desktop_chat_user_id()}"
 
 
 def __getattr__(name: str):
@@ -230,6 +241,7 @@ __all__ = [
     "get_memory_engine", "get_review_log", "get_memory_client",
     "get_engine_db",
     "cli_namespace_from_workspace", "desktop_namespace",
+    "desktop_chat_user_id",
     "close_db",
     "ChangesetStore", "get_changeset_store",
     "Base", "ROOT_NODE_UUID", "Node", "Memory", "Edge", "Path",

--- a/omicsclaw/memory/compat.py
+++ b/omicsclaw/memory/compat.py
@@ -297,13 +297,21 @@ class CompatMemoryStore:
     async def _client_for_session(self, session_id: str) -> MemoryClient:
         """Resolve a session to its owner-namespace client.
 
-        Falls back to ``__shared__`` when the session can't be resolved
-        (defensive — in production the bot always creates a session before
-        the first save_memory call).
+        Raises ``LookupError`` when the session can't be resolved.
+        Silently falling back to ``__shared__`` (the previous behavior)
+        was a privacy hole — auto-captured datasets arriving before
+        their session was created would land globally where every other
+        user could read them. Callers (``save_memory``,
+        ``_auto_capture_dataset``) already wrap memory ops in
+        try/except, so propagating the error skips the write safely.
         """
         session = await self.get_session(session_id)
         if session is None:
-            return self._client_for_namespace(SHARED_NAMESPACE)
+            raise LookupError(
+                f"Cannot resolve session_id={session_id!r}: no session "
+                "row found. Ensure create_session() was called before "
+                "save_memory()."
+            )
         namespace = f"{session.platform}/{session.user_id}"
         return self._client_for_namespace(namespace)
 

--- a/omicsclaw/memory/graph.py
+++ b/omicsclaw/memory/graph.py
@@ -237,6 +237,9 @@ class GraphService:
         node_uuid: str = ROOT_NODE_UUID,
         context_domain: Optional[str] = None,
         context_path: Optional[str] = None,
+        *,
+        namespace: Optional[str] = None,
+        include_shared: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Get direct children of a node via the edges table.
@@ -246,6 +249,19 @@ class GraphService:
           1. Same domain AND path starts with ``context_path/``
           2. Same domain (any path)
           3. Any path at all
+
+        ``namespace`` filtering modes:
+          * ``namespace=None`` — legacy unfiltered admin view.
+          * ``namespace=X``, ``include_shared=False`` (default) — strict,
+            matches ``MemoryEngine.list_children`` semantics. A child
+            whose only path lives outside ``X`` is dropped.
+          * ``namespace=X``, ``include_shared=True`` — UI/desktop mode.
+            Children with paths in ``X`` *or* ``__shared__`` are listed,
+            with namespace-matched paths preferred when picking the
+            display path. The desktop ``/memory/children`` endpoint
+            uses this mode so the user can browse their own writes
+            *and* shared system rows (``core://agent/*``, future
+            ``core://kh/*`` seeds) from one tree.
         """
         async with self.session() as session:
             stmt = (
@@ -284,10 +300,28 @@ class GraphService:
                     continue
                 seen.add(edge.child_uuid)
 
-                path_result = await session.execute(
-                    select(Path).where(Path.edge_id == edge.id)
-                )
+                path_stmt = select(Path).where(Path.edge_id == edge.id)
+                if namespace is not None:
+                    if include_shared:
+                        path_stmt = path_stmt.where(
+                            Path.namespace.in_([namespace, SHARED_NAMESPACE])
+                        )
+                    else:
+                        path_stmt = path_stmt.where(Path.namespace == namespace)
+                path_result = await session.execute(path_stmt)
                 all_paths = path_result.scalars().all()
+
+                # Drop children that have no path in the requested scope.
+                if namespace is not None and not all_paths:
+                    continue
+
+                # Prefer namespace-matched paths over shared when both
+                # exist (mirrors engine.search ordering).
+                if namespace is not None and include_shared and len(all_paths) > 1:
+                    all_paths = sorted(
+                        all_paths,
+                        key=lambda p: 0 if p.namespace == namespace else 1,
+                    )
 
                 if node_uuid == ROOT_NODE_UUID and context_domain:
                     has_domain_path = any(p.domain == context_domain for p in all_paths)
@@ -357,8 +391,27 @@ class GraphService:
         # Tier 3: whatever is available
         return paths[0]
 
-    async def get_all_paths(self, domain: Optional[str] = None) -> List[Dict[str, Any]]:
-        """Get all paths with their node/edge info."""
+    async def get_all_paths(
+        self,
+        domain: Optional[str] = None,
+        *,
+        namespace: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get all paths with their node/edge info.
+
+        ``namespace`` filtering modes:
+          * ``namespace=None`` — legacy admin view (all rows). The
+            ``namespace`` key is included in the output dict so admin
+            consumers can distinguish same-URI rows across partitions.
+          * ``namespace=X``, ``include_shared=False`` (default) — strict
+            scope to ``X``.
+          * ``namespace=X``, ``include_shared=True`` — UI/desktop mode.
+            Returns rows in ``X`` *or* ``__shared__``, with
+            namespace-matched rows ordered first so dedupe (by
+            ``(domain, path)`` URI within this scoped view) keeps the
+            user's own copy when both partitions hold the same URI.
+        """
         async with self.session() as session:
             stmt = (
                 select(Path, Edge, Memory)
@@ -375,14 +428,43 @@ class GraphService:
 
             if domain is not None:
                 stmt = stmt.where(Path.domain == domain)
+            if namespace is not None:
+                if include_shared:
+                    stmt = stmt.where(
+                        Path.namespace.in_([namespace, SHARED_NAMESPACE])
+                    )
+                else:
+                    stmt = stmt.where(Path.namespace == namespace)
 
             stmt = stmt.order_by(Path.domain, Path.path)
             result = await session.execute(stmt)
 
+            rows = list(result.all())
+
+            # Within a scoped view (namespace given), order namespace-matched
+            # rows before shared so the (domain, path) dedupe below keeps
+            # the caller's own copy when both partitions hold the same URI.
+            scoped_view = namespace is not None
+            if scoped_view and include_shared:
+                rows.sort(
+                    key=lambda triple: 0
+                    if triple[0].namespace == namespace
+                    else 1
+                )
+
             paths = []
             seen = set()
-            for path_obj, edge, memory in result.all():
-                key = (path_obj.domain, path_obj.path)
+            for path_obj, edge, memory in rows:
+                # In admin view, dedupe by (namespace, domain, path) so
+                # two namespaces' same URI both surface; in scoped view
+                # dedupe by (domain, path) so a shared duplicate of a
+                # user-namespace row collapses (user's row wins via the
+                # CASE order above).
+                key = (
+                    (path_obj.domain, path_obj.path)
+                    if scoped_view
+                    else (path_obj.namespace, path_obj.domain, path_obj.path)
+                )
                 if key in seen:
                     continue
                 seen.add(key)
@@ -390,6 +472,7 @@ class GraphService:
                     {
                         "domain": path_obj.domain,
                         "path": path_obj.path,
+                        "namespace": path_obj.namespace,
                         "uri": f"{path_obj.domain}://{path_obj.path}",
                         "name": path_obj.path.rsplit("/", 1)[-1],
                         "priority": edge.priority,
@@ -473,14 +556,27 @@ class GraphService:
         return path_obj
 
     async def _resolve_path(
-        self, session: AsyncSession, path: str, domain: str = "core"
+        self,
+        session: AsyncSession,
+        path: str,
+        domain: str = "core",
+        namespace: Optional[str] = None,
     ) -> Optional[tuple]:
-        """Resolve domain+path to (Path, Edge, node_uuid). Returns None if not found."""
-        result = await session.execute(
+        """Resolve domain+path to (Path, Edge, node_uuid). Returns None if not found.
+
+        When ``namespace`` is given, the lookup is restricted to that
+        namespace — preventing one user's resolve from picking up another
+        user's row with the same ``(domain, path)``. ``namespace=None``
+        preserves the legacy unfiltered behavior for admin tooling.
+        """
+        stmt = (
             select(Path, Edge)
             .join(Edge, Path.edge_id == Edge.id)
             .where(Path.domain == domain, Path.path == path)
         )
+        if namespace is not None:
+            stmt = stmt.where(Path.namespace == namespace)
+        result = await session.execute(stmt)
         row = result.first()
         if not row:
             return None
@@ -714,11 +810,17 @@ class GraphService:
         domain: str,
         path: str,
         *,
+        namespace: Optional[str] = None,
         collector: Optional[ChangeCollector] = None,
     ) -> None:
-        """Delete a path and all its descendant paths in the given domain."""
+        """Delete a path and all its descendant paths in the given domain.
+
+        When ``namespace`` is given, the deletion is scoped to that
+        namespace — so userA's remove_path can never delete userB's
+        same ``(domain, path)`` row.
+        """
         safe = escape_like_literal(path)
-        result = await session.execute(
+        stmt = (
             select(Path)
             .where(Path.domain == domain)
             .where(
@@ -728,6 +830,9 @@ class GraphService:
                 )
             )
         )
+        if namespace is not None:
+            stmt = stmt.where(Path.namespace == namespace)
+        result = await session.execute(stmt)
         paths = result.scalars().all()
 
         for p in paths:
@@ -741,9 +846,21 @@ class GraphService:
         session: AsyncSession,
         edge: Edge,
         *,
+        namespace: Optional[str] = None,
         collector: Optional[ChangeCollector] = None,
     ) -> None:
-        """Delete an edge, all its path references, and descendant paths."""
+        """Delete an edge, all its path references, and descendant paths.
+
+        ``namespace`` propagates the strict scope from a namespaced
+        ``remove_path`` call. The current call graph would be safe
+        without this propagation (``_gc_node_soft`` only fires post-
+        global-orphan-check on a per-namespace ``node_uuid``, so
+        descendants live in the same namespace), but encoding the
+        contract on the helper prevents a future caller from
+        re-introducing a cross-namespace cascade. ``namespace=None``
+        preserves the legacy unfiltered behavior for ``cascade_delete_node``
+        and similar admin paths.
+        """
         paths_result = await session.execute(
             select(Path).where(Path.edge_id == edge.id)
         )
@@ -754,6 +871,7 @@ class GraphService:
                 session,
                 p.domain,
                 p.path,
+                namespace=namespace,
                 collector=collector,
             )
 
@@ -861,10 +979,17 @@ class GraphService:
         session: AsyncSession,
         node_uuid: str,
         *,
+        namespace: Optional[str] = None,
         collector: Optional[ChangeCollector] = None,
     ) -> None:
         """Soft GC: if a node has no incoming paths, deprecate its memories
-        and cascade-delete all edges/paths around it."""
+        and cascade-delete all edges/paths around it.
+
+        ``namespace`` propagates the strict scope from a namespaced
+        ``remove_path`` so the cascade through ``_cascade_delete_edge``
+        cannot stray into another namespace. ``namespace=None`` preserves
+        the legacy admin-cascade behavior.
+        """
         if await self._count_incoming_paths(session, node_uuid) > 0:
             return
 
@@ -881,6 +1006,7 @@ class GraphService:
             await self._cascade_delete_edge(
                 session,
                 edge,
+                namespace=namespace,
                 collector=collector,
             )
 
@@ -1008,6 +1134,8 @@ class GraphService:
         priority: Optional[int] = None,
         disclosure: Optional[str] = None,
         domain: str = "core",
+        *,
+        namespace: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Update a memory.
@@ -1017,12 +1145,18 @@ class GraphService:
 
         PR #3c shim: delegates to ``MemoryEngine.upsert_versioned`` (when
         content changes) or ``MemoryEngine.patch_edge_metadata`` (metadata
-        only) with ``namespace='__shared__'``. Pre-flight resolves the
-        path and snapshots ``rows_before``; post-flight re-fetches to
-        build ``rows_after``. The ``priority``/``disclosure`` defaults of
-        ``None`` mean "preserve" in the legacy contract — we translate
-        that into the engine's ``_UNSET`` sentinel by simply omitting
-        unset kwargs from the engine call.
+        only). Pre-flight resolves the path and snapshots ``rows_before``;
+        post-flight re-fetches to build ``rows_after``. The
+        ``priority``/``disclosure`` defaults of ``None`` mean "preserve"
+        in the legacy contract — we translate that into the engine's
+        ``_UNSET`` sentinel by simply omitting unset kwargs from the
+        engine call.
+
+        ``namespace=None`` preserves the legacy ``__shared__`` lock so
+        existing admin tooling (``oc memory-server`` browse routes) keeps
+        editing shared memories. User-facing surfaces (desktop
+        ``/memory/update``) pass their own namespace so the user's
+        per-namespace memories are addressable.
         """
         if path == "":
             raise ValueError("Cannot update the root node.")
@@ -1032,6 +1166,8 @@ class GraphService:
                 f"No update fields provided for '{domain}://{path}'. "
                 "At least one of content, priority, or disclosure must be set."
             )
+
+        target_ns = namespace if namespace is not None else SHARED_NAMESPACE
 
         # Pre-flight: snapshot the current edge + active memory.
         async with self.session() as session:
@@ -1047,7 +1183,7 @@ class GraphService:
                     ),
                 )
                 .where(
-                    Path.namespace == SHARED_NAMESPACE,
+                    Path.namespace == target_ns,
                     Path.domain == domain,
                     Path.path == path,
                 )
@@ -1079,14 +1215,14 @@ class GraphService:
             ref = await self._engine.upsert_versioned(
                 f"{domain}://{path}",
                 content,
-                namespace=SHARED_NAMESPACE,
+                namespace=target_ns,
                 **engine_kwargs,
             )
             new_memory_id = ref.new_memory_id
         else:
             await self._engine.patch_edge_metadata(
                 f"{domain}://{path}",
-                namespace=SHARED_NAMESPACE,
+                namespace=target_ns,
                 **engine_kwargs,
             )
             new_memory_id = old_id
@@ -1253,14 +1389,25 @@ class GraphService:
             }
 
     async def remove_path(
-        self, path: str, domain: str = "core", session: Optional[AsyncSession] = None
+        self,
+        path: str,
+        domain: str = "core",
+        session: Optional[AsyncSession] = None,
+        *,
+        namespace: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Remove a path and its sub-paths with orphan prevention."""
+        """Remove a path and its sub-paths with orphan prevention.
+
+        When ``namespace`` is given, lookup and deletion are scoped to
+        that namespace — ``MemoryClient(namespace="A").forget(...)`` can
+        never delete a row in namespace ``B``. ``namespace=None``
+        preserves the legacy unfiltered behavior for admin tooling.
+        """
         if path == "":
             raise ValueError("Cannot remove the root path.")
 
         async with self._optional_session(session) as session:
-            target = await self._resolve_path(session, path, domain)
+            target = await self._resolve_path(session, path, domain, namespace=namespace)
             if not target:
                 raise ValueError(f"Path '{domain}://{path}' not found")
             _, target_edge, target_node_uuid = target
@@ -1296,11 +1443,15 @@ class GraphService:
 
             collector = ChangeCollector()
             affected_nodes = await self._search.get_node_uuids_for_prefix(session, domain, path)
-            await self._delete_subtree_paths(session, domain, path, collector=collector)
+            await self._delete_subtree_paths(
+                session, domain, path, namespace=namespace, collector=collector
+            )
             await session.flush()
 
             await self._gc_edge_if_pathless(session, target_edge, collector=collector)
-            await self._gc_node_soft(session, target_node_uuid, collector=collector)
+            await self._gc_node_soft(
+                session, target_node_uuid, namespace=namespace, collector=collector
+            )
 
             for node_uuid in affected_nodes:
                 await self._search.refresh_search_documents_for_node(node_uuid, session=session)
@@ -1382,10 +1533,28 @@ class GraphService:
     # Recent Memories
     # =========================================================================
 
-    async def get_recent_memories(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get the most recently created/updated non-deprecated memories."""
+    async def get_recent_memories(
+        self,
+        limit: int = 10,
+        *,
+        namespace: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Get the most recently created/updated non-deprecated memories.
+
+        ``namespace`` filtering modes:
+          * ``namespace=None`` — legacy admin view (all rows).
+          * ``namespace=X``, ``include_shared=False`` (default) — strict.
+            ``MemoryClient(namespace="A").get_recent()`` uses this so a
+            user does not see other users' or system shared rows in
+            their own recent listing.
+          * ``namespace=X``, ``include_shared=True`` — UI/desktop mode.
+            Returns rows in ``X`` *or* ``__shared__``. The desktop
+            ``/memory/recent`` endpoint uses this so user-customized
+            ``core://agent/*`` rows surface alongside per-user rows.
+        """
         async with self.session() as session:
-            result = await session.execute(
+            stmt = (
                 select(Memory, Edge, Path)
                 .select_from(Path)
                 .join(Edge, Path.edge_id == Edge.id)
@@ -1398,6 +1567,14 @@ class GraphService:
                 )
                 .order_by(Memory.created_at.desc())
             )
+            if namespace is not None:
+                if include_shared:
+                    stmt = stmt.where(
+                        Path.namespace.in_([namespace, SHARED_NAMESPACE])
+                    )
+                else:
+                    stmt = stmt.where(Path.namespace == namespace)
+            result = await session.execute(stmt)
 
             seen = set()
             memories = []

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -369,29 +369,48 @@ class MemoryClient:
     # ------------------------------------------------------------------
 
     async def get_recent(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Return recently updated memories (no namespace filter — admin view)."""
+        """Return recently updated memories scoped to the client's namespace.
+
+        Strict — no shared fallback, by the same rule as
+        ``MemoryEngine.list_children`` (recent listings should not bleed
+        ``__shared__`` system rows into a per-user view).
+        """
         await self._ensure_init()
         from .graph import GraphService
 
         assert self._engine is not None
         graph = GraphService(self._engine.db, self._engine.search_indexer)
-        return await graph.get_recent_memories(limit=limit)
+        return await graph.get_recent_memories(
+            limit=limit, namespace=self._namespace
+        )
 
     async def forget(self, uri: str) -> Dict[str, Any]:
-        """Remove a memory by URI.
+        """Remove a memory by URI, mirroring ``remember``'s routing policy.
 
-        Currently delegates to ``GraphService.remove_path`` — the engine
-        does not yet expose a delete verb (that lands in PR #4b
-        ``ReviewLog.cascade_delete``). Path lookup is scoped to the
-        client's namespace.
+        Resolves the target namespace via the same ``namespace_policy``
+        that ``remember`` uses: ``core://agent/*``, ``core://kh/*``,
+        ``core://my_user_default/*`` route to ``__shared__`` regardless of
+        the caller's namespace; everything else stays in the caller's
+        namespace. This keeps ``remember(uri) → forget(uri)`` symmetric
+        — a per-user client can clean up its own shared-prefix writes —
+        while still preventing cross-user deletes for non-shared URIs
+        (``MemoryClient(namespace="A").forget("dataset://x")`` cannot
+        reach namespace ``B``).
+
+        Delegates to ``GraphService.remove_path`` (the engine does not
+        yet expose a delete verb — that lands in PR #4b
+        ``ReviewLog.cascade_delete``).
         """
         await self._ensure_init()
         from .graph import GraphService
 
         parsed = MemoryURI.parse(uri)
+        target_ns = resolve_namespace(parsed, current=self._namespace)
         assert self._engine is not None
         graph = GraphService(self._engine.db, self._engine.search_indexer)
-        result = await graph.remove_path(path=parsed.path, domain=parsed.domain)
+        result = await graph.remove_path(
+            path=parsed.path, domain=parsed.domain, namespace=target_ns
+        )
 
         try:
             from .snapshot import get_changeset_store

--- a/tests/memory/test_compat_namespace.py
+++ b/tests/memory/test_compat_namespace.py
@@ -186,14 +186,22 @@ async def test_search_memories_filters_by_session_namespace(store):
 
 
 @pytest.mark.asyncio
-async def test_save_memory_with_unknown_session_falls_back_to_shared(store):
-    """If the session can't be resolved, write goes to __shared__ — not silently
-    lost. (Defensive default; in practice the bot always creates a session
-    first, so this is the recovery path for log replay or test harnesses.)"""
-    await store.save_memory(
-        "nonexistent-session-id", DatasetMemory(file_path="orphan.h5ad")
-    )
+async def test_save_memory_with_unknown_session_raises(store):
+    """If the session can't be resolved, the write must NOT fall back to
+    ``__shared__`` (every other user could read it). Instead
+    ``_client_for_session`` raises ``LookupError`` and ``save_memory``
+    propagates — the caller decides whether to log-and-skip
+    (``_auto_capture_dataset``) or surface the error.
 
+    This pins the privacy fix: the prior behavior was a silent
+    fall-back to the shared partition, which leaked auto-captured
+    datasets across users when a session was missing or evicted."""
+    with pytest.raises(LookupError):
+        await store.save_memory(
+            "nonexistent-session-id", DatasetMemory(file_path="orphan.h5ad")
+        )
+
+    # Nothing landed anywhere — particularly not in __shared__.
     async with store._db.session() as s:
         rows = (
             await s.execute(
@@ -202,6 +210,4 @@ async def test_save_memory_with_unknown_session_falls_back_to_shared(store):
                 )
             )
         ).scalars().all()
-
-    assert len(rows) == 1
-    assert rows[0].namespace == "__shared__"
+    assert rows == []

--- a/tests/memory/test_namespace_isolation.py
+++ b/tests/memory/test_namespace_isolation.py
@@ -1,0 +1,411 @@
+"""Tests for namespace isolation across legacy GraphService stragglers
+and CompatMemoryStore session-fallback behavior.
+
+These tests pin the contract that the surface-layer wiring promises but
+the legacy GraphService methods (still wired into MemoryClient.forget,
+MemoryClient.get_recent, and three /memory/* server endpoints) used to
+break: namespace-scoped reads/writes must not cross into other users'
+partitions.
+
+Red→green pairs in this file:
+  - test_forget_does_not_delete_other_namespace_path     (D2)
+  - test_get_recent_only_returns_own_namespace            (D2')
+  - test_get_children_filters_by_namespace                (D3)
+  - test_get_all_paths_filters_by_namespace               (D3')
+  - test_update_memory_respects_namespace                 (5th GraphService site)
+  - test_client_for_session_refuses_when_session_missing  (D5)
+  - test_desktop_chat_user_id_matches_desktop_namespace   (D1)
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.compat import CompatMemoryStore, DatasetMemory
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.graph import GraphService
+from omicsclaw.memory.memory_client import MemoryClient
+from omicsclaw.memory.models import Path, SHARED_NAMESPACE
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    engine = MemoryEngine(db, search)
+    graph = GraphService(db, search)
+    yield engine, db, graph
+    await db.close()
+
+
+@pytest_asyncio.fixture
+async def two_clients(env):
+    engine, _, _ = env
+    yield (
+        MemoryClient(engine=engine, namespace="tg/userA"),
+        MemoryClient(engine=engine, namespace="tg/userB"),
+    )
+
+
+# ----------------------------------------------------------------------
+# D2 — forget must not cross namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_does_not_delete_other_namespace_path(two_clients, env):
+    """User A's forget('dataset://shared.h5ad') must NOT delete User B's
+    same URI in their own namespace.
+
+    This regression pins PR #131-class data-loss bugs: the legacy
+    GraphService.remove_path used to do `WHERE domain=X AND path=Y` with
+    no namespace filter, so userA.forget would race with whichever row
+    .first() picked — sometimes userB's.
+    """
+    engine, _, _ = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("dataset://shared.h5ad", "A's content")
+    await client_b.remember("dataset://shared.h5ad", "B's content")
+
+    await client_a.forget("dataset://shared.h5ad")
+
+    # B's row must survive untouched.
+    record_b = await engine.recall(
+        "dataset://shared.h5ad", namespace="tg/userB", fallback_to_shared=False
+    )
+    assert record_b is not None, "User B's path was unexpectedly deleted"
+    assert record_b.content == "B's content"
+
+    # A's row must be gone.
+    record_a = await engine.recall(
+        "dataset://shared.h5ad", namespace="tg/userA", fallback_to_shared=False
+    )
+    assert record_a is None
+
+
+# ----------------------------------------------------------------------
+# D2 follow-up — forget must mirror remember's shared-prefix routing
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forget_routes_shared_prefix_uris_to_shared(env, two_clients):
+    """``MemoryClient.remember("core://agent/style", ...)`` writes to
+    ``__shared__`` via ``namespace_policy``. ``forget`` must mirror that
+    routing so a per-user client can delete what it earlier wrote;
+    otherwise ``remember(uri) → forget(uri)`` is asymmetric and the row
+    becomes un-removable through the same client.
+    """
+    engine, _, _ = env
+    client_a, _ = two_clients
+
+    await client_a.remember("core://agent/style", "concise replies")
+
+    # Sanity: it landed in __shared__, not tg/userA.
+    record = await engine.recall(
+        "core://agent/style",
+        namespace=SHARED_NAMESPACE,
+        fallback_to_shared=False,
+    )
+    assert record is not None
+    assert record.content == "concise replies"
+
+    await client_a.forget("core://agent/style")
+
+    record_after = await engine.recall(
+        "core://agent/style",
+        namespace=SHARED_NAMESPACE,
+        fallback_to_shared=False,
+    )
+    assert record_after is None, (
+        "forget did not remove the shared-prefix row — remember/forget "
+        "asymmetric"
+    )
+
+
+# ----------------------------------------------------------------------
+# D2' — get_recent must not leak across namespaces
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_recent_only_returns_own_namespace(two_clients):
+    """A namespace-bound MemoryClient.get_recent must return rows only
+    from that client's namespace (plus optionally __shared__), never
+    from other users' partitions."""
+    client_a, client_b = two_clients
+
+    await client_a.remember("dataset://onlyA.h5ad", "A only")
+    await client_b.remember("dataset://onlyB.h5ad", "B only")
+
+    rows = await client_a.get_recent(limit=10)
+    uris = {r["uri"] for r in rows}
+    assert "dataset://onlyA.h5ad" in uris
+    assert "dataset://onlyB.h5ad" not in uris, (
+        "get_recent leaked another namespace's URI into the caller's view"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_recent_excludes_shared_rows(env, two_clients):
+    """get_recent is strict (no __shared__ fallback) by the same rule as
+    list_children / get_subtree. A core://agent shared row written by
+    one user must NOT bleed into another user's recent listing — that
+    would re-introduce a different cross-namespace leak.
+    """
+    client_a, client_b = two_clients
+
+    await client_a.remember("core://agent/style", "concise")  # → __shared__
+    await client_b.remember("dataset://onlyB.h5ad", "B's data")
+
+    rows_b = await client_b.get_recent(limit=10)
+    uris_b = {r["uri"] for r in rows_b}
+    assert "dataset://onlyB.h5ad" in uris_b
+    assert "core://agent/style" not in uris_b, (
+        "get_recent leaked a __shared__ row into a per-user listing"
+    )
+
+
+# ----------------------------------------------------------------------
+# D3 — graph.get_children must filter by namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_children_filters_by_namespace(env, two_clients):
+    """When two namespaces have sibling top-level paths, get_children at
+    root scoped to one namespace must surface only that namespace's
+    children. The desktop /memory/children endpoint calls this with
+    node_uuid=ROOT, so this is the real production call shape."""
+    _, _, graph = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("analysis://onlyA", "A's top-level analysis")
+    await client_b.remember("analysis://onlyB", "B's top-level analysis")
+
+    children = await graph.get_children(
+        context_domain="analysis",
+        namespace="tg/userA",
+    )
+    paths = {c["path"] for c in children}
+    assert "onlyA" in paths
+    assert "onlyB" not in paths, (
+        "get_children leaked another namespace's top-level URI"
+    )
+
+
+# ----------------------------------------------------------------------
+# D3' — graph.get_all_paths must filter by namespace
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_all_paths_filters_by_namespace(env, two_clients):
+    """get_all_paths(namespace='A') must skip B's rows entirely."""
+    _, _, graph = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("dataset://onlyA.h5ad", "A")
+    await client_b.remember("dataset://onlyB.h5ad", "B")
+
+    rows = await graph.get_all_paths(namespace="tg/userA")
+    uris = {r["uri"] for r in rows}
+    assert "dataset://onlyA.h5ad" in uris
+    assert "dataset://onlyB.h5ad" not in uris
+
+
+# ----------------------------------------------------------------------
+# Desktop UI mode — include_shared=True for /memory/* endpoints
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_children_include_shared_surfaces_user_writes(env, two_clients):
+    """Desktop tree view (`include_shared=True`) must show shared-prefix
+    rows the same client wrote via remember(). Without this the user
+    can write a `core://agent/style` row but never see it in the tree."""
+    _, _, graph = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("core://agent/style", "concise replies")
+    await client_b.remember("dataset://onlyB.h5ad", "B's data")
+
+    children = await graph.get_children(
+        context_domain="core",
+        namespace="tg/userA",
+        include_shared=True,
+    )
+    paths = {c["path"] for c in children}
+    assert "agent" in paths or "agent/style" in paths, (
+        "include_shared=True should surface user's __shared__ writes"
+    )
+
+    # User B's per-user dataset must NOT leak — include_shared adds
+    # __shared__ only, not other namespaces.
+    children_a_dataset = await graph.get_children(
+        context_domain="dataset",
+        namespace="tg/userA",
+        include_shared=True,
+    )
+    a_paths = {c["path"] for c in children_a_dataset}
+    assert "onlyB.h5ad" not in a_paths
+
+
+@pytest.mark.asyncio
+async def test_get_recent_memories_include_shared(env, two_clients):
+    """get_recent_memories(namespace=A, include_shared=True) returns
+    A's rows + __shared__ rows (desktop UI mode), but not B's."""
+    _, _, graph = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("dataset://onlyA.h5ad", "A's data")
+    await client_a.remember("core://agent/style", "concise")
+    await client_b.remember("dataset://onlyB.h5ad", "B's data")
+
+    rows = await graph.get_recent_memories(
+        limit=10, namespace="tg/userA", include_shared=True
+    )
+    uris = {r["uri"] for r in rows}
+    assert "dataset://onlyA.h5ad" in uris
+    assert "core://agent/style" in uris, (
+        "include_shared=True should include __shared__ rows"
+    )
+    assert "dataset://onlyB.h5ad" not in uris, (
+        "include_shared=True must not leak other namespaces"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_all_paths_include_shared(env, two_clients):
+    """get_all_paths(namespace=A, include_shared=True) returns A's URIs
+    plus __shared__ URIs, with namespace-matched rows preferred when
+    the same URI appears in both."""
+    _, _, graph = env
+    client_a, client_b = two_clients
+
+    await client_a.remember("dataset://onlyA.h5ad", "A")
+    await client_a.remember("core://agent/style", "concise")
+    await client_b.remember("dataset://onlyB.h5ad", "B")
+
+    rows = await graph.get_all_paths(
+        namespace="tg/userA", include_shared=True
+    )
+    uris = {r["uri"] for r in rows}
+    assert "dataset://onlyA.h5ad" in uris
+    assert "core://agent/style" in uris
+    assert "dataset://onlyB.h5ad" not in uris
+
+
+# ----------------------------------------------------------------------
+# 5th GraphService site — update_memory must not be locked to __shared__
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_memory_respects_caller_namespace(env, two_clients):
+    """graph.update_memory(path, namespace='A') must update A's row,
+    not the __shared__ partition.
+
+    The old shim hardcoded ``Path.namespace == SHARED_NAMESPACE``, which
+    meant /memory/update could never edit a user's per-namespace memory.
+    """
+    engine, _, graph = env
+    client_a, _ = two_clients
+
+    await client_a.remember("preference://qc/threshold", "20%")
+
+    await graph.update_memory(
+        path="qc/threshold",
+        domain="preference",
+        content="25%",
+        namespace="tg/userA",
+    )
+
+    record = await engine.recall(
+        "preference://qc/threshold",
+        namespace="tg/userA",
+        fallback_to_shared=False,
+    )
+    assert record is not None
+    assert record.content == "25%"
+
+
+# ----------------------------------------------------------------------
+# D5 — _client_for_session must refuse silently writing to __shared__
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_for_session_refuses_when_session_missing(tmp_path):
+    """When a session_id can't be resolved, CompatMemoryStore must NOT
+    fall back to writing into __shared__ (where every user can read it).
+
+    The defensive-fallback behavior was a privacy hole: an
+    auto-captured dataset arriving before its session was created would
+    land globally. The fix raises LookupError so the caller (which
+    already wraps in try/except) silently skips the write."""
+    store = CompatMemoryStore(database_url=f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await store.initialize()
+    try:
+        with pytest.raises(LookupError):
+            await store._client_for_session("nonexistent-session-id")
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_save_memory_swallows_missing_session(tmp_path):
+    """save_memory called with an unknown session_id must surface as
+    LookupError to the caller (not write to __shared__)."""
+    store = CompatMemoryStore(database_url=f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await store.initialize()
+    try:
+        ds_mem = DatasetMemory(file_path="x.h5ad")
+        with pytest.raises(LookupError):
+            await store.save_memory("nonexistent-session-id", ds_mem)
+
+        # The dataset URI must NOT appear in __shared__ (or anywhere).
+        async with store._db.session() as s:
+            rows = (
+                await s.execute(
+                    sa.select(Path).where(Path.domain == "dataset")
+                )
+            ).scalars().all()
+        assert rows == [], (
+            f"save_memory leaked {[(r.namespace, r.path) for r in rows]} "
+            "despite missing session"
+        )
+    finally:
+        await store.close()
+
+
+# ----------------------------------------------------------------------
+# D1 — Desktop chat namespace must converge with endpoint namespace
+# ----------------------------------------------------------------------
+
+
+def test_desktop_chat_user_id_matches_desktop_namespace(monkeypatch):
+    """Whatever user_id the desktop chat agent loop hands to
+    CompatMemoryStore must compose to the same string as
+    desktop_namespace().
+
+    Concretely: f"app/{desktop_chat_user_id()}" == desktop_namespace().
+    Without this invariant, in multi-launch desktop deployments the
+    /memory/* endpoints (read namespace=desktop_namespace()) and the
+    chat path (write namespace=f"app/desktop_user") would diverge and
+    the UI would not see chat-saved memories.
+    """
+    from omicsclaw.memory import desktop_chat_user_id, desktop_namespace
+
+    monkeypatch.delenv("OMICSCLAW_DESKTOP_LAUNCH_ID", raising=False)
+    assert f"app/{desktop_chat_user_id()}" == desktop_namespace()
+
+    monkeypatch.setenv("OMICSCLAW_DESKTOP_LAUNCH_ID", "launch-xyz")
+    assert desktop_chat_user_id() == "launch-xyz"
+    assert f"app/{desktop_chat_user_id()}" == desktop_namespace()


### PR DESCRIPTION
## Summary

Verification of the PR #125–#134 memory refactor turned up a family of real bugs: the 5 legacy `GraphService` methods still called from `MemoryClient.forget`, `MemoryClient.get_recent`, and three desktop `/memory/*` endpoints had **no namespace filtering**. Same SQL pattern as the PR #131 GC data-loss bug.

| # | Bug | Severity |
|---|---|---|
| **D2** | `MemoryClient.forget(uri)` could delete another user's `(domain, path)` row — cross-namespace data loss | Critical |
| **D2'** | `MemoryClient.get_recent()` returned recent memories from EVERY namespace | Critical (privacy) |
| **D3** | `/memory/children` returned cross-namespace children to the desktop UI | High (info leak) |
| **D3'** | `/memory/domains` mixed counts across namespaces and dedup'd them away | Medium (incorrect counts + leak) |
| **5th site** | `/memory/update` was hardcoded to `Path.namespace == SHARED_NAMESPACE` — desktop users could never edit their per-namespace memories | High (broken feature) |
| **D1** | `app/server.py` hardcoded `user_id="desktop_user"` for chat while `desktop_namespace()` reads `OMICSCLAW_DESKTOP_LAUNCH_ID`. Multi-launch deployments wrote chat memories to a namespace the endpoints couldn't read | High (silent under default; bites multi-launch) |
| **D5** | `CompatMemoryStore._client_for_session` silently fell back to `__shared__` when a session was missing — auto-captured datasets arriving before session creation leaked globally | Medium (privacy) |

## Approach

Add `namespace=` (and `include_shared=` where UX requires it) to the 5 `GraphService` methods. `namespace=None` preserves the legacy unfiltered admin path used by `oc memory-server`'s browse routes (`omicsclaw/memory/api/browse.py`) — zero changes needed there.

`MemoryClient.forget` routes via the same `namespace_policy.resolve_namespace()` as `MemoryClient.remember()`, so shared-prefix URIs (`core://agent/*`, `core://kh/*`) stay **symmetric** — a per-user client can clean up its own shared writes — while non-shared URIs cannot reach other namespaces.

Desktop endpoints (`/memory/children`, `/memory/domains`, `/memory/recent`) pass `include_shared=True` so the single-user UI tree shows user-customized `__shared__` rows alongside per-namespace rows. Strict default keeps multi-tenant bot inventories clean.

Cascade chain (`_cascade_delete_edge`, `_gc_node_soft`) also threads `namespace` through, encoding the invariant on the helpers themselves so a future caller can't re-introduce the cross-namespace cascade by accident.

`CompatMemoryStore._client_for_session` now raises `LookupError` instead of falling back to `__shared__`. All three callers (`save_memory`, `get_memories`, `search_memories`) sit inside `try/except` wrappers in production callers (`_auto_capture_dataset`, etc.) so the error is contained as a logged skip — never as a privacy leak.

## Test plan

- [x] 13 new tests in `tests/memory/test_namespace_isolation.py` (red→green map in module docstring)
  - Cross-namespace forget data loss (D2)
  - Shared-prefix forget symmetry (D2 follow-up — caught at 5-axis review)
  - get_recent cross-namespace info leak (D2')
  - get_recent excludes `__shared__` rows by default (read-fallback boundary)
  - get_children / get_all_paths namespace filter (D3)
  - get_children / get_all_paths / get_recent_memories `include_shared=True` desktop UI mode
  - update_memory respects caller's namespace (5th site)
  - `_client_for_session` raises LookupError; `save_memory` propagates and writes nothing (D5)
  - Desktop chat user_id ↔ desktop_namespace invariant (D1)
- [x] Updated `tests/memory/test_compat_namespace.py::test_save_memory_with_unknown_session_raises` to pin the new contract (was `..._falls_back_to_shared`)
- [x] Curated regression suite from prior session: **283/283** (was 270 pre-fix; +13 isolation, +1 renamed compat test)
- [x] 5-axis review by code-reviewer agent — addressed 1 important blocker (forget asymmetry) + 1 important latent bug (`_cascade_delete_edge` namespace propagation) + 1 important UX (desktop `include_shared`) before commit
- [ ] CI green

## Out of scope

- `omicsclaw/memory/api/browse.py` (admin REST API for `oc memory-server`) keeps `namespace=None` legacy behavior — it's not in the user-facing entry layer.
- CLI/TUI is graph-unbound today (uses `ScopedMemory` only); a future PR can wire it via `cli_namespace_from_workspace` if cross-Surface continuity becomes a feature.
- Plan §6.2 acceptance "graph.py < 100 lines" remains unmet; full GraphService retirement is tracked as a follow-up (handoff Option B). This PR closes the bugs **without** that retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)