### PR TITLE
feat(skill_lint): require Skip when/if/for clause in v2 descriptions (PR-eval of skill rework)

### DIFF
--- a/scripts/skill_lint.py
+++ b/scripts/skill_lint.py
@@ -67,11 +67,22 @@ def _parse_skill_md(skill_dir: Path) -> tuple[dict, str] | None:
     return frontmatter, body
 
 
+_SKIP_CLAUSES = ("skip when", "skip if", "skip for")
+
+
 def _check_description(description: str) -> list[str]:
     errors: list[str] = []
     desc = (description or "").strip()
-    if not desc.lower().startswith("load when"):
+    # Whitespace-normalise so YAML folded scalars (`>-` / `|`) that wrap
+    # "Skip when" across lines, or that introduce double spaces, still match.
+    normalised = " ".join(desc.lower().split())
+    if not normalised.startswith("load when"):
         errors.append("description: must start with 'Load when'")
+    if not any(clause in normalised for clause in _SKIP_CLAUSES):
+        errors.append(
+            "description: must include a 'Skip when' / 'Skip if' / 'Skip for' "
+            "clause"
+        )
     if len(desc.split()) > MAX_DESCRIPTION_WORDS:
         errors.append(
             f"description: must be <= {MAX_DESCRIPTION_WORDS} words "

--- a/tests/test_skill_lint.py
+++ b/tests/test_skill_lint.py
@@ -58,7 +58,7 @@ VALID_BODY = (
 def _write_v2_skill(
     base: Path,
     *,
-    description: str = "Load when demoing the lint.",
+    description: str = "Load when demoing the lint. Skip when in production.",
     body: str = VALID_BODY,
     sidecar: dict | None = None,
     skip_references: tuple[str, ...] = (),
@@ -147,6 +147,76 @@ def test_description_word_count_capped(tmp_path: Path) -> None:
     skill = _write_v2_skill(tmp_path / "demo", description=long_desc)
     errors = skill_lint.lint_skill(skill)
     assert any("description" in e and "50" in e for e in errors)
+
+
+def test_description_must_include_skip_clause(tmp_path: Path) -> None:
+    """A description that only says when to load is half a routing trigger;
+    it must also tell the agent which neighbour to bounce to.  Accepts
+    'Skip when' / 'Skip if' / 'Skip for' (all three forms appear in
+    production descriptions).
+    """
+    skill = _write_v2_skill(
+        tmp_path / "demo",
+        description="Load when demoing the lint without a skip clause.",
+    )
+    errors = skill_lint.lint_skill(skill)
+    assert any(
+        "description" in e and "Skip" in e for e in errors
+    ), f"expected a Skip-clause error, got {errors}"
+
+
+@pytest.mark.parametrize("clause", ["Skip when", "Skip if", "Skip for"])
+def test_description_skip_clause_variants_accepted(
+    tmp_path: Path, clause: str
+) -> None:
+    """All three Skip variants observed in production descriptions are
+    accepted by the lint."""
+    skill = _write_v2_skill(
+        tmp_path / "demo",
+        description=f"Load when X. {clause} Y.",
+    )
+    errors = skill_lint.lint_skill(skill)
+    assert not any(
+        "description" in e and "Skip" in e for e in errors
+    ), f"expected Skip clause to satisfy lint, got {errors}"
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        "Load when X.\nSkip\nwhen Y.",  # YAML literal block scalar (`|`)
+        "Load when X. Skip  when Y.",   # double-space artefact
+        "Load when X.\tSkip\twhen Y.",  # tab whitespace
+    ],
+    ids=["newline-wrapped", "double-space", "tab-separated"],
+)
+def test_description_skip_clause_normalised_whitespace(
+    tmp_path: Path, description: str
+) -> None:
+    """YAML folded / literal scalars and quoted forms can introduce newlines,
+    double spaces, or tabs between 'Skip' and the connective.  The lint
+    must whitespace-normalise before matching."""
+    skill = _write_v2_skill(tmp_path / "demo", description=description)
+    errors = skill_lint.lint_skill(skill)
+    assert not any(
+        "description" in e and "Skip" in e for e in errors
+    ), f"expected normalised Skip clause to satisfy lint, got {errors}"
+
+
+def test_description_skip_without_connective_rejected(tmp_path: Path) -> None:
+    """A bare 'Skip' (no when/if/for) carries no routing semantics — the
+    connective is what tells the agent which neighbour to bounce to.
+    Locks in that 'Skip otherwise.' / 'Skip in production.' do NOT satisfy
+    the rule, so a future contributor relaxing the substring to plain 'skip '
+    would see this test fail."""
+    skill = _write_v2_skill(
+        tmp_path / "demo",
+        description="Load when X. Skip otherwise.",
+    )
+    errors = skill_lint.lint_skill(skill)
+    assert any(
+        "description" in e and "Skip" in e for e in errors
+    ), f"expected bare Skip to be rejected, got {errors}"
 
 
 def test_missing_required_section_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR-eval (the first of 8 PRs in the Skill v2 rework continuation). Codifies
the routing-trigger half of the description contract that PR #1-#4 adopted
by convention: every v2 SKILL.md `description` must contain a `Skip when` /
`Skip if` / `Skip for` clause that names which neighbour skill the agent
should bounce to.

Without this clause, "Load when …" alone is half a routing trigger — the
agent learns when to load but not when to defer. PR #4 reviewer flagged
several near-collisions (sc-de vs bulkrna-de vs spatial-de) that the
`Skip when …` clause exists to prevent. This lint gates the next 74
migrations from drifting back into summary-style descriptions.

## What changed

- `scripts/skill_lint.py:67-89` — extended `_check_description` to require
  one of `("skip when", "skip if", "skip for")` after whitespace
  normalisation. The normalisation step matters because YAML folded
  (`>-`) / literal (`|`) scalars — used by 14 of 16 existing v2
  descriptions — can wrap "Skip when" across lines or introduce double
  spaces / tabs that bare substring matching would miss.
- `tests/test_skill_lint.py` — 4 new tests: 1 negative (no Skip clause),
  1 parametrised positive (each of the 3 variants), 1 parametrised
  whitespace-robustness fixture (newline / double-space / tab), 1 negative
  for "Skip otherwise" (bare Skip without connective → rejected).

## Backward compatibility

All 15 already-migrated v2 skills (bulkrna 13 + sc-de + spatial-de)
already follow the convention; `python scripts/skill_lint.py --all`
returns 90 ok / 0 fail unchanged. No retroactive description changes.

## Quality gate

One round of independent code-reviewer-agent review. Round 1 caught the
YAML folded-scalar whitespace risk (Important) which would have silently
let descriptions like `"Skip\nwhen"` slip through; the `.split()/join()`
normalisation in `scripts/skill_lint.py:75` is the round-1 fix.
No Critical findings.

## Test plan

- [x] `pytest tests/test_skill_lint.py` → 20 passed (was 16; +4 new)
- [x] broad sweep across 10 framework test files → 124 passed (was 120; +4 new)
- [x] `python scripts/skill_lint.py --all` → 90 ok / 0 fail
- [x] commit message + PR body verified Claude-trailer-free

## Diff scope

2 files changed, +83/-2 — purely the lint rule + its tests.
