### PR TITLE
docs(memory): close out refactor plan §6 + CONTEXT.md migration notes

### DIFF
--- a/docs/2026-05-09-memory-refactor-plan.md
+++ b/docs/2026-05-09-memory-refactor-plan.md
@@ -527,25 +527,37 @@ PR #1 ─ MemoryURI + namespace_policy
 
 ## Phase 5: Cleanup (PR #6)
 
+> **Status (2026-05-11):** Phase 5 complete. The cold-path API modules (`api/maintenance.py`, `api/review.py`, `api/browse.py`) all retired their `GraphService` dependency across PR #173 / #174 / #175. `omicsclaw/memory/graph.py` is deleted; its path-based admin operations live as a private `BrowseHelpers` class in `omicsclaw/memory/api/_browse_helpers.py`, consumed only by the `oc memory-server` admin UI. Phase 1's KH bootstrap (PR #172) closed the last functional gap. See "Status by PR" table below.
+
+### Status by PR
+
+| PR | Title | Phase | Result |
+|---|---|---|---|
+| [#172](https://github.com/TianGzlab/OmicsClaw/pull/172) | seed `core://kh/*` into `__shared__` on every surface startup | Phase 1 (KH bootstrap, originally untracked) | ✅ merged |
+| [#173](https://github.com/TianGzlab/OmicsClaw/pull/173) | route `/api/maintenance` through ReviewLog | §5 Task 6.x — maintenance migration | ✅ merged |
+| [#174](https://github.com/TianGzlab/OmicsClaw/pull/174) | route `/api/review` through ReviewLog | §5 Task 6.x — review migration | ✅ merged |
+| [#175](https://github.com/TianGzlab/OmicsClaw/pull/175) | retire `GraphService` class (Phase 2c + 3 combined) | §5 Task 6.2 | ✅ merged |
+
 ### PR #6 — delete `GraphService` residue + migrate legacy parsers
 
 #### Task 6.1: Migrate legacy `_parse_uri` call sites
 
 - **Files**: `omicsclaw/memory/snapshot.py:349`, anywhere else still using `_parse_uri`
 - **Acceptance**:
-  - [ ] All `_parse_uri` references replaced with `MemoryURI.parse`
-  - [ ] `grep -rn "_parse_uri" omicsclaw/` returns nothing in non-test files
+  - [x] All `_parse_uri` references replaced with `MemoryURI.parse` *(2026-05-11)*
+  - [x] `grep -rn "_parse_uri" omicsclaw/` returns nothing in non-test files
 - **Dependencies**: PR #5
 - **Scope**: S
 - **Risk**: low
 
 #### Task 6.2: Inline GraphService shim into engine
 
-- **Files**: `omicsclaw/memory/graph.py` (delete or shrink to <100 lines), `omicsclaw/memory/__init__.py` (update exports)
+- **Files**: `omicsclaw/memory/graph.py` (deleted), `omicsclaw/memory/__init__.py` (update exports)
 - **Acceptance**:
-  - [ ] No external file imports `GraphService` (verified via grep)
-  - [ ] Public API: `get_memory_engine()`, `get_review_log()`, `get_memory_client(namespace=...)` replace `get_graph_service()` etc.
-  - [ ] Module docstring updated
+  - [x] No external file imports `GraphService` (verified via grep)
+  - [x] Public API: `get_memory_engine()`, `get_review_log()`, `get_memory_client(namespace=...)` replace `get_graph_service()` etc.
+  - [x] Module docstring updated
+- **Result**: PR #175 — graph.py file removed; class renamed to private `BrowseHelpers` in `omicsclaw/memory/api/_browse_helpers.py`. The implementation is preserved (not deleted) only because `/api/browse/*` exposes path+title admin verbs that have no clean MemoryEngine equivalent yet; a future rewrite can drop the file entirely.
 - **Dependencies**: 6.1
 - **Scope**: M
 - **Risk**: medium — last cross-cutting change
@@ -554,17 +566,17 @@ PR #1 ─ MemoryURI + namespace_policy
 
 - **Files**: `README.md`, `AGENTS.md` (memory section)
 - **Acceptance**:
-  - [ ] Memory section reflects new architecture: 3-layer, namespace, surfaces
-  - [ ] References CONTEXT.md
+  - [x] Memory section reflects new architecture: 3-layer, namespace, surfaces *(README updated in PR #172; AGENTS updated in PR #172 + #175)*
+  - [x] References CONTEXT.md
 - **Dependencies**: 6.2
 - **Scope**: S
 
 #### Checkpoint: end of refactor
 
-- [ ] `wc -l omicsclaw/memory/*.py` shows total LOC reduced from ~5886 to <4000
-- [ ] All tests green
-- [ ] `mypy omicsclaw/memory/` clean
-- [ ] README + AGENTS.md updated; CONTEXT.md unchanged (means contract held)
+- [x] All tests green (367 across memory + bot + app after PR #175)
+- [x] README + AGENTS.md updated; CONTEXT.md reflects the new state (this doc-closure PR)
+- [ ] `wc -l omicsclaw/memory/*.py` LOC target — not pursued; `_browse_helpers.py` keeps ~1500 lines of legacy path-based logic until the admin UI rewrite
+- [ ] `mypy omicsclaw/memory/` clean — pyright suppression header preserved on the legacy module; not pursued in scope of this refactor
 
 ---
 
@@ -585,7 +597,7 @@ PR #1 ─ MemoryURI + namespace_policy
 | Question | Blocks |
 |---|---|
 | `OMICSCLAW_MEMORY_DB_URL` env var: should desktop launches with different `OMICSCLAW_DESKTOP_LAUNCH_ID` use different DBs, or same DB with different namespaces? | PR #5.2 |
-| `core://kh/*` seed: who runs the bootstrap that writes KnowHow guards to `__shared__`? Is it `oc onboard`, `init_db`, or a separate command? | PR #4a (defines `remember_shared` callsite) |
+| ~~`core://kh/*` seed: who runs the bootstrap that writes KnowHow guards to `__shared__`? Is it `oc onboard`, `init_db`, or a separate command?~~ — **resolved 2026-05-11 (PR #172)**: every `init_db()` caller invokes `seed_knowhows()` next; same-content reseeds are no-ops via the idempotent `MemoryEngine.seed_shared`. | ~~PR #4a~~ ✅ |
 | Should `_auto_capture_dataset` (`bot/core.py:829`) write to user's namespace OR shared? Currently fixed `dataset://{file_path}` is user-scoped per design, but a researcher with multiple datasets across workspaces gets duplicate writes. Confirm. | PR #5.3 |
 | ~~When user runs `oc interactive` from `~/` (no project), what namespace?~~ — **resolved 2026-05-11**: `cli_namespace_from_workspace(None)` returns the resolved cwd; `~/` becomes the absolute home path. | ~~PR #5.1~~ ✅ |
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -82,7 +82,7 @@ The `app/`, `telegram/`, `feishu/` prefixes are structural — they prevent any 
 - A **MemoryClient** routes each `remember()` call to either a **Versioned upsert** or an **Overwrite upsert** based on the **Memory URI**'s domain.
 - A **MemoryEngine** writes a `(domain, path)` row partitioned by **Namespace**; **Read fallback** to `__shared__` happens at query time, not at write time.
 - A **ReviewLog** reads the same database as **MemoryEngine** but exposes only **Cold path** verbs.
-- A **Memory URI** with domain `core` and path starting with `agent` / `kh` / `my_user_default` is **routed to** `__shared__` by `namespace_policy` whenever something writes there. As of 2026-05, only `core://agent` is wired; `core://kh/*` and `core://my_user_default` are reserved prefixes — the bot's KnowHow guards still come from filesystem markdown via `KnowHowInjector`, not from memory. Everything outside those three prefixes lives in the caller's current **Namespace**.
+- A **Memory URI** with domain `core` and path starting with `agent` / `kh` / `my_user_default` is **routed to** `__shared__` by `namespace_policy` whenever something writes there. Both `core://agent` and `core://kh/*` are now wired: every memory-init path (Compat bot, MemoryClient legacy db_url, app/server.py chat lifespan, memory/server.py lifespan) calls `seed_knowhows()` after `init_db()`, mirroring the on-disk KH corpus into `__shared__` under `core://kh/<doc_id>`. `core://my_user_default` remains a reserved prefix awaiting a writer. Everything outside those three prefixes lives in the caller's current **Namespace**.
 - A **Versioned upsert**'s `migrated_to` chain is the only structure where **ReviewLog.rollback_to** can operate.
 
 ## Example dialogue
@@ -108,13 +108,15 @@ Decisions that the refactor PRs (#125–#132) chose by sensible default rather t
 
 Tracked but not yet resolved in code:
 
-- **`core://kh/*` seed bootstrap** — Who runs the script that writes KnowHow guards into `__shared__`? Candidates: `oc onboard` (one-time per workstation), `init_db()` (every start), or a separate `oc seed` command. Until this is decided, KH content lives only as markdown under `knowledge_base/knowhows/` and the `read_knowhow` tool reads it directly from disk; the `__shared__` partition holds no KH rows. The `("core", "kh")` entry in `SHARED_PREFIXES` is forward-looking — it ensures that *if* something later writes a `core://kh/*` URI, it lands in `__shared__` automatically.
 - **`_auto_capture_dataset` policy** — When the bot detects a dataset filename, should it write under the user's Namespace or `__shared__`? Today it goes user-scoped (per CompatMemoryStore default), which means the same `pbmc.h5ad` mentioned by two users gets two `dataset://` rows. Whether to deduplicate at `__shared__` is a UX question.
+
+## Resolved (kept here for tombstone)
+
+- ~~**`core://kh/*` seed bootstrap**~~ — **Resolved (PR #172, 2026-05-11)**: every `init_db()` caller invokes `seed_knowhows()`, which iterates `KnowHowInjector.iter_entries()` and writes each `(uri, content)` via the idempotent `MemoryEngine.seed_shared`. Same-content reseeds are no-ops; failures downgrade to a warning log and don't block startup.
 
 ## Flagged ambiguities
 
 - **"user"** is used three ways: (1) the human researcher (`core://my_user`), (2) the chat-side participant (`Session.user_id`), (3) the Linux process owner. In this doc "user" means (1) or (2) — context determines which; never (3).
 - **"workspace"** appears in both the **Surface** layer (the directory the user picked, used as the Namespace string) and the `ScopedMemory` layer (a filesystem root). Same physical directory, different concepts; will collapse only if ScopedMemory is integrated into MemoryEngine.
-- **GraphService** (legacy) and **MemoryEngine** (target) co-exist during the migration window. PR #6 retired the deeper migration to keep its scope bounded — `MemoryClient.forget` / `MemoryClient.get_recent` and three server endpoints (`/memory/update`, `/memory/children`, `/memory/domains`) still route through `GraphService` because their verbs lack a clean engine equivalent. Use `MemoryEngine` in all new code; only touch `GraphService` from migration PRs.
-- **CLI/TUI graph wiring is deferred.** Documentation through PR #132 listed `cli_namespace_from_workspace(workspace_dir)` as the Surface helper, implying CLI/TUI hosted a graph `MemoryClient`. In practice the `/memory` slash command only ever bound to `ScopedMemory`. The helper remains exported for the day CLI/TUI gains cross-Surface continuity; until then `omicsclaw/interactive/` does not construct a `MemoryClient`. Stale `cli/cli_user` and `tui/tui_user` rows in production DBs are migration artifacts with no live writer.
+- **GraphService is retired.** Production code uses `MemoryEngine` / `ReviewLog` / `MemoryClient` exclusively. The legacy path-based admin operations (`/api/browse/*` write endpoints) live in a private `omicsclaw/memory/api/_browse_helpers.BrowseHelpers` class consumed only by the `oc memory-server` admin UI — do not import from outside `omicsclaw/memory/api/`. A future rewrite can port the admin UI against `MemoryEngine` and delete this module entirely.
 - **"namespace"** vs **"domain"**: domain is the URI prefix (`dataset`, `core`, …); namespace is the user/workspace isolation key. They are orthogonal columns; never use one as a synonym for the other.


### PR DESCRIPTION
## TL;DR
Backfills the two documentation tasks (Phase 1.4 and Phase 3.3) that were originally part of the May 2026 memory refactor plan but got skipped at PR time because `docs/CONTEXT.md` and the refactor-plan doc weren't on main yet. They've since landed; this PR catches them up.

No code changes.

## What this PR fixes

`docs/CONTEXT.md` contained three statements that are now false:

1. Line 85 said "only `core://agent` is wired; `core://kh/*` are reserved prefixes — KH guards come from filesystem markdown, not from memory." After PR #172, every `init_db` caller invokes `seed_knowhows()` and `__shared__` mirrors the on-disk KH corpus.
2. Line 111 (Open questions) had "`core://kh/*` seed bootstrap" as an unresolved candidate-pick question. PR #172 chose `init_db()` and shipped it.
3. Line 118 said "GraphService (legacy) and MemoryEngine (target) co-exist during the migration window… three server endpoints still route through GraphService." After PR #175, `GraphService` is deleted; the residual admin path operations live in a private `BrowseHelpers` class.
4. Line 119 said "CLI/TUI graph wiring is deferred." PR #167 wired it.

`docs/2026-05-09-memory-refactor-plan.md` §5 (PR #6) Tasks 6.1 / 6.2 / 6.3 and the end-of-refactor checkpoint had every acceptance checkbox empty even though the merged PRs (172/173/174/175) cover them.

## Changes

- `docs/CONTEXT.md`: rewrite the KH paragraph, tombstone the bootstrap open question, replace the GraphService coexistence note with a one-line pointer at `_browse_helpers.py`, drop the "CLI/TUI deferred" line.
- `docs/2026-05-09-memory-refactor-plan.md`: add a Phase 5 status block with a per-PR table (172/173/174/175), tick the acceptance checkboxes that the merged PRs cover, mark the KH-bootstrap open question resolved.

## Verification

- Docs-only PR; no test changes, no code changes.
- `grep -n "core://kh\|GraphService" docs/CONTEXT.md` now shows only the corrected wording.
- Refactor-plan PR table cross-references real merged PRs.