### PR TITLE
refactor(resolver): single-pass iter + tighten should_search_web default (OMI-12 audit P1 #1+#3)

### DIFF
--- a/omicsclaw/core/capability_resolver.py
+++ b/omicsclaw/core/capability_resolver.py
@@ -442,16 +442,50 @@ def _detect_domain(
     file_path: str = "",
     domain_hint: str = "",
 ) -> str:
+    """Pick the most likely omics domain for ``query``.
+
+    Kept for callers that want domain detection on its own. The main
+    ``resolve_capability`` flow no longer calls this — it uses
+    :func:`_score_skills_and_detect_domain` to compute the domain and the
+    candidate scores in a single walk over ``iter_primary_skills`` (OMI-12
+    audit P1 #1).
+    """
     if domain_hint:
         return domain_hint
+    domain, _candidates = _score_skills_and_detect_domain(
+        registry, query, file_path=file_path
+    )
+    return domain
 
+
+def _score_skills_and_detect_domain(
+    registry: OmicsRegistry,
+    query: str,
+    *,
+    file_path: str = "",
+) -> tuple[str, list["CapabilityCandidate"]]:
+    """Single-pass scoring: walk every primary skill exactly once and emit
+    both the detected domain *and* every skill's per-candidate score.
+
+    Pre-refactor the resolver walked ``iter_primary_skills`` twice — once
+    inside ``_detect_domain`` (89 skills × per-domain accumulation), then
+    again inside ``resolve_capability`` (the same skills, this time with
+    the per-skill weights). The two passes used different weights but read
+    the same SKILL.md fields (alias, legacy aliases, description tokens,
+    trigger keywords), so the duplicate filesystem-derived work was pure
+    overhead. This helper accumulates both score sets in one pass.
+
+    Returns ``(detected_domain, candidates)``. ``candidates`` is the full
+    list of skills that scored positively (unsorted, unfiltered); callers
+    that want only the detected-domain slice filter it themselves.
+    """
     query_lower = query.lower()
     query_tokens = _tokenize(query_lower)
-    domain_scores: dict[str, float] = {
-        domain: 0.0
-        for domain in registry.domains
-    }
+    method_tokens = _method_mentions(query_lower)
 
+    # File-path domain detection seeds the domain accumulator before any
+    # skill-level signals fire.
+    domain_scores: dict[str, float] = {domain: 0.0 for domain in registry.domains}
     if file_path and detect_domain_from_path is not None:
         detected = str(detect_domain_from_path(file_path, fallback="")).strip()
         if detected:
@@ -459,68 +493,80 @@ def _detect_domain(
                 domain_scores.get(detected, 0.0) + _DOMAIN_SCORE_FILE_PATH
             )
 
+    candidates: list[CapabilityCandidate] = []
+    for alias, skill_info in registry.iter_primary_skills():
+        # Iterate each skill's OWN trigger_keywords once and reuse the
+        # match list on both the per-skill (limit=3) and per-domain
+        # (limit=2) sides. The previous "compute keyword matches via
+        # ``registry.build_keyword_map(domain=None)``" optimisation was
+        # incorrect: ``build_keyword_map`` overwrites shared keywords by
+        # last-write-wins, so a keyword that lives on multiple skills
+        # silently dropped its score from every skill except the last
+        # inserted (e.g. ``bulkrna-de`` lost ~3.8 points on shared
+        # "differential" keywords because some other-domain skill happened
+        # to be inserted later).
+        _, all_kw_matches = _score_trigger_keyword_matches(
+            query_lower,
+            skill_info.get("trigger_keywords", []),
+            limit=_SCORE_TRIGGER_KEYWORD_LIMIT,
+        )
+
+        # ---- candidate-side scoring (per-skill weights, up to 3 keywords) ----
+        candidate = _candidate_score(
+            alias,
+            skill_info,
+            query_lower,
+            query_tokens,
+            method_tokens,
+            keyword_matches=all_kw_matches,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+
+        # ---- domain-side scoring (per-domain weights, accumulated into
+        # the skill's home domain; keyword limit drops to 2).
+        skill_domain = str(skill_info.get("domain", ""))
+        if not skill_domain:
+            continue
+        delta = 0.0
+        if _mentions_phrase(query_lower, alias.lower()):
+            delta += _DOMAIN_SCORE_ALIAS_MENTION
+        for legacy in skill_info.get("legacy_aliases", []):
+            legacy_lower = str(legacy).lower()
+            if legacy_lower and _mentions_phrase(query_lower, legacy_lower):
+                delta += _DOMAIN_SCORE_LEGACY_ALIAS_MENTION
+        description = str(skill_info.get("description", "")).lower()
+        overlap = query_tokens & _tokenize(description)
+        delta += (
+            min(len(overlap), _DOMAIN_SCORE_DESCRIPTION_OVERLAP_CAP)
+            * _DOMAIN_SCORE_DESCRIPTION_OVERLAP_PER_TOKEN
+        )
+        # Reuse the same keyword matches with the tighter per-domain limit
+        # so the loop body never rescans this skill's trigger_keywords.
+        for kw_phrase in all_kw_matches[:_DOMAIN_SCORE_TRIGGER_KEYWORD_LIMIT]:
+            delta += _trigger_keyword_score(kw_phrase)
+        domain_scores[skill_domain] = domain_scores.get(skill_domain, 0.0) + delta
+
+    # Domain-name and domain-key textual matches contribute independently of
+    # any skill — keep these post-loop so the loop body has one concern.
+    for domain_key, info in registry.domains.items():
+        domain_name = str(info.get("name", domain_key)).lower()
+        if domain_name in query_lower or domain_key.lower() in query_lower:
+            domain_scores[domain_key] = (
+                domain_scores.get(domain_key, 0.0) + _DOMAIN_SCORE_DOMAIN_NAME_MATCH
+            )
+
+    # Pick the highest-scoring domain. Strict ``>`` matches the old
+    # ``_detect_domain`` behaviour: ties go to the first-seen domain in
+    # ``registry.domains`` insertion order, which is deterministic because
+    # the domain list is hardcoded in ``registry._HARDCODED_DOMAINS``.
     best_domain = ""
     best_score = 0.0
-
-    for domain, info in registry.domains.items():
-        score = domain_scores.get(domain, 0.0)
-        for alias, skill_info in registry.iter_primary_skills(domain=domain):
-            if _mentions_phrase(query_lower, alias.lower()):
-                score += _DOMAIN_SCORE_ALIAS_MENTION
-
-            for legacy in skill_info.get("legacy_aliases", []):
-                legacy_lower = str(legacy).lower()
-                if legacy_lower and _mentions_phrase(query_lower, legacy_lower):
-                    score += _DOMAIN_SCORE_LEGACY_ALIAS_MENTION
-
-            description = str(skill_info.get("description", "")).lower()
-            overlap = query_tokens & _tokenize(description)
-            score += (
-                min(len(overlap), _DOMAIN_SCORE_DESCRIPTION_OVERLAP_CAP)
-                * _DOMAIN_SCORE_DESCRIPTION_OVERLAP_PER_TOKEN
-            )
-
-            keyword_score, _ = _score_trigger_keyword_matches(
-                query_lower,
-                skill_info.get("trigger_keywords", []),
-                limit=_DOMAIN_SCORE_TRIGGER_KEYWORD_LIMIT,
-            )
-            score += keyword_score
-
-        domain_name = str(info.get("name", domain)).lower()
-        if domain_name in query_lower or domain.lower() in query_lower:
-            score += _DOMAIN_SCORE_DOMAIN_NAME_MATCH
-
-        if score > best_score:
-            best_score = score
-            best_domain = domain
-
-    return best_domain
-
-
-def _collect_query_keyword_matches(
-    registry: OmicsRegistry,
-    domain: str | None,
-    query_lower: str,
-) -> dict[str, list[str]]:
-    """Precompute ``{alias: [matched_keywords]}`` for the query.
-
-    Uses ``registry.build_keyword_map()`` so each (keyword → skill) entry is
-    inspected at most once per resolve call, instead of iterating every
-    skill's trigger keywords from inside ``_candidate_score``. The matcher
-    is still ``_mentions_phrase`` so behavior matches the previous
-    implementation byte-for-byte; this only avoids redundant lookups.
-    """
-    keyword_map = registry.build_keyword_map(domain=domain)
-    matches_by_alias: dict[str, list[str]] = {}
-    for keyword, alias in keyword_map.items():
-        phrase = str(keyword).strip().lower()
-        if not phrase or not _mentions_phrase(query_lower, phrase):
-            continue
-        bucket = matches_by_alias.setdefault(alias, [])
-        if len(bucket) < _SCORE_TRIGGER_KEYWORD_LIMIT:
-            bucket.append(phrase)
-    return matches_by_alias
+    for d, s in domain_scores.items():
+        if s > best_score:
+            best_score = s
+            best_domain = d
+    return best_domain, candidates
 
 
 def _candidate_score(
@@ -613,9 +659,24 @@ def resolve_capability(
         )
 
     query_lower = query.lower()
-    query_tokens = _tokenize(query_lower)
-    method_tokens = _method_mentions(query_lower)
-    domain = _detect_domain(registry, query, file_path=file_path, domain_hint=domain_hint)
+
+    # Domain detection + per-skill candidate scoring share a single walk
+    # over ``iter_primary_skills`` (OMI-12 audit P1 #1) — the pre-refactor
+    # code visited each skill twice with different weights for what was
+    # effectively the same set of SKILL.md reads.
+    if domain_hint:
+        domain = domain_hint
+        # When the caller forces a domain, we still need candidate scores
+        # for that domain; do the single-pass scoring and discard the
+        # detection result.
+        _, all_candidates = _score_skills_and_detect_domain(
+            registry, query, file_path=file_path
+        )
+    else:
+        domain, all_candidates = _score_skills_and_detect_domain(
+            registry, query, file_path=file_path
+        )
+
     if _requests_new_literature_implementation(query_lower):
         return CapabilityDecision(
             query=query,
@@ -632,25 +693,14 @@ def resolve_capability(
             ],
         )
 
-    # Precompute keyword matches once via the registry's inverted keyword
-    # index — capability_resolver used to rescan every skill's
-    # ``trigger_keywords`` from inside the per-skill loop (OMI-12 P2.8).
-    keyword_matches_by_alias = _collect_query_keyword_matches(
-        registry, domain or None, query_lower
-    )
-
-    candidates: list[CapabilityCandidate] = []
-    for alias, info in registry.iter_primary_skills(domain=domain or None):
-        candidate = _candidate_score(
-            alias,
-            info,
-            query_lower,
-            query_tokens,
-            method_tokens,
-            keyword_matches=keyword_matches_by_alias.get(alias, []),
-        )
-        if candidate is not None:
-            candidates.append(candidate)
+    # Filter the precomputed candidates to the detected domain — same
+    # restriction the pre-refactor ``iter_primary_skills(domain=...)`` loop
+    # applied; we just compute candidates for every domain up front so the
+    # walk happens once.
+    if domain:
+        candidates = [c for c in all_candidates if c.domain == domain]
+    else:
+        candidates = list(all_candidates)
 
     # Sort by score DESC with a stable alphabetical tie-break on the skill
     # alias. Without the tie-break, the post-PR audit caught WGCNA flapping
@@ -671,6 +721,16 @@ def resolve_capability(
         missing = ["no existing OmicsClaw skill sufficiently matches the requested task"]
         if web_requested:
             missing.append("request explicitly asks for external literature or documentation lookup")
+        # OMI-12 audit P1 #3: ``should_search_web`` used to be hard-coded
+        # ``True`` for every ``no_skill`` outcome. That defaulted the bot's
+        # LLM tool-use loop into a web-search step even when the user asked
+        # a perfectly normal omics question that just didn't match any
+        # currently-registered skill ("do PCA on my data, no skill needed"
+        # → False is correct). Now the flag fires only when the query
+        # explicitly mentions web/literature wording (the ``_WEB_HINTS``
+        # corpus is in this file). The literature-from-paper branch above
+        # still sets it ``True`` directly because that path is the explicit
+        # "go look up external literature" case.
         return CapabilityDecision(
             query=query,
             domain=domain,
@@ -683,7 +743,7 @@ def resolve_capability(
                     _RESOLVE_NO_SKILL_CONFIDENCE_CAP,
                 )
             ),
-            should_search_web=True,
+            should_search_web=web_requested,
             should_create_skill=skill_creation_requested,
             skill_candidates=candidates[:5],
             missing_capabilities=missing,

--- a/tests/fixtures/golden_routing/snapshot.json
+++ b/tests/fixtures/golden_routing/snapshot.json
@@ -18,7 +18,7 @@
           "score": 1.7
         },
         {
-          "skill": "spatial-de",
+          "skill": "spatial-annotate",
           "score": 0.85
         }
       ]
@@ -140,19 +140,19 @@
       "chosen_skill": "",
       "coverage": "no_skill",
       "domain": "bulkrna",
-      "should_search_web": true,
+      "should_search_web": false,
       "should_create_skill": false,
       "top_3_candidates": [
-        {
-          "skill": "bulkrna-survival",
-          "score": 2.55
-        },
         {
           "skill": "bulkrna-de",
           "score": 2.55
         },
         {
           "skill": "bulkrna-deconvolution",
+          "score": 2.55
+        },
+        {
+          "skill": "bulkrna-splicing",
           "score": 2.55
         }
       ]
@@ -171,11 +171,11 @@
           "score": 4.7
         },
         {
-          "skill": "sc-cytotrace",
+          "skill": "sc-cell-communication",
           "score": 1.7
         },
         {
-          "skill": "sc-markers",
+          "skill": "sc-clustering",
           "score": 1.7
         }
       ]
@@ -240,7 +240,7 @@
           "score": 2.55
         },
         {
-          "skill": "bulkrna-trajblend",
+          "skill": "bulkrna-qc",
           "score": 2.55
         }
       ]
@@ -286,7 +286,7 @@
           "score": 2.35
         },
         {
-          "skill": "genomics-variant-calling",
+          "skill": "genomics-phasing",
           "score": 1.7
         }
       ]
@@ -309,7 +309,7 @@
           "score": 2.35
         },
         {
-          "skill": "proteomics-structural",
+          "skill": "proteomics-data-import",
           "score": 0.85
         }
       ]
@@ -390,7 +390,7 @@
           "score": 1.7
         },
         {
-          "skill": "spatial-de",
+          "skill": "spatial-annotate",
           "score": 0.85
         }
       ]

--- a/tests/test_capability_resolver.py
+++ b/tests/test_capability_resolver.py
@@ -77,6 +77,87 @@ def test_validate_custom_analysis_code_allows_basic_analysis():
     assert issues == []
 
 
+def test_resolve_capability_no_skill_fallback_defaults_should_search_web_to_false():
+    """``should_search_web`` used to be hard-coded ``True`` on every
+    ``no_skill`` outcome, defaulting the bot's LLM tool-use loop into a
+    web-search step even when the query had no web/literature wording.
+    After OMI-12 audit P1 #3 the flag only fires when ``_WEB_HINTS``
+    matches (or the request is the explicit "implement from literature"
+    case, handled by ``_requests_new_literature_implementation``).
+    """
+    # An omics-shaped query that doesn't match any skill (single-cell
+    # doublet detection — the resolver lacks a strong-signal skill, so it
+    # falls through to no_skill). No web/literature wording → False.
+    decision = resolve_capability(
+        "Detect doublets in my single-cell data using scDblFinder"
+    )
+    assert decision.coverage == "no_skill"
+    assert decision.should_search_web is False
+
+
+def test_resolve_capability_no_skill_with_web_hints_still_searches_web():
+    """The flip in the test above must NOT mute the path the user actually
+    asked for web search on. Adding ``documentation`` / ``latest`` /
+    ``literature`` / etc. to an omics-shaped no_skill query reverts the
+    flag to ``True``.
+    """
+    decision = resolve_capability(
+        "Detect doublets in my single-cell data; check the latest documentation about scDblFinder"
+    )
+    assert decision.coverage == "no_skill"
+    assert decision.should_search_web is True
+
+
+def test_resolve_capability_literature_implementation_still_searches_web():
+    """The "implement a new method from latest literature" path is
+    independent of ``_WEB_HINTS`` — it has its own explicit branch (via
+    ``_requests_new_literature_implementation``) and must keep
+    ``should_search_web=True``.
+    """
+    decision = resolve_capability(
+        "Implement a hidden Markov model for chromatin state transition analysis from latest literature"
+    )
+    assert decision.coverage == "no_skill"
+    assert decision.should_search_web is True
+
+
+def test_score_skills_and_detect_domain_visits_each_skill_once():
+    """The pre-refactor resolver walked ``iter_primary_skills`` twice for
+    every chat turn — once in ``_detect_domain``, once in
+    ``resolve_capability``. The single-pass helper introduced in
+    OMI-12 audit P1 #1 must visit each skill exactly one time per call.
+
+    Asserted by monkey-patching ``iter_primary_skills`` to count calls.
+    """
+    from omicsclaw.core import capability_resolver as cr
+
+    real_registry = cr.ensure_registry_loaded()
+    call_counts: list[int] = []
+    real_iter = real_registry.__class__.iter_primary_skills
+
+    def counting_iter(self, domain=None):
+        items = real_iter(self, domain=domain)
+        call_counts.append(len(items))
+        return items
+
+    # Patch the bound method on the singleton.
+    original = real_registry.iter_primary_skills
+    real_registry.iter_primary_skills = counting_iter.__get__(real_registry)
+    try:
+        cr.resolve_capability("preprocess my Visium spatial transcriptomics dataset")
+    finally:
+        real_registry.iter_primary_skills = original
+
+    # One scoring pass over every primary skill — no domain filter inside
+    # ``_score_skills_and_detect_domain``; the per-domain filter happens
+    # on the precomputed candidate list, not via a second walk.
+    assert len(call_counts) == 1, (
+        f"resolve_capability invoked iter_primary_skills {len(call_counts)} "
+        f"times (per-call sizes={call_counts}); the post-refactor flow must "
+        f"call it exactly once."
+    )
+
+
 def test_resolve_capability_breaks_score_ties_alphabetically():
     """The candidate sort must tie-break on the canonical alias so the same
     query produces the same ``chosen_skill`` regardless of which order


### PR DESCRIPTION
## Summary
Two related routing-layer cleanups from the OMI-12 audit, bundled because the second one's snapshot diff is easier to read against the first one's refactor:

### 🟡 P1 #1 — Single iter over skills

Pre-refactor `resolve_capability` walked `iter_primary_skills` twice every chat turn:

1. `_detect_domain` iterated all 89 skills with the `_DOMAIN_SCORE_*` weights.
2. `resolve_capability` then iterated the same skills again with the `_SCORE_*` weights to populate candidates.

Both reads touched the same SKILL.md fields (alias, legacy aliases, description tokens, trigger keywords). The duplicate work is now folded into a single helper, `_score_skills_and_detect_domain`, which:

- accumulates both score sets in one pass,
- scans each skill's `trigger_keywords` exactly once and feeds both sides (candidate limit 3 / domain limit 2),
- returns `(detected_domain, candidates)`.

`resolve_capability` filters the precomputed candidate list to the detected domain instead of re-walking the registry. `_detect_domain` survives as a thin wrapper for external callers that only need domain detection.

### Correctness fix surfaced by the refactor

The earlier `_collect_query_keyword_matches` helper called `registry.build_keyword_map(domain=...)` and inherited its **last-write-wins** semantics for shared keywords. When both scoring sides share a walk we'd have to call `build_keyword_map(domain=None)`, which silently dropped scores: a keyword shared by `bulkrna-de` and any later-inserted skill would only ever score for the later skill. The "Run differential expression on bulk RNA-seq counts with DESeq2" query lost ~3.8 points on `bulkrna-de` under that path (7.88 → 4.05 in an interim regen).

**Fix**: iterate each skill's own `trigger_keywords` directly inside the shared walk and reuse the match list on both sides. `_collect_query_keyword_matches` is now unreferenced and deleted.

### 🟡 P1 #3 — `should_search_web` default

`should_search_web=True` used to be hard-coded on every `no_skill` outcome, defaulting the bot's LLM tool-use loop into a web-search step even for an ordinary omics query that just didn't happen to match a skill.

**Fix**: in the `no_skill` fallback, set `should_search_web = web_requested` (i.e. only when `_WEB_HINTS` matched the query). The explicit `_requests_new_literature_implementation` branch keeps its `True` because that path explicitly asked for external literature.

### Golden snapshot regen
- `should_search_web: true → false` for the "Detect doublets in my single-cell data using scDblFinder" query (no web hints) — exactly the intended behavioural change.
- Top-3 candidate orderings for tied-score cases refreshed to alphabetical (the snapshot was stale from before PR #187's tie-break — the test never asserted on top-3 ordering so the stale data went unnoticed).

The single `chosen_skill` / `coverage` / `domain` / `should_search_web` / `should_create_skill` line that the test actually checks remains stable for every other query.

### 4 new regression tests
- `test_resolve_capability_no_skill_fallback_defaults_should_search_web_to_false`
- `test_resolve_capability_no_skill_with_web_hints_still_searches_web`
- `test_resolve_capability_literature_implementation_still_searches_web`
- `test_score_skills_and_detect_domain_visits_each_skill_once` — monkey-patches `iter_primary_skills` to count calls per turn; asserts exactly one call.

## Test plan
- [x] `pytest tests/test_capability_resolver*.py tests/test_routing*.py tests/test_auto_routing_disambiguation.py tests/test_bot_n_epochs_routing.py` — **52 passed, 1 skipped, 5 xfailed** (4 new tests pass).
- [x] `pytest tests/test_capability_resolver*.py tests/test_routing*.py tests/test_skill_runner_contract.py tests/test_runtime_*.py tests/test_registry.py tests/test_execution_*.py tests/test_bot_n_epochs_routing.py` — 118 passed, 4 skipped, 5 xfailed; 1 pre-existing env failure unrelated (`fastapi` missing).
- [x] `pytest tests/bot/test_skill_orchestration.py tests/test_metadata_roundtrip.py tests/test_bot_runner_contract.py tests/test_interactive_omicsclaw_actions.py` — 104 passed; same 4 pre-existing failures as `main`.
- [x] `python omicsclaw.py list` — 89 skills × 8 domains.

## Out of scope (remaining P1 backlog)
- **#2** Drop the `-9 → 0` SIGKILL heuristic in favour of skills writing `result.json.status` (half-day + 89-skill coordination).
- **#4** Converge `SkillRunnerExecutor` onto `SubprocessExecutor` (~1 day).

Both deserve their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined fallback behavior when no matching capability is found—web search is now disabled by default and only enabled for explicit requests or literature-based implementation tasks.

* **Tests**
  * Added regression tests for capability resolution and skill scoring logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->