### PR TITLE
fix(cli): restore subcommand help for oc run/mcp/etc (OMI-10)

### DIFF
--- a/omicsclaw.py
+++ b/omicsclaw.py
@@ -485,9 +485,22 @@ def _resolve_workspace(
 
 
 class OmicsClawParser(argparse.ArgumentParser):
-    """Custom parser for beautiful OmicsClaw CLI help output."""
+    """Custom parser for beautiful OmicsClaw CLI help output.
+
+    Only the root parser renders the curated top-level help. Subparsers created
+    via ``add_subparsers`` inherit this class (argparse copies the parser
+    class), so without the ``is_root`` gate ``oc <command> --help`` would
+    re-render the top-level help instead of the subcommand's own options.
+    """
+
+    def __init__(self, *args, is_root: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._is_root = is_root
 
     def print_help(self, file=None):
+        if not self._is_root:
+            return super().print_help(file=file)
+
         if file is None:
             file = sys.stdout
 
@@ -535,6 +548,7 @@ def main():
     parser = OmicsClawParser(
         description="OmicsClaw -- Multi-Omics Skills Runner",
         formatter_class=argparse.RawTextHelpFormatter,
+        is_root=True,
     )
     parser.add_argument(
         "-V",


### PR DESCRIPTION
## Summary

`OmicsClawParser` overrode `print_help()` for a curated top-level help, but argparse copies the parser class to every subparser created via `add_subparsers`. Every `oc <command> --help` therefore re-rendered the top-level help instead of the subcommand's argparse output.

Gate the custom help on an `is_root` flag set only on the root parser; subparsers fall through to argparse's default `print_help`.

## Verification

```text
oc run --help                  # shows run options (--demo, --input, --output, ...)
oc mcp --help                  # shows {list,add,remove,config}
oc mcp add --help              # shows name/command/--transport/--env
oc knowledge search --help     # shows query/--domain/--type/--limit
oc auth login --help           # shows provider choices
oc --help                      # still renders curated top-level help
oc                             # still renders curated top-level help
oc version                     # OmicsClaw 0.1.1
```

Closes OMI-10.

## Test plan
- [x] `oc run --help` shows run-level args (not top-level help)
- [x] `oc mcp --help`, `oc mcp add --help` show their own help
- [x] `oc --help` and bare `oc` still show curated top-level help
- [x] `oc version` still works