### PR TITLE
feat(memory): expose is_versioned in /memory/browse response

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2480,6 +2480,9 @@ async def memory_browse(
     try:
         from dataclasses import asdict
 
+        from omicsclaw.memory.namespace_policy import should_version
+        from omicsclaw.memory.uri import MemoryURI
+
         uri = f"{domain}://{path}" if path else f"{domain}://"
         children = await _memory_client.list_children(uri)
 
@@ -2490,11 +2493,18 @@ async def memory_browse(
             if record is not None:
                 node = asdict(record)
 
+        # is_versioned tells the desktop UI whether the URI has a
+        # version chain (and therefore whether to surface the
+        # History/rollback button). Mirrors the namespace_policy rule
+        # the engine uses to pick upsert_versioned vs upsert.
+        is_versioned = should_version(MemoryURI.parse(uri))
+
         return {
             "path": path,
             "domain": domain,
             "node": node,
             "children": [asdict(c) for c in children],
+            "is_versioned": is_versioned,
         }
     except Exception as exc:
         logger.exception("Memory browse error")

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2415,6 +2415,96 @@ async def test_memory_browse_endpoint_falls_back_to_shared(monkeypatch, tmp_path
 
 
 # ---------------------------------------------------------------------------
+# /memory/browse — is_versioned flag drives the desktop "Show history" button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_browse_marks_versioned_uri(monkeypatch, tmp_path):
+    """A versioned URI (per ``namespace_policy.should_version``) must
+    surface ``is_versioned=True`` in the /memory/browse response so the
+    desktop UI can decide whether to render the History/rollback button.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    _, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("core://my_user/note", "v1")
+
+        result = await server.memory_browse(path="my_user/note", domain="core")
+        assert result["is_versioned"] is True, (
+            f"core://my_user/note is in VERSIONED_PREFIXES; expected "
+            f"is_versioned=True, got {result.get('is_versioned')!r}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_browse_marks_overwrite_uri(monkeypatch, tmp_path):
+    """An overwrite-only URI (``dataset://``, ``analysis://``) must
+    surface ``is_versioned=False`` so the UI hides the History button —
+    these URIs structurally have no version chain."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    _, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("dataset://x.h5ad", "data x")
+
+        result = await server.memory_browse(path="x.h5ad", domain="dataset")
+        assert result["is_versioned"] is False, (
+            f"dataset:// is overwrite-only; expected is_versioned=False, "
+            f"got {result.get('is_versioned')!r}"
+        )
+    finally:
+        await memory_pkg.close_db()
+
+
+@pytest.mark.asyncio
+async def test_memory_browse_is_versioned_present_on_root_browse(
+    monkeypatch, tmp_path
+):
+    """Root browse (``path=""``, ``domain="core"``) must still include
+    the ``is_versioned`` field. ``core://`` itself is not versioned, so
+    the value is False — but the field's presence is the contract the
+    front-end relies on, not just the value.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    _, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        result = await server.memory_browse(path="", domain="core")
+        assert "is_versioned" in result
+        assert result["is_versioned"] is False
+    finally:
+        await memory_pkg.close_db()
+
+
+# ---------------------------------------------------------------------------
 # T2 S3 — /memory/search namespace-scoped (caller + __shared__ only)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The desktop UI needs to decide whether to show a "History / Roll back" button on a memory view. The decision is purely based on \`namespace_policy.should_version(uri)\`: \`core://agent/*\`, \`core://my_user/*\`, and \`preference://*\` URIs have version chains; everything else is overwrite-only.

Rather than duplicate the rule on the frontend, this PR adds an \`is_versioned: bool\` field to the \`/memory/browse\` response. Single source of truth on the server; frontend reads the flag.

**Slice 1 of 2** for the version-chain history feature. Slice 2 in the OmicsClaw-App repo wires the flag to a History modal + rollback button.

## Tests

3 new tests in \`tests/test_app_server.py\`:
- versioned URI (\`core://my_user/note\`) → \`is_versioned=true\`
- overwrite URI (\`dataset://x.h5ad\`) → \`is_versioned=false\`
- root browse (\`path=""\`, \`domain="core"\`) → field present, value \`false\` (root has no record)

Memory + app_server suite: 298 passed.

## Stat

+102 / -0 across 2 files.

## Test plan

- [x] 3 RED → GREEN tests for is_versioned
- [x] Existing /memory/browse tests still pass (read fallback, namespace isolation)
- [x] Memory regression suite: 298 passed
- [x] 5-axis code review — no blockers, single source of truth preserved
- [ ] Reviewer to confirm: \`is_versioned\` at the HTTP boundary (not on \`MemoryClient\`/\`MemoryEngine\`) is the right layer — argument is "UI-shaped concern lives on the wire"