### PR TITLE
fix(memory): /memory/browse children must use rich shape

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -2484,7 +2484,17 @@ async def memory_browse(
         from omicsclaw.memory.uri import MemoryURI
 
         uri = f"{domain}://{path}" if path else f"{domain}://"
-        children = await _memory_client.list_children(uri)
+        # list_children_rich returns the desktop-tree dict shape
+        # (name, path, domain, content_snippet, approx_children_count, …)
+        # the UI's MemoryTree/MemoryContent rely on for labels and the
+        # directory-vs-leaf icon. include_shared=True so __shared__
+        # children (e.g., core://agent/*) appear alongside the user's own.
+        children = await _memory_client.list_children_rich(
+            uri,
+            context_domain=domain,
+            context_path=path,
+            include_shared=True,
+        )
 
         # Also get the node itself if path is provided
         node = None
@@ -2503,7 +2513,7 @@ async def memory_browse(
             "path": path,
             "domain": domain,
             "node": node,
-            "children": [asdict(c) for c in children],
+            "children": children,
             "is_versioned": is_versioned,
         }
     except Exception as exc:

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2504,6 +2504,60 @@ async def test_memory_browse_is_versioned_present_on_root_browse(
         await memory_pkg.close_db()
 
 
+@pytest.mark.asyncio
+async def test_memory_browse_children_have_rich_shape(monkeypatch, tmp_path):
+    """Each /memory/browse child must carry the desktop-tree fields
+    (``name``, ``path``, ``domain``, ``approx_children_count``) so
+    MemoryTree.tsx and MemoryContent.tsx can render labels and decide
+    whether the entry is a directory. The sparse ``MemoryRef`` shape
+    (``memory_id``/``node_uuid``/``namespace``/``uri`` only) leaves the
+    UI showing blank rows, which is the regression this guards.
+    """
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+    from omicsclaw.memory.memory_client import MemoryClient
+
+    _, _, memory_pkg = await _setup_memory_review_runtime(monkeypatch, tmp_path)
+
+    try:
+        engine = memory_pkg.get_memory_engine()
+        desktop_client = MemoryClient(engine=engine, namespace="app/desktop_user")
+        monkeypatch.setattr(server, "_memory_client", desktop_client)
+
+        await desktop_client.remember("core://parent/child_a", "leaf a")
+        await desktop_client.remember("core://parent/child_b/grandchild", "leaf b")
+
+        result = await server.memory_browse(path="parent", domain="core")
+        children = result["children"]
+        assert len(children) >= 2, (
+            f"expected ≥2 children under core://parent, got {len(children)}"
+        )
+
+        required = {"name", "path", "domain", "approx_children_count"}
+        for child in children:
+            missing = required - set(child)
+            assert not missing, (
+                f"child {child!r} missing rich-shape fields: {missing}. "
+                f"This means /memory/browse is returning the sparse "
+                f"MemoryRef list_children shape instead of "
+                f"list_children_rich, and the desktop UI shows blank rows."
+            )
+
+        by_name = {c["name"]: c for c in children}
+        assert "child_a" in by_name, f"missing 'child_a'; got {list(by_name)}"
+        assert "child_b" in by_name, f"missing 'child_b'; got {list(by_name)}"
+        assert by_name["child_a"]["approx_children_count"] == 0
+        assert by_name["child_b"]["approx_children_count"] >= 1, (
+            "child_b has a grandchild; approx_children_count should be ≥1 "
+            "so the UI marks it as a directory"
+        )
+        assert by_name["child_a"]["domain"] == "core"
+        assert by_name["child_a"]["path"] == "parent/child_a"
+    finally:
+        await memory_pkg.close_db()
+
+
 # ---------------------------------------------------------------------------
 # T2 S3 — /memory/search namespace-scoped (caller + __shared__ only)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `/memory/browse` was still calling `MemoryClient.list_children` (sparse
  `MemoryRef`: `memory_id`, `node_uuid`, `namespace`, `uri`) after PR #146
  switched the parallel `/memory/children` endpoint to `list_children_rich`.
- Desktop UI (`MemoryTree.tsx`, `MemoryContent.tsx`) reads
  `name`/`path`/`domain`/`approx_children_count` to render labels and the
  directory-vs-leaf icon — without those fields every child rendered as a
  blank row (regression visible after the desktop backend was restarted to
  pick up post-#146 code).
- Switch `/memory/browse` to `list_children_rich(context_domain,
  context_path, include_shared=True)` — same call shape `/memory/children`
  already uses, including `__shared__` visibility.

## Test plan

- [x] New TDD test `test_memory_browse_children_have_rich_shape` —
      reproduces the regression on the sparse shape, passes after the fix
- [x] All five `memory_browse` tests green (existing + new)
- [x] Full memory regression suite green: `tests/memory/`,
      `tests/test_app_server.py`, `tests/integration/test_memory_cross_surface.py`,
      etc. — 318 passed
- [ ] Manual verification in `electron:dev`: child names render in the
      Memory tree and right-pane "Children (N)" list, History button still
      shows on `core://my_user/*` after PR #153