### PR TITLE
refactor(memory): route MemoryClient.forget through MemoryEngine

### DIFF
--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -15,6 +15,7 @@ Write verbs (PR #3a):
     - upsert(uri, content, namespace, ...)
     - upsert_versioned(uri, content, namespace, ...)
     - patch_edge_metadata(uri, namespace, ...)
+    - delete(uri, namespace)                  — subtree cascade with orphan prevention
 
 Read verbs (PR #3b):
     - recall(uri, namespace, ...)             — single-row fetch with shared fallback
@@ -35,17 +36,19 @@ import uuid as uuidlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, not_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import (
     ROOT_NODE_UUID,
     SHARED_NAMESPACE,
+    ChangeCollector,
     Edge,
     Memory,
     Node,
     Path,
     escape_like_literal,
+    serialize_row,
 )
 from .uri import MemoryURI
 
@@ -457,6 +460,304 @@ class MemoryEngine:
             edge.disclosure = disclosure
 
         return old_id, new_memory.id, node_uuid
+
+    async def delete(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+    ) -> dict:
+        """Delete a path and its namespace-scoped subtree.
+
+        Soft-delete semantics: Memory rows on the deleted node are
+        marked ``deprecated=True`` rather than physically removed, so
+        the review pane can roll the version chain back. Path / Edge /
+        Node structural rows are physically deleted.
+
+        Pre-flight orphan check: if removing this prefix would leave a
+        child node with no remaining incoming Path in any namespace,
+        the call raises ``ValueError`` instead of creating an
+        unreachable subgraph. The caller can re-route the child first
+        and retry.
+
+        Strict-namespace: only Path rows in ``namespace`` are touched.
+        ``MemoryClient(namespace="A").forget(uri)`` cannot reach
+        namespace ``"B"``.
+
+        Returns ``{"rows_before": <ChangeCollector dict>, "rows_after": {}}``
+        — same audit shape as the legacy ``GraphService.remove_path``
+        so ``snapshot.get_changeset_store().record_many(...)`` keeps
+        working unchanged for the desktop review pane.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        if parsed.is_root or not parsed.path:
+            raise ValueError("Cannot delete the root path.")
+
+        async with self._db.session() as s:
+            target = await self._delete_resolve_target(s, parsed, namespace)
+            if target is None:
+                raise ValueError(f"Path '{parsed}' not found")
+            target_edge, target_node_uuid = target
+
+            await self._delete_check_orphans(s, target_node_uuid, parsed)
+
+            # Pre-collect node UUIDs whose search docs need rebuilding
+            # AFTER the deletes complete. Done before mutation so the
+            # query sees the pre-deletion structure. Cross-namespace by
+            # design — search docs reflect current DB state regardless
+            # of which namespace's Path was just removed.
+            affected_nodes = await self._search.get_node_uuids_for_prefix(
+                s, parsed.domain, parsed.path
+            )
+
+            collector = ChangeCollector()
+            await self._delete_subtree_paths(s, parsed, namespace, collector)
+            await s.flush()
+
+            await self._delete_gc_edge_if_pathless(s, target_edge, collector)
+            await self._delete_gc_node_soft(
+                s, target_node_uuid, namespace, collector
+            )
+
+            for node_uuid in affected_nodes:
+                await self._search.refresh_search_documents_for_node(
+                    node_uuid, session=s
+                )
+
+        return {"rows_before": collector.to_dict(), "rows_after": {}}
+
+    @staticmethod
+    async def _delete_resolve_target(
+        s: AsyncSession, parsed: MemoryURI, namespace: str
+    ) -> Optional[tuple[Edge, str]]:
+        """Find the Edge + child_uuid for ``(namespace, parsed)``."""
+        row = (
+            await s.execute(
+                select(Path, Edge)
+                .join(Edge, Path.edge_id == Edge.id)
+                .where(
+                    Path.namespace == namespace,
+                    Path.domain == parsed.domain,
+                    Path.path == parsed.path,
+                )
+            )
+        ).first()
+        if row is None:
+            return None
+        _, edge = row
+        return edge, edge.child_uuid
+
+    async def _delete_check_orphans(
+        self, s: AsyncSession, target_node_uuid: str, parsed: MemoryURI
+    ) -> None:
+        """Refuse the delete if any direct child would lose its only
+        incoming Path. Raises ``ValueError`` listing the would-orphan
+        children so the caller can re-route them first.
+        """
+        child_edges = (
+            await s.execute(
+                select(Edge).where(Edge.parent_uuid == target_node_uuid)
+            )
+        ).scalars().all()
+
+        would_orphan: list[Edge] = []
+        for child_edge in child_edges:
+            surviving = await self._delete_count_incoming_paths(
+                s,
+                child_edge.child_uuid,
+                exclude_domain=parsed.domain,
+                exclude_path_prefix=parsed.path,
+            )
+            if surviving == 0:
+                would_orphan.append(child_edge)
+
+        if would_orphan:
+            details = ", ".join(
+                f"'{e.name}' (node: {e.child_uuid[:8]}...)"
+                for e in would_orphan
+            )
+            raise ValueError(
+                f"Cannot remove '{parsed}': the following child node(s) "
+                f"would become unreachable: {details}. Create alternative "
+                f"paths for these children first, or remove them explicitly."
+            )
+
+    @staticmethod
+    async def _delete_count_incoming_paths(
+        s: AsyncSession,
+        node_uuid: str,
+        *,
+        exclude_domain: str,
+        exclude_path_prefix: str,
+    ) -> int:
+        """Count Paths whose Edge points TO ``node_uuid``, excluding
+        Paths under the soon-to-be-deleted prefix (so the orphan
+        precheck asks "would this child still have any path AFTER the
+        delete completes")."""
+        safe_prefix = escape_like_literal(exclude_path_prefix)
+        stmt = (
+            select(func.count())
+            .select_from(Path)
+            .join(Edge, Path.edge_id == Edge.id)
+            .where(Edge.child_uuid == node_uuid)
+            .where(
+                not_(
+                    and_(
+                        Path.domain == exclude_domain,
+                        Path.path.like(f"{safe_prefix}/%", escape="\\"),
+                    )
+                )
+            )
+        )
+        return (await s.execute(stmt)).scalar() or 0
+
+    @staticmethod
+    async def _delete_subtree_paths(
+        s: AsyncSession,
+        parsed: MemoryURI,
+        namespace: str,
+        collector: ChangeCollector,
+    ) -> None:
+        """Delete every Path in ``namespace`` whose ``(domain, path)``
+        matches the prefix or sits under it.
+
+        Captures each row into the collector before deleting so the
+        audit/changeset UI can reconstruct what was removed.
+        """
+        safe = escape_like_literal(parsed.path)
+        stmt = (
+            select(Path)
+            .where(Path.namespace == namespace)
+            .where(Path.domain == parsed.domain)
+            .where(
+                or_(
+                    Path.path == parsed.path,
+                    Path.path.like(f"{safe}/%", escape="\\"),
+                )
+            )
+        )
+        for p in (await s.execute(stmt)).scalars().all():
+            collector.record("paths", serialize_row(p))
+            await s.delete(p)
+
+    @staticmethod
+    async def _delete_gc_edge_if_pathless(
+        s: AsyncSession,
+        edge: Edge,
+        collector: ChangeCollector,
+    ) -> None:
+        """Drop ``edge`` if no Path row references it after the subtree
+        delete. Other Paths (aliases) reaching the same edge keep it
+        alive."""
+        remaining = (
+            await s.execute(
+                select(func.count())
+                .select_from(Path)
+                .where(Path.edge_id == edge.id)
+            )
+        ).scalar() or 0
+        if remaining > 0:
+            return
+        collector.record("edges", serialize_row(edge))
+        await s.delete(edge)
+
+    async def _delete_gc_node_soft(
+        self,
+        s: AsyncSession,
+        node_uuid: str,
+        namespace: str,
+        collector: ChangeCollector,
+    ) -> None:
+        """If ``node_uuid`` has no remaining incoming Path (any
+        namespace), deprecate its active memories and cascade-clean
+        edges around it.
+
+        Soft semantics: Memory rows stay (with ``deprecated=True``) so
+        the review pane can roll back. Edges incident to the now-dead
+        node are physically deleted via ``_delete_gc_edge_if_pathless``
+        / ``_delete_cascade_edge``.
+        """
+        still_reachable = (
+            await s.execute(
+                select(func.count())
+                .select_from(Path)
+                .join(Edge, Path.edge_id == Edge.id)
+                .where(Edge.child_uuid == node_uuid)
+            )
+        ).scalar() or 0
+        if still_reachable > 0:
+            return
+
+        # Edges pointing TO this node (parents → us): drop pathless ones.
+        incoming = (
+            await s.execute(
+                select(Edge).where(Edge.child_uuid == node_uuid)
+            )
+        ).scalars().all()
+        for edge in incoming:
+            await self._delete_gc_edge_if_pathless(s, edge, collector)
+
+        # Edges pointing FROM this node (us → children): cascade-clean
+        # the path forest under each. The orphan precheck guarantees
+        # children survive through some other path; this just tidies
+        # the namespace-scoped path rows we own here.
+        outgoing = (
+            await s.execute(
+                select(Edge).where(Edge.parent_uuid == node_uuid)
+            )
+        ).scalars().all()
+        for edge in outgoing:
+            await self._delete_cascade_edge(s, edge, namespace, collector)
+
+        # Snapshot active memories before deprecation so the audit log
+        # can reconstruct what the user "forgot".
+        active = (
+            await s.execute(
+                select(Memory).where(
+                    Memory.node_uuid == node_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+            )
+        ).scalars().all()
+        for m in active:
+            collector.record("memories", serialize_row(m))
+
+        if active:
+            await s.execute(
+                update(Memory)
+                .where(
+                    Memory.node_uuid == node_uuid,
+                    Memory.deprecated == False,  # noqa: E712
+                )
+                .values(deprecated=True)
+            )
+
+    async def _delete_cascade_edge(
+        self,
+        s: AsyncSession,
+        edge: Edge,
+        namespace: str,
+        collector: ChangeCollector,
+    ) -> None:
+        """Strip ``namespace``-scoped Paths off ``edge`` and drop the
+        edge itself when it falls pathless.
+
+        Only acts inside ``namespace`` so an outgoing-edge cascade from
+        a soft-GCed node cannot stray into another user's partition.
+        """
+        for p in (
+            await s.execute(
+                select(Path).where(
+                    Path.edge_id == edge.id,
+                    Path.namespace == namespace,
+                )
+            )
+        ).scalars().all():
+            collector.record("paths", serialize_row(p))
+            await s.delete(p)
+
+        await s.flush()
+        await self._delete_gc_edge_if_pathless(s, edge, collector)
 
     async def patch_edge_metadata(
         self,

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -364,11 +364,9 @@ class MemoryClient:
         return "\n\n".join(parts) if parts else ""
 
     # ------------------------------------------------------------------
-    # forget still routes through the legacy GraphService for the
-    # subtree-cascade + orphan-prevention semantics that the engine
-    # delete verb does not yet replicate. (Next PR in the §6.2
-    # GraphService retirement walks the cascade logic into ReviewLog
-    # so this last call site can come off graph.py too.)
+    # forget — engine-routed since slice 2 of §6.2 GraphService
+    # retirement; subtree cascade with orphan prevention and soft-
+    # deprecate of the affected memories lives in MemoryEngine.delete.
     # ------------------------------------------------------------------
 
     async def get_recent(self, limit: int = 10) -> List[Dict[str, Any]]:
@@ -397,20 +395,16 @@ class MemoryClient:
         (``MemoryClient(namespace="A").forget("dataset://x")`` cannot
         reach namespace ``B``).
 
-        Delegates to ``GraphService.remove_path`` (the engine does not
-        yet expose a delete verb — that lands in PR #4b
-        ``ReviewLog.cascade_delete``).
+        Delegates to ``MemoryEngine.delete``: subtree cascade with
+        orphan prevention and soft-deprecate of the affected memories
+        (review pane can roll back).
         """
         await self._ensure_init()
-        from .graph import GraphService
 
         parsed = MemoryURI.parse(uri)
         target_ns = resolve_namespace(parsed, current=self._namespace)
         assert self._engine is not None
-        graph = GraphService(self._engine.db, self._engine.search_indexer)
-        result = await graph.remove_path(
-            path=parsed.path, domain=parsed.domain, namespace=target_ns
-        )
+        result = await self._engine.delete(parsed, namespace=target_ns)
 
         try:
             from .snapshot import get_changeset_store

--- a/tests/memory/test_engine_delete.py
+++ b/tests/memory/test_engine_delete.py
@@ -1,0 +1,191 @@
+"""Tests for ``MemoryEngine.delete`` — the engine-level cascade delete
+verb that replaces ``GraphService.remove_path`` for ``MemoryClient.forget``.
+
+Contract pinned by these tests:
+
+  * Single-path delete removes the target Path and prunes the orphan
+    edge + node (soft delete: memories stay as deprecated rows).
+  * Subtree delete removes the prefix's whole namespace-scoped subtree.
+  * Orphan check refuses deletion when a child node would lose its only
+    incoming Path (would become unreachable in any namespace).
+  * Strict-namespace: ``delete(uri, namespace="A")`` cannot touch
+    namespace ``"B"`` rows even when the URI matches.
+  * Memories on the deleted node are *deprecated*, not physically
+    removed — review pane can later roll back via ``ReviewLog``.
+  * Missing path raises ``ValueError`` (mirrors legacy contract).
+  * Return shape ``{"rows_before": {...}, "rows_after": {}}`` for the
+    audit/changeset UI.
+
+Slice 2 of §6.2 GraphService retirement.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.memory_client import MemoryClient
+from omicsclaw.memory.models import Memory, Path
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    engine = MemoryEngine(db, search)
+    yield engine, db
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_single_path(env):
+    """A single-leaf delete removes the target Path row in the namespace."""
+    engine, db = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("dataset://x.h5ad", "x")
+
+    result = await engine.delete("dataset://x.h5ad", namespace="tg/A")
+
+    assert result["rows_after"] == {}
+    record = await engine.recall(
+        "dataset://x.h5ad", namespace="tg/A", fallback_to_shared=False
+    )
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_delete_refuses_when_children_would_orphan(env):
+    """Removing a parent whose children only have Paths under the same
+    prefix is refused — the orphan precheck protects the user from
+    silently losing reachability into a subtree.
+
+    Mirrors ``GraphService.remove_path``'s behaviour: callers must
+    delete bottom-up (or attach an alias to the children first) to
+    take down a parent. This is intentionally conservative — the
+    only forget call sites in production are leaf URIs, so this case
+    is the safety net for the rare misuse, not the common path.
+    """
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("analysis://run", "parent")
+    await a.remember("analysis://run/step1", "child 1")
+    await a.remember("analysis://run/step2", "child 2")
+
+    with pytest.raises(ValueError, match="unreachable"):
+        await engine.delete("analysis://run", namespace="tg/A")
+
+    # Parent and children must all survive the rejected delete.
+    for uri in (
+        "analysis://run",
+        "analysis://run/step1",
+        "analysis://run/step2",
+    ):
+        record = await engine.recall(
+            uri, namespace="tg/A", fallback_to_shared=False
+        )
+        assert record is not None, (
+            f"{uri} was destroyed despite the orphan check raising"
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_strict_namespace(env):
+    """delete(uri, namespace='A') must not touch namespace 'B'."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    b = MemoryClient(engine=engine, namespace="tg/B")
+    await a.remember("dataset://shared.h5ad", "A")
+    await b.remember("dataset://shared.h5ad", "B")
+
+    await engine.delete("dataset://shared.h5ad", namespace="tg/A")
+
+    rec_a = await engine.recall(
+        "dataset://shared.h5ad", namespace="tg/A", fallback_to_shared=False
+    )
+    rec_b = await engine.recall(
+        "dataset://shared.h5ad", namespace="tg/B", fallback_to_shared=False
+    )
+    assert rec_a is None, "A's row survived its own delete"
+    assert rec_b is not None, "delete leaked into namespace B"
+    assert rec_b.content == "B"
+
+
+@pytest.mark.asyncio
+async def test_delete_soft_deprecates_memories(env):
+    """Memories on the deleted node must be marked deprecated, not
+    physically removed — the review pane can roll the version chain
+    back if the user changes their mind.
+    """
+    engine, db = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("core://my_user/note", "v1")
+    await a.remember("core://my_user/note", "v2")
+
+    # Capture the node_uuid before delete via an engine recall.
+    record_before = await engine.recall(
+        "core://my_user/note", namespace="tg/A", fallback_to_shared=False
+    )
+    assert record_before is not None
+    node_uuid = record_before.node_uuid
+
+    await engine.delete("core://my_user/note", namespace="tg/A")
+
+    # The Path is gone but the Memory rows still exist (deprecated).
+    async with db.session() as s:
+        memories = (
+            await s.execute(
+                sa.select(Memory).where(Memory.node_uuid == node_uuid)
+            )
+        ).scalars().all()
+    assert len(memories) >= 1, (
+        "soft-delete contract broken: all memory rows for the node were "
+        "physically removed; review-pane rollback impossible"
+    )
+    assert all(m.deprecated for m in memories), (
+        "soft-delete should mark memories deprecated, not leave any active"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_missing_path(env):
+    """ValueError mirrors GraphService.remove_path's contract — callers
+    (forget) rely on it for "URI not found" UX."""
+    engine, _ = env
+    with pytest.raises(ValueError, match="not found"):
+        await engine.delete("dataset://nonexistent.h5ad", namespace="tg/A")
+
+
+@pytest.mark.asyncio
+async def test_delete_raises_on_root_path(env):
+    """Root-path deletion is structurally meaningless — refuse it."""
+    engine, _ = env
+    with pytest.raises(ValueError, match="root"):
+        await engine.delete("core://", namespace="tg/A")
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_audit_dict(env):
+    """Return shape ``{rows_before: {...}, rows_after: {}}`` so
+    MemoryClient.forget can pipe into ``snapshot.get_changeset_store``
+    without code change."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("dataset://x.h5ad", "x")
+
+    result = await engine.delete("dataset://x.h5ad", namespace="tg/A")
+
+    assert "rows_before" in result
+    assert "rows_after" in result
+    assert result["rows_after"] == {}
+    rows_before = result["rows_before"]
+    # ChangeCollector buckets — paths must be populated.
+    assert "paths" in rows_before
+    assert any(
+        p.get("domain") == "dataset" and p.get("path") == "x.h5ad"
+        for p in rows_before["paths"]
+    ), f"expected the deleted path in rows_before.paths, got {rows_before}"


### PR DESCRIPTION
## Summary

Slice 2 of the §6.2 GraphService retirement. Adds `MemoryEngine.delete` and switches `MemoryClient.forget` off `GraphService.remove_path`. After this and slice 1 (PR #143), the only `MemoryClient` method still on the legacy `GraphService` is gone — only the four desktop server endpoints remain (slice 3).

- `MemoryEngine.delete(uri, *, namespace) -> dict` — subtree cascade with orphan prevention.
- Soft semantics preserved: Memory rows on the deleted node are marked `deprecated=True`, not physically removed, so the review pane and `ReviewLog.rollback_to` can resurrect them.
- Audit shape `{rows_before, rows_after}` is byte-equivalent, so `MemoryClient.forget`'s `snapshot.get_changeset_store().record_many(...)` call keeps working unchanged.
- One strictness improvement: the new `_delete_cascade_edge` helper is namespace-required (the legacy variant accepted `namespace=None` for admin tooling). Defense-in-depth — `engine.delete`'s only call site always forwards a namespace.

## Why slice this small

`graph.remove_path` is genuinely the most complex GraphService method: subtree path delete, orphan precheck, edge GC, soft node GC, search refresh, audit collector. Replicating it in the engine is ~250 LOC of careful porting; mixing this with the simpler `get_recent` swap (slice 1) or the rich UI dict shapes of the server endpoints (slice 3) would have been a bigger PR for no review benefit.

## Tests

7 new TDD tests in \`tests/memory/test_engine_delete.py\`:
- \`test_delete_removes_single_path\`
- \`test_delete_refuses_when_children_would_orphan\`
- \`test_delete_strict_namespace\`
- \`test_delete_soft_deprecates_memories\` — verifies Memory rows survive as deprecated
- \`test_delete_raises_on_missing_path\`
- \`test_delete_raises_on_root_path\`
- \`test_delete_returns_audit_dict\`

Existing namespace-isolation forget tests (`test_forget_does_not_delete_other_namespace_path`, `test_forget_routes_shared_prefix_uris_to_shared`) continue to pass with `engine.delete` underneath — they were always written against the surface contract, not the GraphService implementation path.

Memory regression suite: **301 passed**, zero regressions.

## Stacking

This PR branches from \`main\`, not from PR #143, but they touch independent regions of \`engine.py\` (`get_recent` is appended after `get_subtree`; `delete` is inserted near the other write verbs). Merge order doesn't matter; the import line in `engine.py` will need a trivial conflict resolution if both are merged.

## Test plan

- [x] 7 RED → GREEN tests for engine.delete
- [x] Memory regression suite: 301 passed
- [x] 5-axis code review — no blockers, atomicity verified, faithful contract reproduction confirmed
- [ ] Reviewer to confirm: orphan-check semantics match expectation (refuses parent delete if children only have under-prefix Paths — same as legacy)