### PR TITLE
refactor(memory): route /memory/recent through MemoryEngine

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2578,15 +2578,6 @@ def _get_review_log():
         raise HTTPException(503, detail=f"Memory system unavailable: {exc}")
 
 
-def _get_graph_service():
-    """Return GraphService, raising 503 if the memory module is not available."""
-    try:
-        from omicsclaw.memory import get_graph_service
-        return get_graph_service()
-    except Exception as exc:
-        raise HTTPException(503, detail=f"Memory graph service unavailable: {exc}")
-
-
 def _get_glossary_service():
     """Return GlossaryService, raising 503 if the memory module is not available."""
     try:
@@ -2965,16 +2956,12 @@ async def memory_recent(
         raise HTTPException(503, detail="Memory system not available")
 
     try:
-        # Desktop UI mode: route through GraphService directly with
-        # include_shared=True so user-customized core://agent/* rows
-        # surface alongside per-namespace rows. The strict
-        # MemoryClient.get_recent is reserved for multi-tenant bot
-        # surfaces where shared bleed-through would be wrong.
-        graph = _get_graph_service()
-        results = await graph.get_recent_memories(
-            limit=limit,
-            namespace=_memory_client.namespace,
-            include_shared=True,
+        # Desktop UI mode: include_shared=True surfaces user-customised
+        # core://agent/* alongside per-namespace rows. Multi-tenant bot
+        # surfaces use the default (strict) so one user's shared writes
+        # don't bleed into another's view.
+        results = await _memory_client.get_recent(
+            limit=limit, include_shared=True
         )
         return {"results": results, "count": len(results)}
     except Exception as exc:

--- a/omicsclaw/memory/memory_client.py
+++ b/omicsclaw/memory/memory_client.py
@@ -544,17 +544,31 @@ class MemoryClient:
     # deprecate of the affected memories lives in MemoryEngine.delete.
     # ------------------------------------------------------------------
 
-    async def get_recent(self, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_recent(
+        self,
+        limit: int = 10,
+        *,
+        include_shared: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Return recently updated memories scoped to the client's namespace.
 
-        Strict — no shared fallback, by the same rule as
+        Strict by default — no shared fallback, by the same rule as
         ``MemoryEngine.list_children`` (recent listings should not bleed
         ``__shared__`` system rows into a per-user view).
+
+        ``include_shared=True`` is the desktop UI mode: returns rows in
+        the client's namespace *or* ``__shared__`` so user-customised
+        ``core://agent/*`` surfaces alongside per-user rows. Reserved
+        for single-tenant surfaces — multi-tenant bot surfaces should
+        keep the default to avoid leaking shared writes from one user
+        into another's view.
         """
         await self._ensure_init()
         assert self._engine is not None
         return await self._engine.get_recent(
-            namespace=self._namespace, limit=limit
+            namespace=self._namespace,
+            limit=limit,
+            include_shared=include_shared,
         )
 
     async def forget(self, uri: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Trivial follow-up that closes the §6.2 GraphService retirement. After slices 1 (#143), 2 (#145), 3 (#146), \`/memory/recent\` was the last GraphService caller in \`omicsclaw/app/server.py\`. This PR:

- Adds an \`include_shared\` kwarg to \`MemoryClient.get_recent\` (default \`False\` — backward-compatible with the 2 existing callers).
- Switches \`/memory/recent\` to call \`_memory_client.get_recent(limit=limit, include_shared=True)\`.
- Drops the now-dead \`_get_graph_service\` helper from \`server.py\`.

After merge, no production code in \`MemoryClient\` or \`omicsclaw/app/server.py\` touches \`GraphService\`. \`graph.py\` survives only behind the explicit \`oc memory-server\` admin routes in \`omicsclaw/memory/api/{browse,maintenance,review}.py\`, which intentionally keep \`namespace=None\` admin mode.

## Tests

- Existing endpoint test \`test_memory_recent_endpoint_excludes_other_namespaces\` (PR #137 / #139) passes on the new path — the desktop's own writes + \`__shared__\` rows surface, bystander writes don't leak.
- Existing strict-namespace contract tests (\`test_get_recent_only_returns_own_namespace\`, \`test_get_recent_excludes_shared_rows\`) still hold — \`get_recent\` strict default is unchanged.
- Engine-level \`include_shared\` semantics already tested by \`test_engine_get_recent_include_shared\` (added in slice 1, PR #143).
- Memory + app_server suite: 295 passed.

Diff: 23 insertions / 22 deletions.

## Test plan

- [x] Existing /memory/recent endpoint test passes on engine path
- [x] Strict-namespace get_recent tests still pass (backward compat verified)
- [x] No production calls to GraphService remain in MemoryClient or app/server.py
- [ ] Reviewer to confirm: include_shared kwarg default-False is the right backward-compat choice (alternative: new method \`get_recent_with_shared\`, but kwarg keeps the API surface tighter)