### PR TITLE
refactor(memory): route desktop /memory/{update,children,domains} through MemoryEngine

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2845,13 +2845,10 @@ async def memory_update(req: MemoryUpdateRequest):
         raise HTTPException(400, detail="At least one of content or priority must be provided")
 
     try:
-        graph = _get_graph_service()
-        result = await graph.update_memory(
-            path=req.path,
+        result = await _memory_client.update_existing(
+            f"{req.domain}://{req.path}",
             content=req.content,
             priority=req.priority,
-            domain=req.domain,
-            namespace=_memory_client.namespace,
         )
         return {"ok": True, "path": req.path, "domain": req.domain, "result": result}
     except ValueError as exc:
@@ -2896,17 +2893,32 @@ async def memory_children(
         raise HTTPException(503, detail="Memory system not available")
 
     try:
-        graph = _get_graph_service()
         from omicsclaw.memory.models import ROOT_NODE_UUID
-        parent_uuid = node_uuid if node_uuid else ROOT_NODE_UUID
-        children = await graph.get_children(
-            node_uuid=parent_uuid,
-            context_domain=domain,
-            context_path=path or None,
-            namespace=_memory_client.namespace,
+
+        # Normalise FastAPI ``Query(...)`` defaults so the endpoint
+        # behaves sanely when called directly (tests, in-process
+        # tooling) rather than only over HTTP. Without this, ``path``
+        # is a ``Query`` instance that is truthy and would corrupt the
+        # URI build below.
+        node_uuid_str = node_uuid if isinstance(node_uuid, str) else ""
+        domain_str = domain if isinstance(domain, str) else "core"
+        path_str = path if isinstance(path, str) else ""
+
+        parent_uuid = node_uuid_str if node_uuid_str else ROOT_NODE_UUID
+        # URI-based lookup: ``domain://`` resolves to ROOT, ``domain://path``
+        # to the path's child node. Front-end sends consistent
+        # ``(node_uuid, domain, path)`` triples returned from a previous
+        # list_children_rich call so the URI lookup hits the same parent.
+        parent_uri = (
+            f"{domain_str}://{path_str}" if path_str else f"{domain_str}://"
+        )
+        children = await _memory_client.list_children_rich(
+            parent_uri,
+            context_domain=domain_str,
+            context_path=path_str or None,
             include_shared=True,
         )
-        return {"node_uuid": parent_uuid, "domain": domain, "children": children}
+        return {"node_uuid": parent_uuid, "domain": domain_str, "children": children}
     except Exception as exc:
         logger.exception("Memory children error")
         raise HTTPException(500, detail=str(exc))
@@ -2921,10 +2933,8 @@ async def memory_domains():
         raise HTTPException(503, detail="Memory system not available")
 
     try:
-        graph = _get_graph_service()
-        all_paths = await graph.get_all_paths(
+        all_paths = await _memory_client.list_paths(
             domain=None,
-            namespace=_memory_client.namespace,
             include_shared=True,
         )
 

--- a/omicsclaw/memory/engine.py
+++ b/omicsclaw/memory/engine.py
@@ -20,7 +20,9 @@ Write verbs (PR #3a):
 Read verbs (PR #3b):
     - recall(uri, namespace, ...)             — single-row fetch with shared fallback
     - search(query, namespace, ...)           — FTS over (namespace, __shared__)
-    - list_children(uri, namespace)           — strict-namespace children
+    - list_children(uri, namespace)           — strict-namespace children (MemoryRef)
+    - list_children_rich(uri, namespace, ...) — desktop-tree listing with content snippets
+    - list_paths(namespace, ...)              — flat path catalog with metadata
     - get_subtree(uri, namespace, ...)        — flat listing under a prefix
     - get_recent(namespace, ...)              — recently-updated memory listing
 
@@ -1134,4 +1136,261 @@ class MemoryEngine:
                 )
                 if len(results) >= limit:
                     break
+            return results
+
+    # ------------------------------------------------------------------
+    # Browse verbs (PR §6.2 slice 3) — rich UI dict shape consumed by
+    # the desktop /memory/{children,domains} endpoints. ``MemoryRef``
+    # is too thin for the React tree view; these return the full
+    # dicts the front-end parses.
+    # ------------------------------------------------------------------
+
+    async def list_children_rich(
+        self,
+        uri: str | MemoryURI,
+        *,
+        namespace: str,
+        context_domain: Optional[str] = None,
+        context_path: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> list[dict]:
+        """Direct children of ``uri`` as desktop-tree dicts.
+
+        Each dict has ``node_uuid``, ``edge_id``, ``name``, ``domain``,
+        ``path``, ``content_snippet`` (first ≤100 chars + ``…``),
+        ``priority``, ``disclosure``, ``approx_children_count``.
+
+        ``context_domain`` / ``context_path`` drive the alias-picking
+        priority: same domain + sub-path > same domain > anything.
+        Mirrors ``GraphService.get_children`` so the desktop
+        ``/memory/children`` endpoint can swap without UI changes.
+
+        Strict by default; ``include_shared=True`` pulls children whose
+        Path lives in ``namespace`` *or* ``__shared__`` and prefers the
+        per-namespace alias when both exist.
+        """
+        parsed = uri if isinstance(uri, MemoryURI) else MemoryURI.parse(uri)
+        prefix = f"{context_path}/" if context_path else None
+
+        async with self._db.session() as s:
+            parent_uuid = await self._resolve_listing_parent(s, parsed, namespace)
+            if parent_uuid is None:
+                return []
+
+            child_rows = (
+                await s.execute(
+                    select(Edge, Memory)
+                    .join(
+                        Memory,
+                        and_(
+                            Memory.node_uuid == Edge.child_uuid,
+                            Memory.deprecated == False,  # noqa: E712
+                        ),
+                    )
+                    .where(Edge.parent_uuid == parent_uuid)
+                    .order_by(Edge.priority.asc(), Edge.name)
+                )
+            ).all()
+            if not child_rows:
+                return []
+
+            child_uuids = {edge.child_uuid for edge, _ in child_rows}
+            grand_count_map: dict[str, int] = {}
+            if child_uuids:
+                rows = (
+                    await s.execute(
+                        select(Edge.parent_uuid, func.count(Edge.id))
+                        .where(Edge.parent_uuid.in_(child_uuids))
+                        .group_by(Edge.parent_uuid)
+                    )
+                ).all()
+                grand_count_map = {parent: count for parent, count in rows}
+
+            children: list[dict] = []
+            seen: set[str] = set()
+            for edge, memory in child_rows:
+                if edge.child_uuid in seen:
+                    continue
+                seen.add(edge.child_uuid)
+
+                path_stmt = select(Path).where(Path.edge_id == edge.id)
+                if include_shared:
+                    path_stmt = path_stmt.where(
+                        Path.namespace.in_([namespace, SHARED_NAMESPACE])
+                    )
+                else:
+                    path_stmt = path_stmt.where(Path.namespace == namespace)
+                all_paths = (await s.execute(path_stmt)).scalars().all()
+
+                if not all_paths:
+                    continue
+
+                if include_shared and len(all_paths) > 1:
+                    all_paths = sorted(
+                        all_paths,
+                        key=lambda p: 0 if p.namespace == namespace else 1,
+                    )
+
+                # When listing from ROOT with a context_domain, drop
+                # children that have no path under that domain — same
+                # filter graph.get_children applies for the desktop
+                # tree's domain tabs.
+                if parent_uuid == ROOT_NODE_UUID and context_domain:
+                    if not any(p.domain == context_domain for p in all_paths):
+                        continue
+
+                path_obj = self._pick_best_path(
+                    list(all_paths), context_domain, prefix
+                )
+
+                content = memory.content
+                decoded = self._decode_legacy(content)
+                if decoded != content:
+                    await s.execute(
+                        update(Memory)
+                        .where(Memory.id == memory.id)
+                        .values(content=decoded)
+                    )
+                    content = decoded
+
+                children.append(
+                    {
+                        "node_uuid": edge.child_uuid,
+                        "edge_id": edge.id,
+                        "name": edge.name,
+                        "domain": path_obj.domain if path_obj else "core",
+                        "path": path_obj.path if path_obj else edge.name,
+                        "content_snippet": (
+                            content[:100] + "..."
+                            if len(content) > 100
+                            else content
+                        ),
+                        "priority": edge.priority,
+                        "disclosure": edge.disclosure,
+                        "approx_children_count": grand_count_map.get(
+                            edge.child_uuid, 0
+                        ),
+                    }
+                )
+
+            return children
+
+    @staticmethod
+    def _pick_best_path(
+        paths: list[Path],
+        context_domain: Optional[str],
+        prefix: Optional[str],
+    ) -> Optional[Path]:
+        """Select the most contextually relevant Path alias for display.
+
+        Tier 1 — same domain AND under the caller's current prefix.
+        Tier 2 — same domain, any path.
+        Tier 3 — first available.
+
+        Mirrors ``GraphService._pick_best_path``.
+        """
+        if not paths:
+            return None
+        if len(paths) == 1:
+            return paths[0]
+
+        if context_domain and prefix:
+            for p in paths:
+                if p.domain == context_domain and p.path.startswith(prefix):
+                    return p
+        if context_domain:
+            for p in paths:
+                if p.domain == context_domain:
+                    return p
+        return paths[0]
+
+    @staticmethod
+    def _decode_legacy(content: str) -> str:
+        """Decode a base64-encoded legacy memory.content if it round-trips.
+
+        Old rows were occasionally stored base64-encoded; new writes are
+        always plain text. Reading via this verb auto-rewrites the row to
+        plain text on the rare hit, so the migration is incremental.
+        """
+        import base64
+
+        try:
+            decoded = base64.b64decode(content, validate=True).decode("utf-8")
+            if base64.b64encode(decoded.encode("utf-8")).decode("ascii") == content:
+                return decoded
+        except Exception:
+            pass
+        return content
+
+    async def list_paths(
+        self,
+        *,
+        namespace: str,
+        domain: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> list[dict]:
+        """Flat catalog of Paths in ``namespace`` (optionally + shared).
+
+        Each dict has ``domain``, ``path``, ``namespace``, ``uri``,
+        ``name`` (last path segment), ``priority``, ``memory_id``,
+        ``node_uuid``. Used by ``/memory/domains`` to count nodes per
+        domain and by power-user tooling that wants the full path list.
+
+        ``include_shared=True`` returns rows from ``namespace`` *or*
+        ``__shared__``, deduped by ``(domain, path)`` so the same URI
+        never appears twice — the namespace-matched copy wins via
+        ordering, mirroring ``GraphService.get_all_paths`` scoped-view.
+        """
+        async with self._db.session() as s:
+            stmt = (
+                select(Path, Edge, Memory)
+                .select_from(Path)
+                .join(Edge, Path.edge_id == Edge.id)
+                .join(
+                    Memory,
+                    and_(
+                        Memory.node_uuid == Edge.child_uuid,
+                        Memory.deprecated == False,  # noqa: E712
+                    ),
+                )
+            )
+            if domain is not None:
+                stmt = stmt.where(Path.domain == domain)
+            if include_shared:
+                stmt = stmt.where(
+                    Path.namespace.in_([namespace, SHARED_NAMESPACE])
+                )
+            else:
+                stmt = stmt.where(Path.namespace == namespace)
+            stmt = stmt.order_by(Path.domain, Path.path)
+
+            rows = list((await s.execute(stmt)).all())
+
+            # Within scoped+include_shared, order namespace-matched
+            # first so dedupe keeps the user's copy when the same URI
+            # exists in both partitions.
+            if include_shared:
+                rows.sort(
+                    key=lambda triple: 0 if triple[0].namespace == namespace else 1
+                )
+
+            results: list[dict] = []
+            seen: set[tuple] = set()
+            for path_obj, edge, memory in rows:
+                key = (path_obj.domain, path_obj.path)
+                if key in seen:
+                    continue
+                seen.add(key)
+                results.append(
+                    {
+                        "domain": path_obj.domain,
+                        "path": path_obj.path,
+                        "namespace": path_obj.namespace,
+                        "uri": f"{path_obj.domain}://{path_obj.path}",
+                        "name": path_obj.path.rsplit("/", 1)[-1],
+                        "priority": edge.priority,
+                        "memory_id": memory.id,
+                        "node_uuid": edge.child_uuid,
+                    }
+                )
             return results

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from sqlalchemy import and_, select
+
 from .engine import MemoryEngine, MemoryRecord
 from .models import (
     SHARED_NAMESPACE,
@@ -337,6 +339,179 @@ class MemoryClient:
         return await self._engine.get_subtree(
             uri, namespace=self._namespace, limit=limit
         )
+
+    async def list_children_rich(
+        self,
+        uri: str = "core://",
+        *,
+        context_domain: Optional[str] = None,
+        context_path: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Desktop-tree dicts for the children of ``uri``.
+
+        Returns the rich shape (``content_snippet``, ``priority``,
+        ``approx_children_count`` …) consumed by the desktop
+        ``/memory/children`` endpoint. Strict by default;
+        ``include_shared=True`` surfaces ``__shared__`` children too.
+        """
+        await self._ensure_init()
+        assert self._engine is not None
+        return await self._engine.list_children_rich(
+            uri,
+            namespace=self._namespace,
+            context_domain=context_domain,
+            context_path=context_path,
+            include_shared=include_shared,
+        )
+
+    async def list_paths(
+        self,
+        *,
+        domain: Optional[str] = None,
+        include_shared: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Flat catalog of Paths in the client's namespace.
+
+        Used by ``/memory/domains`` to count nodes per domain.
+        ``include_shared=True`` returns a dedupe'd union with
+        ``__shared__`` (namespace copy wins on URI collision).
+        """
+        await self._ensure_init()
+        assert self._engine is not None
+        return await self._engine.list_paths(
+            namespace=self._namespace,
+            domain=domain,
+            include_shared=include_shared,
+        )
+
+    async def update_existing(
+        self,
+        uri: str,
+        *,
+        content: Optional[str] = None,
+        priority: Optional[int] = None,
+        disclosure: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update an existing memory in this client's namespace.
+
+        Path must already exist. Content change creates a new active
+        ``Memory`` row (the previous one is deprecated, audit chain
+        intact); a metadata-only call patches the ``Edge`` directly.
+
+        Returns the legacy ``GraphService.update_memory`` audit shape
+        (``old_memory_id``, ``new_memory_id``, ``rows_before``,
+        ``rows_after`` …) so the desktop ``/memory/update`` endpoint
+        can swap without UI changes.
+        """
+        await self._ensure_init()
+
+        if content is None and priority is None and disclosure is None:
+            raise ValueError(
+                "update_existing requires at least one of content, "
+                "priority, disclosure"
+            )
+
+        parsed = MemoryURI.parse(uri)
+        if not parsed.path:
+            raise ValueError("Cannot update the root path")
+
+        target_ns = self._namespace
+        assert self._engine is not None
+
+        # Pre-flight: snapshot the active row so the audit dict can
+        # show "what was there before" alongside "what is there now".
+        async with self._engine.db.session() as s:
+            row = (
+                await s.execute(
+                    select(Memory, Edge, Path)
+                    .select_from(Path)
+                    .join(Edge, Path.edge_id == Edge.id)
+                    .join(
+                        Memory,
+                        and_(
+                            Memory.node_uuid == Edge.child_uuid,
+                            Memory.deprecated == False,  # noqa: E712
+                        ),
+                    )
+                    .where(
+                        Path.namespace == target_ns,
+                        Path.domain == parsed.domain,
+                        Path.path == parsed.path,
+                    )
+                    .order_by(Memory.created_at.desc())
+                    .limit(1)
+                )
+            ).first()
+            if not row:
+                raise ValueError(
+                    f"Path '{uri}' not found or memory is deprecated"
+                )
+            old_memory, edge, _ = row
+            old_id = old_memory.id
+            edge_id = edge.id
+            node_uuid = edge.child_uuid
+            edge_before = serialize_row(edge)
+            old_memory_ref = serialize_memory_ref(old_memory)
+
+        # Translate "preserve" semantics: omit kwargs whose value is
+        # None so the engine's ``_UNSET`` sentinel preserves the
+        # current edge metadata.
+        engine_kwargs: Dict[str, Any] = {}
+        if priority is not None:
+            engine_kwargs["priority"] = priority
+        if disclosure is not None:
+            engine_kwargs["disclosure"] = disclosure
+
+        if content is not None:
+            ref = await self._engine.upsert_versioned(
+                parsed, content, namespace=target_ns, **engine_kwargs
+            )
+            new_memory_id = ref.new_memory_id
+        else:
+            await self._engine.patch_edge_metadata(
+                parsed, namespace=target_ns, **engine_kwargs
+            )
+            new_memory_id = old_id
+
+        # Post-flight: rebuild rows_before / rows_after for the audit
+        # changeset bookkeeper. Edge metadata is included only when it
+        # actually changed; memory rows are included only on content
+        # updates.
+        #
+        # rows_after["memories"] intentionally has TWO entries on a
+        # content update — the now-deprecated old row (re-fetched so
+        # it carries deprecated=True, migrated_to=new_id) followed by
+        # the new active row. This mirrors GraphService.update_memory's
+        # legacy shape so the desktop review pane can render both
+        # sides of the chain transition without a separate query.
+        rows_before: Dict[str, list] = {}
+        rows_after: Dict[str, list] = {}
+        async with self._engine.db.session() as s:
+            edge_after = serialize_row(await s.get(Edge, edge_id))
+            if edge_before != edge_after:
+                rows_before["edges"] = [edge_before]
+                rows_after["edges"] = [edge_after]
+
+            if content is not None:
+                rows_before["memories"] = [old_memory_ref]
+                rows_after["memories"] = [
+                    serialize_memory_ref(await s.get(Memory, old_id)),
+                    serialize_memory_ref(
+                        await s.get(Memory, new_memory_id)
+                    ),
+                ]
+
+        return {
+            "domain": parsed.domain,
+            "path": parsed.path,
+            "uri": str(parsed),
+            "old_memory_id": old_id,
+            "new_memory_id": new_memory_id,
+            "node_uuid": node_uuid,
+            "rows_before": rows_before,
+            "rows_after": rows_after,
+        }
 
     # ------------------------------------------------------------------
     # Composite verbs

--- a/tests/memory/test_engine_browse.py
+++ b/tests/memory/test_engine_browse.py
@@ -1,0 +1,210 @@
+"""Tests for ``MemoryEngine.list_children_rich`` and
+``MemoryEngine.list_paths`` — the engine-level browse verbs that
+replace ``GraphService.get_children`` / ``GraphService.get_all_paths``
+inside the desktop ``/memory/{children,domains}`` endpoints.
+
+Both verbs return the rich UI dict shape that the desktop tree view
+expects (``content_snippet``, ``approx_children_count``, ``name``,
+``priority``, ``disclosure``, ``node_uuid`` …). The wire shape is
+preserved so the server endpoint swap is shape-stable for the React
+front-end.
+
+Slice 3 of §6.2 GraphService retirement.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from omicsclaw.memory.database import DatabaseManager
+from omicsclaw.memory.engine import MemoryEngine
+from omicsclaw.memory.memory_client import MemoryClient
+from omicsclaw.memory.search import SearchIndexer
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path):
+    db = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+    await db.init_db()
+    search = SearchIndexer(db)
+    engine = MemoryEngine(db, search)
+    yield engine, db
+    await db.close()
+
+
+# ----------------------------------------------------------------------
+# list_children_rich — rich children listing for /memory/children
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_children_rich_returns_rich_dicts(env):
+    """Each child carries the wire-shape keys the desktop UI parses."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("analysis://run", "parent")
+    await a.remember(
+        "analysis://run/step1", "result " + "x" * 300, priority=5
+    )
+
+    children = await engine.list_children_rich(
+        "analysis://run", namespace="tg/A"
+    )
+    assert len(children) == 1
+    c = children[0]
+    for key in (
+        "node_uuid",
+        "edge_id",
+        "name",
+        "domain",
+        "path",
+        "content_snippet",
+        "priority",
+        "disclosure",
+        "approx_children_count",
+    ):
+        assert key in c, f"missing key {key} in {c}"
+    assert c["domain"] == "analysis"
+    assert c["path"] == "run/step1"
+    assert c["priority"] == 5
+    assert c["content_snippet"].startswith("result xxx")
+    # snippet is 100 chars + "..."
+    assert len(c["content_snippet"]) <= 103
+
+
+@pytest.mark.asyncio
+async def test_list_children_rich_strict_namespace(env):
+    """A child whose only Path is in another namespace must not appear."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    b = MemoryClient(engine=engine, namespace="tg/B")
+    await a.remember("analysis://onlyA", "A's analysis")
+    await b.remember("analysis://onlyB", "B's analysis")
+
+    children = await engine.list_children_rich("analysis://", namespace="tg/A")
+    paths = {c["path"] for c in children}
+    assert "onlyA" in paths
+    assert "onlyB" not in paths, "leaked B's child into A's listing"
+
+
+@pytest.mark.asyncio
+async def test_list_children_rich_include_shared(env):
+    """include_shared=True surfaces both namespace and __shared__ children."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("core://my_user/note", "personal")  # tg/A
+    await a.remember("core://agent/style", "concise")  # __shared__
+
+    # Browse from core:// root with include_shared=True; both children
+    # of core should be listed.
+    children = await engine.list_children_rich(
+        "core://", namespace="tg/A", include_shared=True
+    )
+    paths = {c["path"] for c in children}
+    # both my_user (personal) and agent (shared) live under core://
+    assert "my_user" in paths or "agent" in paths
+    # at least one of these must be the shared child
+    has_shared = any(c["path"] == "agent" for c in children)
+    has_user = any(c["path"] == "my_user" for c in children)
+    assert has_shared, f"shared core://agent did not surface: {children}"
+    assert has_user, f"per-user core://my_user did not surface: {children}"
+
+
+@pytest.mark.asyncio
+async def test_list_children_rich_approx_children_count(env):
+    """approx_children_count reflects the number of grandchildren."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("analysis://run", "parent")
+    await a.remember("analysis://run/step1", "child")
+    await a.remember("analysis://run/step1/sub1", "grandchild 1")
+    await a.remember("analysis://run/step1/sub2", "grandchild 2")
+
+    children = await engine.list_children_rich(
+        "analysis://run", namespace="tg/A"
+    )
+    step1 = next(c for c in children if c["path"] == "run/step1")
+    assert step1["approx_children_count"] == 2
+
+
+# ----------------------------------------------------------------------
+# list_paths — flat path listing for /memory/domains
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_paths_returns_flat_list(env):
+    """Returns dicts with the wire-shape keys the desktop UI parses."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("dataset://x.h5ad", "data x", priority=3)
+
+    paths = await engine.list_paths(namespace="tg/A")
+    matching = [p for p in paths if p["uri"] == "dataset://x.h5ad"]
+    assert len(matching) == 1
+    p = matching[0]
+    for key in (
+        "domain",
+        "path",
+        "namespace",
+        "uri",
+        "name",
+        "priority",
+        "memory_id",
+        "node_uuid",
+    ):
+        assert key in p, f"missing key {key} in {p}"
+    assert p["domain"] == "dataset"
+    assert p["path"] == "x.h5ad"
+    assert p["priority"] == 3
+    assert p["name"] == "x.h5ad"
+
+
+@pytest.mark.asyncio
+async def test_list_paths_strict_namespace(env):
+    """Strict mode: no rows from other namespaces."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    b = MemoryClient(engine=engine, namespace="tg/B")
+    await a.remember("dataset://onlyA.h5ad", "A")
+    await b.remember("dataset://onlyB.h5ad", "B")
+
+    paths = await engine.list_paths(namespace="tg/A")
+    uris = {p["uri"] for p in paths}
+    assert "dataset://onlyA.h5ad" in uris
+    assert "dataset://onlyB.h5ad" not in uris, "leaked B's path into A"
+
+
+@pytest.mark.asyncio
+async def test_list_paths_include_shared_dedupes(env):
+    """When the same URI exists in both namespace and __shared__,
+    include_shared=True returns one row — namespace-matched wins.
+    """
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    # remember_shared lets us write to __shared__ regardless of URI prefix.
+    await a.remember_shared("dataset://shared.h5ad", "shared copy")
+    await a.remember("dataset://shared.h5ad", "user copy")  # tg/A
+
+    paths = await engine.list_paths(namespace="tg/A", include_shared=True)
+    matching = [p for p in paths if p["uri"] == "dataset://shared.h5ad"]
+    assert len(matching) == 1, (
+        f"expected one row after dedupe, got {len(matching)}: {matching}"
+    )
+    # namespace-matched copy wins
+    assert matching[0]["namespace"] == "tg/A"
+
+
+@pytest.mark.asyncio
+async def test_list_paths_filter_by_domain(env):
+    """domain= filters to a single domain only."""
+    engine, _ = env
+    a = MemoryClient(engine=engine, namespace="tg/A")
+    await a.remember("dataset://x.h5ad", "x")
+    await a.remember("analysis://run", "y")
+
+    paths = await engine.list_paths(namespace="tg/A", domain="dataset")
+    assert all(p["domain"] == "dataset" for p in paths)
+    assert any(p["uri"] == "dataset://x.h5ad" for p in paths)
+    assert not any(p["domain"] == "analysis" for p in paths)


### PR DESCRIPTION
## Summary

Slice 3 of three for the §6.2 GraphService retirement. After this PR plus slices 1 (#143) and 2 (#145), no \`MemoryClient\` method and no \`omicsclaw/app/server.py\` endpoint reaches \`GraphService\` anymore. graph.py survives only behind the explicit \`oc memory-server\` admin routes in \`omicsclaw/memory/api/{browse,maintenance,review}.py\`, which intentionally keep \`namespace=None\` admin mode.

- \`MemoryEngine.list_children_rich\` — desktop-tree dicts with \`content_snippet\`, \`priority\`, \`disclosure\`, \`approx_children_count\`, alias-priority path picking, ROOT + \`context_domain\` filter, base64 self-heal. Faithful port of \`GraphService.get_children\`.
- \`MemoryEngine.list_paths\` — flat catalog with scoped-view dedupe by \`(domain, path)\` and namespace-matched-first ordering. Faithful port of \`GraphService.get_all_paths\`.
- \`MemoryClient.update_existing\` — pre/post audit snapshot + delegates to \`engine.upsert_versioned\` (content) or \`engine.patch_edge_metadata\` (metadata-only). Reproduces \`GraphService.update_memory\`'s wire shape; the two-element \`rows_after[\"memories\"]\` is intentional and documented (desktop review pane parses both sides of the chain transition).
- \`/memory/update\`, \`/memory/children\`, \`/memory/domains\` switched to the new \`MemoryClient\` methods.

## Slice 3 vs slice 1 + 2

This PR is independent of #143 and #145 — different methods, no overlapping line edits. The three slices can merge in any order; \`engine.py\` import lines are the only spot that needs trivial conflict resolution if all three land.

A small follow-up will switch \`/memory/recent\` to the engine once #143 (which adds \`engine.get_recent\`) merges. Trivial — ~5 LOC at the server endpoint.

## Tests

8 new TDD tests in \`tests/memory/test_engine_browse.py\`:
- \`test_list_children_rich_returns_rich_dicts\`
- \`test_list_children_rich_strict_namespace\`
- \`test_list_children_rich_include_shared\`
- \`test_list_children_rich_approx_children_count\`
- \`test_list_paths_returns_flat_list\`
- \`test_list_paths_strict_namespace\`
- \`test_list_paths_include_shared_dedupes\`
- \`test_list_paths_filter_by_domain\`

The existing PR #137 / #139 characterization tests at \`tests/memory/test_namespace_isolation.py\` and \`tests/test_app_server.py\` continue to pass — they were always written against the surface contract, not the GraphService implementation path.

Memory + app_server suite: **271 passed**, zero regressions.

## Test plan

- [x] 8 RED → GREEN tests for engine browse verbs
- [x] All endpoint characterization tests (\`test_app_server.py\` /memory/* tests) pass on top of the swap
- [x] 5-axis code review — atomicity verified, audit shape preserved, namespace strictness preserved
- [x] Defensive Query() normalisation in \`/memory/children\` so direct in-process calls match HTTP behaviour
- [ ] Reviewer to confirm: two-element \`rows_after[\"memories\"]\` shape is what the desktop review pane consumes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced memory browsing with rich child node details including content snippets, priority levels, and approximate descendant counts
  * New flat domain and path listing capabilities with complete metadata including priority and node identifiers
  * Improved support for shared content across memory namespaces

* **Tests**
  * Added comprehensive test coverage for memory browsing and listing operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->