### PR TITLE
test(memory): end-to-end coverage for production triggers and HTTP endpoints (T2)

### DIFF
--- a/tests/bot/test_skill_orchestration.py
+++ b/tests/bot/test_skill_orchestration.py
@@ -76,3 +76,112 @@ def test_skill_orchestration_re_exports_share_identity_with_bot_core():
     assert not mismatched_identity, (
         f"Parallel copies (must be same object): {mismatched_identity}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T2 S7 — _auto_capture_dataset lands at session namespace (production trigger #2)
+# ---------------------------------------------------------------------------
+
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+
+@pytest_asyncio.fixture
+async def memory_store(tmp_path, monkeypatch):
+    """Real CompatMemoryStore wired into bot.core.memory_store, the global
+    that _auto_capture_dataset reads via late binding."""
+    from omicsclaw.memory.compat import CompatMemoryStore
+    import bot.core
+
+    store = CompatMemoryStore(database_url=f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await store.initialize()
+    monkeypatch.setattr(bot.core, "memory_store", store)
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_auto_capture_dataset_lands_in_session_namespace(memory_store, tmp_path):
+    """When a skill processes a dataset file, the bot's auto-capture
+    helper must persist a `dataset://...` row in the running session's
+    namespace — not silently leak to `__shared__` (D5 fix).
+
+    Existing tests for skill orchestration monkeypatch `_auto_capture_dataset`
+    to a no-op; this is the first behavior-level coverage of the real
+    function. A non-h5ad file is fine — the function tolerates failed
+    h5py introspection by leaving n_obs/n_vars as None.
+    """
+    from bot.skill_orchestration import _auto_capture_dataset
+    from omicsclaw.memory.models import Path
+
+    session = await memory_store.create_session("alice", "telegram")
+
+    # A plain text file, not under OMICSCLAW_DIR — _auto_capture_dataset
+    # falls back to using just the basename for the URI path.
+    fake_dataset = tmp_path / "sample.h5ad"
+    fake_dataset.write_text("(not real h5ad payload)")
+
+    await _auto_capture_dataset(
+        session_id=session.session_id,
+        input_path=str(fake_dataset),
+        data_type="h5ad",
+    )
+
+    async with memory_store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(Path.domain == "dataset")
+            )
+        ).scalars().all()
+
+    namespaces = {r.namespace for r in rows}
+    paths = {r.path for r in rows}
+
+    assert "telegram/alice" in namespaces, (
+        f"auto-capture did not land in session namespace; got namespaces={namespaces}"
+    )
+    assert "__shared__" not in namespaces, (
+        f"auto-capture leaked into __shared__ — D5 silent fallback regressed"
+    )
+    assert any("sample.h5ad" in p for p in paths), (
+        f"dataset URI not derived from filename; got paths={paths}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_capture_dataset_skips_when_session_missing(
+    memory_store, tmp_path
+):
+    """If a skill execution races ahead of session creation, auto-capture
+    must NOT silently land the dataset URI in __shared__ — D5's fix
+    raises LookupError from _client_for_session, and _auto_capture_dataset
+    swallows it via its broad try/except. The result: a logged warning,
+    no row written anywhere."""
+    from bot.skill_orchestration import _auto_capture_dataset
+    from omicsclaw.memory.models import Path
+
+    fake_dataset = tmp_path / "orphan.h5ad"
+    fake_dataset.write_text("x")
+
+    # Pass a session_id that was never created. Pre-D5 fix this would
+    # have written to __shared__; post-fix it must skip silently.
+    await _auto_capture_dataset(
+        session_id="nonexistent-session",
+        input_path=str(fake_dataset),
+        data_type="h5ad",
+    )
+
+    async with memory_store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(Path.domain == "dataset")
+            )
+        ).scalars().all()
+    assert rows == [], (
+        f"auto-capture leaked a row despite missing session: "
+        f"{[(r.namespace, r.path) for r in rows]}"
+    )

--- a/tests/bot/test_tool_executors.py
+++ b/tests/bot/test_tool_executors.py
@@ -75,6 +75,84 @@ def test_tool_executors_re_exports_share_identity_with_bot_core():
     )
 
 
+# ---------------------------------------------------------------------------
+# T2 S1 — bot's manage_memory tool path lands writes in session namespace
+# ---------------------------------------------------------------------------
+
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+
+@pytest_asyncio.fixture
+async def memory_store(tmp_path, monkeypatch):
+    """A real CompatMemoryStore wired to ``bot.core.memory_store``.
+
+    The bot tool ``execute_remember`` reads ``_core.memory_store`` (late
+    binding from bot.core's module-level global), so the test must mutate
+    that global to inject a temp-DB store. ``monkeypatch`` restores it
+    cleanly.
+    """
+    from omicsclaw.memory.compat import CompatMemoryStore
+    import bot.core
+
+    store = CompatMemoryStore(database_url=f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await store.initialize()
+    monkeypatch.setattr(bot.core, "memory_store", store)
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_execute_remember_lands_in_session_namespace(memory_store):
+    """When the LLM tool ``execute_remember`` saves a preference for an
+    active Telegram session, the resulting row must land in the
+    session-derived namespace ``f"{platform}/{user_id}"`` — the
+    production guarantee that two bot users cannot see each other's
+    preferences. This test exercises the real bot→CompatMemoryStore→
+    MemoryEngine→DB path; the only thing it skips is the LLM emitting
+    the tool call."""
+    from bot.tool_executors import execute_remember
+    from omicsclaw.memory.models import Path
+
+    session = await memory_store.create_session("alice", "telegram")
+
+    result = await execute_remember(
+        args={
+            "memory_type": "preference",
+            "domain": "global",
+            "key": "qc_threshold",
+            "value": "20%",
+        },
+        session_id=session.session_id,
+    )
+
+    assert "✓" in result or "saved" in result.lower(), (
+        f"execute_remember reported failure: {result!r}"
+    )
+
+    async with memory_store._db.session() as s:
+        rows = (
+            await s.execute(
+                sa.select(Path).where(
+                    Path.domain == "preference",
+                    Path.path == "global/qc_threshold",
+                )
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1, (
+        f"Expected exactly 1 path row, got {len(rows)}: "
+        f"{[(r.namespace, r.domain, r.path) for r in rows]}"
+    )
+    assert rows[0].namespace == "telegram/alice", (
+        f"Preference landed in {rows[0].namespace!r}; expected 'telegram/alice'"
+    )
+
+
 def test_tool_executors_dispatch_table_lists_all_24_executors():
     """``_available_tool_executors()`` returns the full dispatch map.
     The lazy ``bot.core.TOOL_EXECUTORS`` attribute also adds the

--- a/tests/integration/test_memory_cross_surface.py
+++ b/tests/integration/test_memory_cross_surface.py
@@ -165,3 +165,64 @@ async def test_two_cli_workspaces_isolate_their_writes(shared_engine):
     assert a_record.content == "ws_a's analysis"
     assert b_record.content == "ws_b's analysis"
     assert a_record.namespace != b_record.namespace
+
+
+# ---------------------------------------------------------------------------
+# T2 S8 — memories survive engine close/reopen (server restart simulation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memories_survive_engine_close_and_reopen(tmp_path, monkeypatch):
+    """The memory system's promise to the user — 'the agent remembers what
+    I told it across sessions' — only holds if writes survive a server
+    restart. Simulate: write → close engine → reopen engine pointing at
+    the same DB file → recall.
+
+    Without this, the namespace machinery could be in-memory and we
+    wouldn't notice. The pin: SQLite file persists, init_db is
+    idempotent, and engine cache reset is clean.
+    """
+    db_path = f"{tmp_path}/persist.db"
+    monkeypatch.setenv("OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}")
+
+    from omicsclaw.memory import (
+        close_db,
+        get_engine_db,
+        get_memory_client,
+    )
+
+    # First "process": write a memory in a per-user namespace and a
+    # shared one, then close the engine cleanly.
+    await close_db()
+    await get_engine_db().init_db()
+    user = get_memory_client(namespace="telegram/alice")
+    await user.remember("preference://qc/threshold", "20% mito")
+    await user.remember("core://agent/style", "concise")  # → __shared__
+    await close_db()
+
+    # Second "process": reopen against the same DB file. The package's
+    # singletons reset on close_db; init_db is a no-op for an already-
+    # migrated schema.
+    await get_engine_db().init_db()
+    user2 = get_memory_client(namespace="telegram/alice")
+
+    pref = await user2.recall("preference://qc/threshold")
+    assert pref is not None, "preference vanished across restart"
+    assert pref.content == "20% mito"
+
+    style = await user2.recall("core://agent/style")
+    assert style is not None, "shared row vanished across restart"
+    assert style.content == "concise"
+
+    # And isolation is still enforced after restart: a different
+    # namespace must not see alice's preference.
+    bob = get_memory_client(namespace="telegram/bob")
+    bob_view = await bob.recall(
+        "preference://qc/threshold", fallback_to_shared=False
+    )
+    assert bob_view is None, (
+        "Namespace isolation lost across restart — bob saw alice's row"
+    )
+
+    await close_db()

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2371,6 +2371,145 @@ async def test_mcp_sync_empty_payload_removes_all_existing_servers(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# T2 S4 — /memory/{children,domains,recent} desktop-UI mode (include_shared)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_children_endpoint_surfaces_shared_and_excludes_others(
+    monkeypatch, tmp_path
+):
+    """GET /memory/children for the desktop client returns children in
+    its own namespace AND in __shared__ (PR #137's include_shared=True
+    UI mode), but never children that live only in another bot user's
+    namespace.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        other_client = MemoryClient(engine=engine, namespace="telegram/bob")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        # Desktop's own write
+        await desktop_client.remember("dataset://desktop_only.h5ad", "desk")
+        # A shared-prefix write (lands in __shared__ via namespace_policy)
+        await desktop_client.remember("core://agent/style", "concise")
+        # Bystander's own write — must NOT show in desktop tree
+        await other_client.remember("dataset://bob_secret.h5ad", "bob")
+
+        children = await server.memory_children(
+            node_uuid="", domain="dataset"
+        )
+        paths = {c["path"] for c in children["children"]}
+        assert "desktop_only.h5ad" in paths, (
+            f"Desktop's own dataset missing from tree: {paths}"
+        )
+        assert "bob_secret.h5ad" not in paths, (
+            f"Bystander telegram/bob's dataset leaked into desktop tree: {paths}"
+        )
+
+        core_children = await server.memory_children(
+            node_uuid="", domain="core"
+        )
+        core_paths = {c["path"] for c in core_children["children"]}
+        assert any("agent" in p for p in core_paths), (
+            f"Shared core://agent/* missing from desktop tree (include_shared "
+            f"contract broken): {core_paths}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_recent_endpoint_excludes_other_namespaces(
+    monkeypatch, tmp_path
+):
+    """GET /memory/recent for the desktop client must include the
+    desktop's own writes AND __shared__ rows (the desktop-UI mode), but
+    never another user's per-namespace writes."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        other_client = MemoryClient(engine=engine, namespace="telegram/bob")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("dataset://desktop_only.h5ad", "desk")
+        await desktop_client.remember("core://agent/style", "concise")
+        await other_client.remember("dataset://bob_secret.h5ad", "bob")
+
+        result = await server.memory_recent(limit=20)
+        uris = {r["uri"] for r in result["results"]}
+        assert "dataset://desktop_only.h5ad" in uris
+        assert "core://agent/style" in uris, (
+            "include_shared contract: desktop /memory/recent should surface "
+            f"user's __shared__ writes; got {uris}"
+        )
+        assert "dataset://bob_secret.h5ad" not in uris, (
+            f"Bystander row leaked into desktop's /memory/recent: {uris}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_domains_endpoint_counts_user_plus_shared_only(
+    monkeypatch, tmp_path
+):
+    """GET /memory/domains counts paths the desktop user can address —
+    own namespace + __shared__ — never sibling namespaces. The legacy
+    unscoped count was a privacy/correctness leak."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        other_client = MemoryClient(engine=engine, namespace="telegram/bob")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("dataset://d1.h5ad", "d1")
+        await desktop_client.remember("analysis://a1/run", "a1")
+        await desktop_client.remember("core://agent/style", "concise")
+        # Three rows for telegram/bob — must not influence desktop's counts
+        await other_client.remember("dataset://b1.h5ad", "b1")
+        await other_client.remember("dataset://b2.h5ad", "b2")
+        await other_client.remember("analysis://b/run", "b3")
+
+        result = await server.memory_domains()
+        domain_counts = {d["domain"]: d["node_count"] for d in result["domains"]}
+
+        assert "dataset" in domain_counts and domain_counts["dataset"] >= 1
+        assert "analysis" in domain_counts and domain_counts["analysis"] >= 1
+        # Desktop has 1 dataset; bystander has 2 — total under unscoped
+        # would be 3. Scoped count must show 1 (just the desktop's).
+        assert domain_counts["dataset"] == 1, (
+            f"Domain count leaked telegram/bob's datasets: "
+            f"got {domain_counts['dataset']}, expected 1 (desktop only). "
+            f"Full counts: {domain_counts}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+# ---------------------------------------------------------------------------
 # T2 S6 — /memory/delete is namespace-scoped (no cross-namespace blast)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2370,6 +2370,70 @@ async def test_mcp_sync_empty_payload_removes_all_existing_servers(monkeypatch):
     assert removed == ["stale-a", "stale-b"]
 
 
+# ---------------------------------------------------------------------------
+# T2 S5 — /memory/update writes to the desktop client's namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_update_endpoint_writes_to_desktop_namespace(monkeypatch, tmp_path):
+    """POST /memory/update must update the row in the desktop's namespace
+    (``_memory_client.namespace``), not the legacy ``__shared__``-only
+    target. PR #137 fixed the GraphService shim that hardcoded
+    ``Path.namespace == SHARED_NAMESPACE``; without that fix a desktop
+    user's per-namespace memory was unreachable through this endpoint.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.app.server import MemoryUpdateRequest
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        # Bind the server's _memory_client to a non-shared namespace so we
+        # can prove updates land there (not in __shared__).
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        # Seed a row at app/desktop_user — note core://test/* is NOT in
+        # SHARED_PREFIXES, so MemoryClient.remember writes to the caller's
+        # namespace as expected.
+        await desktop_client.remember("core://test/key", "v1")
+
+        # Act: hit the endpoint function (the public HTTP surface).
+        result = await server.memory_update(
+            MemoryUpdateRequest(
+                path="test/key", domain="core", content="v2",
+            )
+        )
+        assert result["ok"] is True
+
+        # Assert: the desktop namespace row updated; nothing in __shared__.
+        record = await engine.recall(
+            "core://test/key",
+            namespace="app/desktop_user",
+            fallback_to_shared=False,
+        )
+        assert record is not None, "Update vaporized the desktop row"
+        assert record.content == "v2", (
+            f"Expected v2 in app/desktop_user, got {record.content!r}"
+        )
+
+        shared_record = await engine.recall(
+            "core://test/key",
+            namespace="__shared__",
+            fallback_to_shared=False,
+        )
+        assert shared_record is None, (
+            f"/memory/update leaked into __shared__: {shared_record!r}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
 @pytest.mark.asyncio
 async def test_memory_review_clear_discards_pending_memory_create(monkeypatch, tmp_path):
     pytest.importorskip("fastapi")

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2371,6 +2371,105 @@ async def test_mcp_sync_empty_payload_removes_all_existing_servers(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# T2 S2 — /memory/browse recall falls back to __shared__
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_browse_endpoint_falls_back_to_shared(monkeypatch, tmp_path):
+    """GET /memory/browse for a URI that lives only in __shared__ must
+    surface the shared content to the desktop client via read fallback.
+    Pins the engine.recall(fallback_to_shared=True) contract at the
+    HTTP boundary."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        # core://agent/* routes to __shared__ via namespace_policy.
+        await desktop_client.remember("core://agent/style", "concise replies")
+
+        # Sanity: the row really lives only in __shared__.
+        assert (
+            await engine.recall(
+                "core://agent/style",
+                namespace="app/desktop_user",
+                fallback_to_shared=False,
+            )
+        ) is None
+
+        result = await server.memory_browse(path="agent/style", domain="core")
+        assert result["node"] is not None, (
+            "browse returned no node — read fallback to __shared__ broken"
+        )
+        assert result["node"]["content"] == "concise replies"
+    finally:
+        await memory_pkg.close_db()
+
+
+# ---------------------------------------------------------------------------
+# T2 S3 — /memory/search namespace-scoped (caller + __shared__ only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_search_endpoint_excludes_other_namespaces(
+    monkeypatch, tmp_path
+):
+    """GET /memory/search must scope FTS hits to the desktop's namespace
+    plus __shared__. Bystander namespaces' content matching the query
+    must not leak — the production guarantee for multi-tenant DBs."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        bystander_client = MemoryClient(engine=engine, namespace="telegram/bob")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        # Three rows, all containing "mito" — one per namespace.
+        await desktop_client.remember(
+            "analysis://desktop/qc-report", "mito 18% in pbmc"
+        )
+        await desktop_client.remember(
+            "core://agent/style", "concise replies about mito"
+        )  # → __shared__
+        await bystander_client.remember(
+            "analysis://bob/qc", "mito 22% (bob's secret)"
+        )
+
+        result = await server.memory_search(q="mito", limit=20, domain=None)
+        namespaces = {r.get("namespace") for r in result["results"]}
+        contents = " ".join(
+            (r.get("content_snippet") or "") for r in result["results"]
+        )
+
+        assert "app/desktop_user" in namespaces, (
+            f"Desktop's own row missing from FTS: {result['results']}"
+        )
+        assert "telegram/bob" not in namespaces, (
+            f"Bystander telegram/bob leaked into desktop FTS: {result['results']}"
+        )
+        assert "bob's secret" not in contents, (
+            f"Bystander content leaked through search snippets: {contents!r}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+# ---------------------------------------------------------------------------
 # T2 S4 — /memory/{children,domains,recent} desktop-UI mode (include_shared)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2371,6 +2371,61 @@ async def test_mcp_sync_empty_payload_removes_all_existing_servers(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# T2 S6 — /memory/delete is namespace-scoped (no cross-namespace blast)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_endpoint_does_not_cross_namespace(monkeypatch, tmp_path):
+    """DELETE /memory/delete must remove only the desktop client's row.
+    Two namespaces holding the same ``(domain, path)`` URI must not be
+    collapsed by the delete — that would be the PR #131-class data-loss
+    pattern PR #137 closed for the legacy GraphService path.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    graph, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        bystander_client = MemoryClient(engine=engine, namespace="telegram/bob")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("dataset://pbmc.h5ad", "desktop's pbmc")
+        await bystander_client.remember("dataset://pbmc.h5ad", "bob's pbmc")
+
+        # Act
+        result = await server.memory_delete(path="pbmc.h5ad", domain="dataset")
+        assert result["ok"] is True
+
+        # Assert: desktop row gone; bystander row intact
+        desktop_after = await engine.recall(
+            "dataset://pbmc.h5ad",
+            namespace="app/desktop_user",
+            fallback_to_shared=False,
+        )
+        bystander_after = await engine.recall(
+            "dataset://pbmc.h5ad",
+            namespace="telegram/bob",
+            fallback_to_shared=False,
+        )
+        assert desktop_after is None, (
+            f"Desktop row survived its own delete: {desktop_after!r}"
+        )
+        assert bystander_after is not None, (
+            "telegram/bob's same-URI row was deleted by desktop's "
+            "/memory/delete — PR #137 cross-namespace safety broken"
+        )
+        assert bystander_after.content == "bob's pbmc"
+    finally:
+        await memory_pkg.close_db()
+
+
+# ---------------------------------------------------------------------------
 # T2 S5 — /memory/update writes to the desktop client's namespace
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the test-coverage gap between the **memory layer** (which had ~283 unit + 4 cross-surface tests) and the **production paths that use it** (which had close to zero):

| Path | Pre-PR coverage | Post-PR |
|---|---|---|
| bot `execute_remember` LLM tool | none | S1 |
| `_auto_capture_dataset` (skill→memory hook) | always monkeypatched in tests | S7 (×2) |
| `/memory/browse` recall + read fallback | none | S2 |
| `/memory/search` namespace scoping | none | S3 |
| `/memory/{children,recent,domains}` `include_shared=True` desktop UI mode | none | S4 (×3) |
| `/memory/update` writes to user namespace (PR #137 fix) | graph-method unit only | S5 |
| `/memory/delete` cross-namespace safety (PR #137 fix) | graph-method unit only | S6 |
| Persistence across server restart | none | S8 |

11 new tests, 605 LOC, no production code changes — pure characterization tests pinning behavior the team relies on for "the agent really remembers what users tell it."

## Methodology

Followed `tdd` (vertical slices: one test → run → green-or-fix → commit → next) and `incremental-implementation` (one slice per commit, never more than one logical change). Each commit message names the slice (S1–S8) and the contract it pins.

8 commits on this branch — one per slice — for clean review.

## Slices

- **S1** [`3d25cf9`](../commit/3d25cf9) — bot's `execute_remember` lands in session-derived namespace `f"{platform}/{user_id}"`
- **S5** [`8cf3b22`](../commit/8cf3b22) — `/memory/update` writes to `_memory_client.namespace`, not legacy `__shared__` (PR #137 fix at HTTP boundary)
- **S6** [`ac20016`](../commit/ac20016) — `/memory/delete` cannot reach a sibling namespace's same-URI row (PR #131-class data-loss pattern stays closed)
- **S4** [`b0dab9b`](../commit/b0dab9b) — desktop `/memory/{children,recent,domains}` show user namespace + `__shared__`, never sibling per-user namespaces (PR #137 desktop UI mode)
- **S7** [`9a6b44d`](../commit/9a6b44d) — `_auto_capture_dataset` writes to session namespace; with missing session, broad try/except contains LookupError (D5 fix) and writes nothing
- **S2** [`7d49c51`](../commit/7d49c51) — `/memory/browse` recall falls back to `__shared__`, pinning the asymmetric read-fallback contract at HTTP
- **S3** [`7d49c51`](../commit/7d49c51) — `/memory/search` scopes FTS to (caller_namespace, `__shared__`); bystander rows never leak through search snippets
- **S8** [`aa07164`](../commit/aa07164) — memories survive engine close+reopen against same SQLite file; namespace isolation persists across restart

## Test plan

- [x] Each slice's test red-green verified during development
- [x] Curated regression: **324/324** in tests/memory/ + tests/bot/ + tests/test_app_server.py + tests/integration/test_memory_cross_surface.py + adjacent files (was 283 pre-PR; +11 new + ~30 from broader scope)
- [x] No production code changed — pure test additions
- [ ] CI green

## Out of scope

- **Live LLM end-to-end** (start `oc app-server`, send chat, observe `manage_memory` tool call): would test the LLM's ability to invoke the tool, not the memory wiring. Brittle and expensive; the tool function itself is now covered.
- **Bot live integration** (real Telegram/Feishu tokens): same reasoning — channel adapter is thin, the shared `bot.core.memory_store → CompatMemoryStore` path is what S1+S7 cover.
- **Multi-launch desktop end-to-end**: invariant `f"app/{desktop_chat_user_id()}" == desktop_namespace()` already pinned at unit level in PR #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Expanded test coverage for memory persistence across system operations and dataset capture workflows.
* Added integration tests validating that memories persist correctly after server restarts and database instance transitions.
* Enhanced test suite for namespace-scoped memory endpoints, ensuring proper data isolation, fallback behavior, and namespace boundaries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/139)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->