### PR TITLE
fix(resolver+bot): stable WGCNA tie-break + drop dead spatial-domain-identification branches (OMI-12 audit P0)

### DIFF
--- a/bot/skill_orchestration.py
+++ b/bot/skill_orchestration.py
@@ -486,10 +486,14 @@ async def _run_skill_via_shared_runner(
     if batch_key:
         forwarded_args.extend(["--batch-key", batch_key])
     if n_epochs is not None:
-        if canonical_skill == "spatial-domain-identification":
-            forwarded_args.extend(["--epochs", str(int(n_epochs))])
-        else:
-            forwarded_args.extend(["--n-epochs", str(int(n_epochs))])
+        # The legacy alias ``spatial-domain-identification`` was the only skill
+        # that wanted ``--epochs`` instead of ``--n-epochs``, but the registry
+        # now resolves that alias to canonical ``spatial-domains`` before we
+        # land here — the conditional was dead code. ``argv_builder``'s
+        # ``--epochs`` ↔ ``--n-epochs`` rewrite (see
+        # ``omicsclaw/core/runtime/argv_builder.py``) handles whichever flag
+        # each skill's ``allowed_extra_flags`` actually accepts.
+        forwarded_args.extend(["--n-epochs", str(int(n_epochs))])
     forwarded_args.extend(_normalize_extra_args(extra_args))
 
     def _emit_stdout(line: str) -> None:

--- a/bot/tool_executors.py
+++ b/bot/tool_executors.py
@@ -283,10 +283,13 @@ async def execute_omicsclaw(args: dict, session_id: str = None, chat_id: int | s
     if batch_key:
         hint_cmd.extend(["--batch-key", batch_key])
     if n_epochs is not None:
-        if canonical_skill == "spatial-domain-identification":
-            hint_cmd.extend(["--epochs", str(int(n_epochs))])
-        else:
-            hint_cmd.extend(["--n-epochs", str(int(n_epochs))])
+        # ``argv_builder.filter_forwarded_args`` rewrites ``--n-epochs`` to
+        # ``--epochs`` (or vice versa) per the receiving skill's
+        # ``allowed_extra_flags``; the legacy
+        # ``if canonical_skill == "spatial-domain-identification"`` branch
+        # never fired because the registry resolves that alias to
+        # ``spatial-domains`` before this code runs.
+        hint_cmd.extend(["--n-epochs", str(int(n_epochs))])
     hint_cmd.extend(_normalize_extra_args(extra_args))
     param_hint = _build_param_hint(skill_key, method, hint_cmd)
 

--- a/omicsclaw/core/capability_resolver.py
+++ b/omicsclaw/core/capability_resolver.py
@@ -652,7 +652,13 @@ def resolve_capability(
         if candidate is not None:
             candidates.append(candidate)
 
-    candidates.sort(key=lambda c: c.score, reverse=True)
+    # Sort by score DESC with a stable alphabetical tie-break on the skill
+    # alias. Without the tie-break, the post-PR audit caught WGCNA flapping
+    # between ``bulkrna-coexpression`` and ``bulkrna-ppi-network`` depending
+    # on the order ``registry.iter_primary_skills`` happened to return them
+    # in — which itself depends on filesystem traversal at registry load
+    # time. Alphabetical order gives a deterministic winner.
+    candidates.sort(key=lambda c: (-c.score, c.skill))
 
     custom_requested = any(h in query_lower for h in _CUSTOM_FALLBACK_HINTS)
     web_requested = any(h in query_lower for h in _WEB_HINTS)

--- a/tests/test_bot_n_epochs_routing.py
+++ b/tests/test_bot_n_epochs_routing.py
@@ -1,0 +1,78 @@
+"""Regression test for the dead ``spatial-domain-identification`` --epochs
+conditional removal.
+
+The bot used to branch on ``canonical_skill == "spatial-domain-identification"``
+to pick between ``--epochs`` and ``--n-epochs``. The registry resolves that
+alias to canonical ``spatial-domains`` before this code runs, so the branch
+was dead — the bot always emitted ``--n-epochs`` and relied on
+``argv_builder.filter_forwarded_args`` to rewrite ``--n-epochs`` to
+``--epochs`` (or vice versa) per each skill's ``allowed_extra_flags``.
+
+This test pins the simplification so a future "helpful" branch
+re-introduction has to break a test.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bot_skill_orchestration_has_no_spatial_domain_identification_special_case():
+    """``bot/skill_orchestration.py`` must not switch on the legacy alias.
+
+    The argv builder owns the ``--epochs`` / ``--n-epochs`` rewrite; the
+    bot adapter is supposed to be ignorant of which skill takes which.
+    """
+    source = (ROOT / "bot" / "skill_orchestration.py").read_text(encoding="utf-8")
+    # Tolerate docstring / comment mentions explaining the removal, but not
+    # an actual code conditional.
+    pattern = re.compile(r'^\s*if\s+canonical_skill\s*==\s*"spatial-domain-identification"', re.M)
+    assert not pattern.search(source), (
+        "dead ``if canonical_skill == 'spatial-domain-identification'`` "
+        "conditional reintroduced in bot/skill_orchestration.py — let "
+        "argv_builder.filter_forwarded_args handle the --epochs rewrite."
+    )
+
+
+def test_bot_tool_executors_has_no_spatial_domain_identification_special_case():
+    """``bot/tool_executors.py`` must not switch on the legacy alias either."""
+    source = (ROOT / "bot" / "tool_executors.py").read_text(encoding="utf-8")
+    pattern = re.compile(r'^\s*if\s+canonical_skill\s*==\s*"spatial-domain-identification"', re.M)
+    assert not pattern.search(source), (
+        "dead ``if canonical_skill == 'spatial-domain-identification'`` "
+        "conditional reintroduced in bot/tool_executors.py — let "
+        "argv_builder.filter_forwarded_args handle the --epochs rewrite."
+    )
+
+
+def test_argv_builder_still_rewrites_n_epochs_for_spatial_domains():
+    """Sanity-check the rewrite the bot now relies on: when a skill only
+    allow-lists ``--epochs``, the bot's ``--n-epochs`` argv is rewritten
+    correctly. If this stops working, the dead-branch deletion would
+    silently strip the flag and skills would run with default epochs."""
+    from omicsclaw.core.runtime.argv_builder import filter_forwarded_args
+
+    out = filter_forwarded_args(
+        ["--n-epochs", "50"], allowed_extra_flags={"--epochs"}
+    )
+    assert out == ["--epochs", "50"]
+
+
+def test_spatial_domains_canonical_alias_makes_branch_unreachable():
+    """The branch was dead because the registry's canonical alias for
+    ``spatial-domain-identification`` is ``spatial-domains``. Pin that so a
+    future SKILL.md edit that renames the canonical alias back to
+    ``spatial-domain-identification`` re-introduces the bug visibly."""
+    from omicsclaw.core.registry import ensure_registry_loaded
+
+    registry = ensure_registry_loaded()
+    legacy_view = registry.skills.get("spatial-domain-identification")
+    assert legacy_view is not None, "legacy alias must remain resolvable"
+    assert legacy_view["alias"] == "spatial-domains", (
+        "If the canonical alias changes back to spatial-domain-identification, "
+        "the bot's dead-branch deletion needs to be revisited — the rewrite "
+        "rule lives in argv_builder now."
+    )

--- a/tests/test_capability_resolver.py
+++ b/tests/test_capability_resolver.py
@@ -75,3 +75,27 @@ def test_validate_custom_analysis_code_allows_basic_analysis():
         "import scanpy as sc\nimport pandas as pd\nprint('ok')\n"
     )
     assert issues == []
+
+
+def test_resolve_capability_breaks_score_ties_alphabetically():
+    """The candidate sort must tie-break on the canonical alias so the same
+    query produces the same ``chosen_skill`` regardless of which order
+    ``registry.iter_primary_skills`` happens to return tied skills in.
+
+    Pre-fix this test failed about half the time depending on filesystem
+    traversal at registry load — ``bulkrna-coexpression`` and
+    ``bulkrna-ppi-network`` both score 7.25 for this WGCNA query, and
+    Python's stable sort kept whichever the registry yielded first.
+    """
+    decision = resolve_capability(
+        "Build a WGCNA co-expression network on my bulk RNA-seq counts, return hub genes"
+    )
+    top_two = [c.skill for c in decision.skill_candidates[:2]]
+    if len(top_two) >= 2 and decision.skill_candidates[0].score == decision.skill_candidates[1].score:
+        assert top_two == sorted(top_two), (
+            f"tied top candidates must be sorted alphabetically; got {top_two}"
+        )
+    # And the specific query that originally exposed the flake must produce
+    # ``bulkrna-coexpression`` (alphabetically before ``bulkrna-ppi-network``)
+    # under any registry iteration order.
+    assert decision.chosen_skill == "bulkrna-coexpression"


### PR DESCRIPTION
## Summary
Two real bugs from the OMI-12 post-P2.9 audit, each addressable in well under an hour:

### 🔴 P0 #1 — Golden routing test flapping on `main`

`tests/fixtures/golden_routing/snapshot.json` pins the WGCNA query to `bulkrna-coexpression`, but the live resolver returns `bulkrna-ppi-network` on a fresh checkout:

```
FAILED tests/test_capability_resolver_golden.py
chosen_skill drifted for 'Build a WGCNA co-expression network ...':
expected 'bulkrna-coexpression', got 'bulkrna-ppi-network'.
```

Root cause: **both skills score exactly 7.250**, and `candidates.sort(key=lambda c: c.score, reverse=True)` is Python-stable — the winner is whichever `registry.iter_primary_skills` yielded first, which depends on filesystem traversal at registry load. The PR #186 `regenerate()` happened to land on `bulkrna-coexpression`; subsequent checkouts on a different filesystem ordering land on `bulkrna-ppi-network`.

**Fix**: `candidates.sort(key=lambda c: (-c.score, c.skill))` — same primary key, deterministic alphabetical tie-break. `bulkrna-coexpression < bulkrna-ppi-network` so the snapshot matches under any iteration order.

**Side benefit**: `test_routing_regression.py::clear WGCNA on bulk` was one of two strict-fail tests on `main`; it now passes deterministically. The XCMS case was already moved to xfail upstream.

### 🔴 P0 #2 — Dead `spatial-domain-identification` branch in bot adapters

`bot/skill_orchestration.py:489` and `bot/tool_executors.py:286` both branched on `canonical_skill == "spatial-domain-identification"` to pick `--epochs` vs `--n-epochs`. But the registry's canonical alias for that skill is now `spatial-domains` — the rename happened in an earlier PR, so the `if` branch **never fires**. The bot always sent `--n-epochs`, and `argv_builder.filter_forwarded_args` quietly rewrote it to `--epochs` per the receiving skill's allow-list. Three implementations of the same rewrite, two of them dead.

**Fix**: collapse both bot branches to unconditional `["--n-epochs", str(n_epochs)]` and let `argv_builder` own the rewrite. Comments document why.

## New regression tests
- `tests/test_capability_resolver.py::test_resolve_capability_breaks_score_ties_alphabetically` — pins the WGCNA case to `bulkrna-coexpression` and asserts top-1/top-2 are alphabetically ordered when tied.
- `tests/test_bot_n_epochs_routing.py` (4 tests) — AST-greps both bot modules to ensure the dead conditional doesn't sneak back, sanity-checks the argv-builder rewrite the bot now depends on, and asserts the registry still resolves the legacy alias to `spatial-domains` (a future SKILL.md rename would have to revisit this PR).

## Test plan
- [x] `pytest tests/test_capability_resolver.py tests/test_capability_resolver_golden.py tests/test_routing_regression.py tests/test_auto_routing_disambiguation.py tests/test_bot_n_epochs_routing.py` — **48 passed**, 1 skipped, 5 xfailed (WGCNA strict-fail flipped to pass; everything else unchanged).
- [x] `pytest tests/test_capability_resolver*.py tests/test_routing*.py tests/test_skill_runner_contract.py tests/test_runtime_*.py tests/test_registry.py tests/test_execution_default_executor.py tests/test_execution_executors.py tests/test_bot_n_epochs_routing.py` — 114 passed, 4 skipped, 5 xfailed; 1 pre-existing env failure unrelated (`fastapi` missing).
- [x] `pytest tests/bot/test_skill_orchestration.py tests/test_metadata_roundtrip.py tests/test_bot_runner_contract.py tests/test_interactive_omicsclaw_actions.py` — 104 passed; same 4 pre-existing failures as `main` (pydantic version + bot logger-name assertion).
- [x] `python omicsclaw.py list` — 89 skills × 8 domains.

## Out of scope (P1 backlog from the audit)
- Share single iter over skills between `_detect_domain` and `resolve_capability` (O(2N) → O(N))
- Drop the `-9 → 0` SIGKILL heuristic in favour of skills writing `result.json.status`
- Default `should_search_web=False`, fire only on `_WEB_HINTS`
- Converge `SkillRunnerExecutor` onto `SubprocessExecutor`

These need their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)