### PR TITLE
refactor(executor): async-native SkillRunnerExecutor, drop asyncio.to_thread (OMI-12 audit P1 #4)

### DIFF
--- a/omicsclaw/core/runtime/async_subprocess_driver.py
+++ b/omicsclaw/core/runtime/async_subprocess_driver.py
@@ -1,0 +1,148 @@
+"""Async sibling of :mod:`subprocess_driver` for the executor path.
+
+OMI-12 audit P1 #4: ``SkillRunnerExecutor`` used to wrap the blocking
+``run_skill`` call in ``asyncio.to_thread``, which parked one
+ThreadPoolExecutor worker per active skill. With the default 32-worker
+pool, a busy app-server running long skills (velocity, pseudotime, …)
+could exhaust the pool and stall unrelated async work.
+
+This module replaces that thread-blocking path with a native
+``asyncio.create_subprocess_exec`` driver that exposes the same outcome
+shape as the sync ``drive_subprocess`` (a :class:`subprocess.CompletedProcess`
+with the status-field-aware return code logic from P1 #2). The sync
+driver stays in place for the CLI / bot / pipeline-runner paths that
+already run inside their own threads or processes; this driver is the
+async-native counterpart for callers that already live in an asyncio
+event loop.
+
+Behaviour parity with the sync driver:
+
+- ``start_new_session=True`` so cancellation can SIGTERM/SIGKILL the
+  whole process group, not just the leader.
+- Cancel path: ``asyncio.CancelledError`` raised on the awaiting task
+  flows into SIGTERM → wait ``_CANCEL_GRACE_SECONDS`` → SIGKILL → re-raise.
+- Status field / ``-9 → 0`` heuristic from :func:`read_result_status`
+  applies identically.
+
+Behaviour deltas vs the sync driver (small + documented):
+
+- Cancellation comes from ``asyncio.CancelledError`` rather than a
+  ``threading.Event`` poll loop. asyncio cancellation is decisive; we
+  never reclassify a cancelled run as success regardless of any partial
+  ``status: ok`` left on disk.
+- Per-line ``stdout_callback`` / ``stderr_callback`` are not supported
+  here — the executor sink writes the aggregated output to
+  ``ctx.stdout_log`` after the process exits. The bot path that needs
+  per-line streaming continues to use the sync ``run_skill`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+from omicsclaw.common.report import read_result_status
+
+
+_CANCEL_GRACE_SECONDS = 5.0
+
+
+async def _read_stream(stream: asyncio.StreamReader | None) -> bytes:
+    if stream is None:
+        return b""
+    return await stream.read()
+
+
+async def _terminate_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGTERM the child's process group, wait for the grace period, then SIGKILL.
+
+    Mirrors the sync driver's cancel watcher. ``start_new_session=True``
+    at spawn time means the child is its own process-group leader, so
+    ``os.killpg`` reaches every grandchild — important for skills that
+    fork workers (multiprocessing, joblib, …).
+    """
+    if proc.returncode is not None:
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError, OSError):
+        return
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        return
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_CANCEL_GRACE_SECONDS)
+    except asyncio.TimeoutError:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        try:
+            await proc.wait()
+        except Exception:
+            pass
+
+
+async def adrive_subprocess(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    out_dir: Path,
+) -> subprocess.CompletedProcess:
+    """Spawn ``cmd`` via ``asyncio.create_subprocess_exec``, return a
+    ``CompletedProcess`` with the same status-field / SIGKILL-heuristic
+    semantics as the sync :func:`drive_subprocess`.
+
+    Raises :class:`asyncio.CancelledError` when the awaiting task is
+    cancelled; the child's process group is SIGTERM'd (then SIGKILL'd
+    after the grace period) before the exception propagates.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd),
+        env=env,
+        start_new_session=True,
+    )
+
+    cancelled = False
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.gather(
+            _read_stream(proc.stdout),
+            _read_stream(proc.stderr),
+        )
+        await proc.wait()
+    except asyncio.CancelledError:
+        cancelled = True
+        await _terminate_process_group(proc)
+        raise
+    finally:
+        if not cancelled and proc.returncode is None:
+            # Defensive: any other exit path should still reap the child
+            # so a half-spawned process doesn't outlive the executor.
+            await _terminate_process_group(proc)
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    return_code = proc.returncode if proc.returncode is not None else -1
+
+    # Status field + ``-9 → 0`` fallback — same semantics as the sync
+    # driver. Cancellation never gets here (we re-raised above).
+    status = read_result_status(out_dir)
+    if status == "ok":
+        return_code = 0
+    elif status in ("partial", "failed"):
+        if return_code == 0:
+            return_code = 1
+    elif return_code == -9 and (out_dir / "result.json").exists():
+        return_code = 0
+
+    return subprocess.CompletedProcess(cmd, return_code, stdout, stderr)

--- a/omicsclaw/core/skill_runner.py
+++ b/omicsclaw/core/skill_runner.py
@@ -15,15 +15,17 @@ surface that needs to run a skill should import ``run_skill`` from here.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from omicsclaw.common.report import build_output_dir_name
 from omicsclaw.core.registry import ensure_registry_loaded, registry
@@ -33,6 +35,7 @@ from omicsclaw.core.runtime.argv_builder import (
     extract_flag_value,
     filter_forwarded_args,
 )
+from omicsclaw.core.runtime.async_subprocess_driver import adrive_subprocess
 from omicsclaw.core.runtime.output_finalize import (
     deduplicate_path,
     finalize_output_directory,
@@ -73,6 +76,195 @@ _build_user_run_command = build_user_run_command
 _deduplicate_path = deduplicate_path
 _finalize_output_directory = finalize_output_directory
 _write_pipeline_readme = write_pipeline_readme
+
+
+@dataclass(frozen=True)
+class _PreparedSkillRun:
+    """Everything ``run_skill`` / ``arun_skill`` need after setup, before spawn.
+
+    Carved out of ``run_skill`` so the sync (CLI / bot / pipeline) path and
+    the async executor path (OMI-12 audit P1 #4) can share the same
+    resolution, argv build, and output-finalize logic without duplicating
+    ~70 lines of bookkeeping. The two entry points differ only in *which*
+    subprocess driver they call (sync ``drive_subprocess`` vs async
+    ``adrive_subprocess``).
+    """
+
+    skill_name: str
+    skill_info: dict[str, Any]
+    script_path: Path
+    resolved_input: str | None
+    resolved_input_paths: list[str] | None
+    out_dir: Path
+    user_supplied_output_dir: bool
+    generated_ts: str
+    requested_method: str | None
+    cmd: list[str]
+    filtered_extra_args: list[str]
+    env: dict[str, str]
+    demo: bool
+    session_path: str | None
+
+
+def _prepare_skill_run(
+    skill_name: str,
+    *,
+    input_path: str | None,
+    input_paths: list[str] | None,
+    output_dir: str | None,
+    demo: bool,
+    session_path: str | None,
+    extra_args: list[str] | None,
+    log_banner: bool = True,
+) -> _PreparedSkillRun | SkillRunResult:
+    """Resolve skill, build argv, prepare output dir. Returns the prepared
+    run or a stable ``_err`` ``SkillRunResult`` on setup failure.
+
+    ``log_banner`` controls whether the human-readable "Running …" banner
+    prints; the async executor path keeps it silent because the jobs
+    router has its own log stream.
+    """
+    skills = ensure_registry_loaded().skills
+    skill_info = skills.get(skill_name)
+    if skill_info is None:
+        return _err(skill_name, f"Unknown skill '{skill_name}'. Available: {list(skills.keys())}")
+
+    script_path: Path = skill_info["script"]
+    if not script_path.exists():
+        return _err(skill_name, f"Script not found: {script_path}")
+
+    resolved_input_paths: list[str] | None = None
+    if input_paths and len(input_paths) >= 2:
+        resolved_input_paths = [str(Path(p).resolve()) for p in input_paths]
+
+    resolved_input = input_path
+    if session_path and not input_path and not demo and not resolved_input_paths:
+        from omicsclaw.common.session import SpatialSession
+
+        session = SpatialSession.load(session_path)
+        if session.h5ad_path:
+            resolved_input = session.h5ad_path
+
+    if resolved_input:
+        resolved_input = str(Path(resolved_input).resolve())
+
+    user_supplied_output_dir = output_dir is not None
+    generated_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    requested_method = extract_flag_value(extra_args, "--method")
+
+    if output_dir:
+        out_dir = Path(output_dir).resolve()
+    else:
+        auto_name = build_output_dir_name(skill_name, generated_ts, method=requested_method)
+        out_dir = deduplicate_path(DEFAULT_OUTPUT_ROOT / auto_name)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = build_skill_argv(
+        python_executable=PYTHON,
+        script_path=script_path,
+        skill_info=skill_info,
+        demo=demo,
+        input_path=resolved_input,
+        input_paths=resolved_input_paths,
+        output_dir=out_dir,
+    )
+    if cmd is None:
+        return _err(skill_name, "No --input, --demo, or --session provided.")
+
+    if log_banner:
+        domain = skill_info.get("domain", "unknown")
+        domain_display = registry.domains.get(domain, {}).get("name", domain.title())
+        if demo:
+            mode_str = f"{CYAN}demo mode{RESET}"
+        elif resolved_input_paths:
+            mode_str = f"inputs: {', '.join(resolved_input_paths)}"
+        else:
+            mode_str = f"input: {resolved_input}"
+        print(f"\n{BOLD}Running {domain_display} skill:{RESET} {GREEN}{skill_name}{RESET} ({mode_str})")
+        print(f"{BOLD}Output:{RESET} {out_dir}\n")
+
+    filtered = filter_forwarded_args(
+        extra_args,
+        allowed_extra_flags=skill_info.get("allowed_extra_flags", set()),
+    )
+    cmd.extend(filtered)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(OMICSCLAW_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+
+    return _PreparedSkillRun(
+        skill_name=skill_name,
+        skill_info=skill_info,
+        script_path=script_path,
+        resolved_input=resolved_input,
+        resolved_input_paths=resolved_input_paths,
+        out_dir=out_dir,
+        user_supplied_output_dir=user_supplied_output_dir,
+        generated_ts=generated_ts,
+        requested_method=requested_method,
+        cmd=cmd,
+        filtered_extra_args=filtered,
+        env=env,
+        demo=demo,
+        session_path=session_path,
+    )
+
+
+def _finalize_skill_run(
+    prepared: _PreparedSkillRun,
+    proc: subprocess.CompletedProcess,
+    duration: float,
+) -> SkillRunResult:
+    """Run output finalization, build a ``SkillRunResult``, store session.
+
+    Shared between the sync ``run_skill`` and the async ``arun_skill`` so
+    success / failure shape stays identical regardless of which subprocess
+    driver fired.
+    """
+    final_out_dir = prepared.out_dir
+    actual_method = prepared.requested_method
+    readme_path = ""
+    notebook_path = ""
+    if proc.returncode == 0:
+        user_command = build_user_run_command(
+            skill_name=prepared.skill_name,
+            demo=prepared.demo,
+            input_path=prepared.resolved_input,
+            output_dir=prepared.out_dir,
+            forwarded_args=prepared.filtered_extra_args,
+        )
+        final_out_dir, actual_method, readme_path, notebook_path, _ = finalize_output_directory(
+            prepared.out_dir,
+            skill_name=prepared.skill_name,
+            skill_info=prepared.skill_info,
+            timestamp=prepared.generated_ts,
+            user_supplied_output_dir=prepared.user_supplied_output_dir,
+            preferred_method=prepared.requested_method,
+            actual_command=user_command,
+        )
+
+    output_files = sorted(
+        [path.name for path in final_out_dir.rglob("*") if path.is_file()]
+    ) if final_out_dir.exists() else []
+
+    result = build_skill_run_result(
+        skill=prepared.skill_name,
+        success=proc.returncode == 0,
+        exit_code=proc.returncode,
+        output_dir=final_out_dir,
+        files=output_files,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        duration_seconds=duration,
+        method=actual_method,
+        readme_path=readme_path,
+        notebook_path=notebook_path,
+    )
+
+    if prepared.session_path and result.success:
+        _store_result_in_session(prepared.session_path, prepared.skill_name, final_out_dir)
+
+    return result
 
 
 def resolve_skill_alias(skill_name: str) -> str:
@@ -145,79 +337,25 @@ def run_skill(
         if pipeline_result is not None:
             return pipeline_result
 
-    skills = ensure_registry_loaded().skills
-    skill_info = skills.get(skill_name)
-    if skill_info is None:
-        return _err(skill_name, f"Unknown skill '{skill_name}'. Available: {list(skills.keys())}")
-
-    script_path: Path = skill_info["script"]
-    if not script_path.exists():
-        return _err(skill_name, f"Script not found: {script_path}")
-
-    resolved_input_paths: list[str] | None = None
-    if input_paths and len(input_paths) >= 2:
-        resolved_input_paths = [str(Path(p).resolve()) for p in input_paths]
-
-    resolved_input = input_path
-    if session_path and not input_path and not demo and not resolved_input_paths:
-        from omicsclaw.common.session import SpatialSession
-
-        session = SpatialSession.load(session_path)
-        if session.h5ad_path:
-            resolved_input = session.h5ad_path
-
-    if resolved_input:
-        resolved_input = str(Path(resolved_input).resolve())
-
-    user_supplied_output_dir = output_dir is not None
-    generated_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    requested_method = extract_flag_value(extra_args, "--method")
-
-    if output_dir:
-        out_dir = Path(output_dir).resolve()
-    else:
-        auto_name = build_output_dir_name(skill_name, generated_ts, method=requested_method)
-        out_dir = deduplicate_path(DEFAULT_OUTPUT_ROOT / auto_name)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    cmd = build_skill_argv(
-        python_executable=PYTHON,
-        script_path=script_path,
-        skill_info=skill_info,
+    prepared = _prepare_skill_run(
+        skill_name,
+        input_path=input_path,
+        input_paths=input_paths,
+        output_dir=output_dir,
         demo=demo,
-        input_path=resolved_input,
-        input_paths=resolved_input_paths,
-        output_dir=out_dir,
+        session_path=session_path,
+        extra_args=extra_args,
     )
-    if cmd is None:
-        return _err(skill_name, "No --input, --demo, or --session provided.")
-
-    domain = skill_info.get("domain", "unknown")
-    domain_display = registry.domains.get(domain, {}).get("name", domain.title())
-    if demo:
-        mode_str = f"{CYAN}demo mode{RESET}"
-    elif resolved_input_paths:
-        mode_str = f"inputs: {', '.join(resolved_input_paths)}"
-    else:
-        mode_str = f"input: {resolved_input}"
-    print(f"\n{BOLD}Running {domain_display} skill:{RESET} {GREEN}{skill_name}{RESET} ({mode_str})")
-    print(f"{BOLD}Output:{RESET} {out_dir}\n")
-
-    filtered = filter_forwarded_args(
-        extra_args,
-        allowed_extra_flags=skill_info.get("allowed_extra_flags", set()),
-    )
-    cmd.extend(filtered)
+    if isinstance(prepared, SkillRunResult):
+        return prepared
 
     t0 = time.time()
     try:
-        env = os.environ.copy()
-        env["PYTHONPATH"] = str(OMICSCLAW_DIR) + os.pathsep + env.get("PYTHONPATH", "")
         proc = drive_subprocess(
-            cmd,
-            cwd=script_path.parent,
-            env=env,
-            out_dir=out_dir,
+            prepared.cmd,
+            cwd=prepared.script_path.parent,
+            env=prepared.env,
+            out_dir=prepared.out_dir,
             stdout_callback=stdout_callback,
             stderr_callback=stderr_callback,
             cancel_event=cancel_event,
@@ -227,51 +365,85 @@ def run_skill(
         return _err(skill_name, str(exc), duration=duration)
 
     duration = time.time() - t0
+    return _finalize_skill_run(prepared, proc, duration)
 
-    final_out_dir = out_dir
-    actual_method = requested_method
-    readme_path = ""
-    notebook_path = ""
-    if proc.returncode == 0:
-        user_command = build_user_run_command(
-            skill_name=skill_name,
-            demo=demo,
-            input_path=resolved_input,
-            output_dir=out_dir,
-            forwarded_args=filtered,
-        )
-        final_out_dir, actual_method, readme_path, notebook_path, _ = finalize_output_directory(
-            out_dir,
-            skill_name=skill_name,
-            skill_info=skill_info,
-            timestamp=generated_ts,
-            user_supplied_output_dir=user_supplied_output_dir,
-            preferred_method=requested_method,
-            actual_command=user_command,
-        )
 
-    output_files = sorted(
-        [path.name for path in final_out_dir.rglob("*") if path.is_file()]
-    ) if final_out_dir.exists() else []
+async def arun_skill(
+    skill_name: str,
+    *,
+    input_path: str | None = None,
+    input_paths: list[str] | None = None,
+    output_dir: str | None = None,
+    demo: bool = False,
+    session_path: str | None = None,
+    extra_args: list[str] | None = None,
+) -> SkillRunResult:
+    """Async sibling of :func:`run_skill` for callers already in an event loop.
 
-    result = build_skill_run_result(
-        skill=skill_name,
-        success=proc.returncode == 0,
-        exit_code=proc.returncode,
-        output_dir=final_out_dir,
-        files=output_files,
-        stdout=proc.stdout,
-        stderr=proc.stderr,
-        duration_seconds=duration,
-        method=actual_method,
-        readme_path=readme_path,
-        notebook_path=notebook_path,
+    OMI-12 audit P1 #4: ``SkillRunnerExecutor`` used to wrap the blocking
+    ``run_skill`` in ``asyncio.to_thread``, which parked one
+    ``ThreadPoolExecutor`` worker for every active skill. With the default
+    32-worker pool, busy app-server traffic could exhaust the pool and
+    stall unrelated async work. This async-native entry point spawns the
+    skill subprocess via :func:`asyncio.create_subprocess_exec` instead,
+    so concurrent skills only cost one async task each, not one OS thread.
+
+    Behavior parity with ``run_skill``:
+
+    - Same skill resolution, argv build, env (``PYTHONPATH``), cwd
+      (script's parent dir), and output-finalize logic (rename, README,
+      notebook) — they share ``_prepare_skill_run`` and
+      ``_finalize_skill_run``.
+    - Same status-field + ``-9 → 0`` fallback for deciding success.
+    - Same ``SkillRunResult`` return shape.
+
+    Behavior deltas (documented):
+
+    - Pipeline dispatch (``<name>-pipeline``) is **not** handled here.
+      The async path is meant for the executor (one skill at a time);
+      pipelines run via the sync ``run_skill`` from CLI / bot.
+    - ``stdout_callback`` / ``stderr_callback`` are not supported.
+      Per-line log streaming stays on the sync path that the bot uses.
+    - Cancellation flows via :class:`asyncio.CancelledError` instead of
+      a ``threading.Event`` — propagating the cancel through the
+      awaiting task is enough; the underlying
+      :func:`omicsclaw.core.runtime.async_subprocess_driver.adrive_subprocess`
+      SIGTERM/SIGKILLs the process group on its way out.
+    """
+    skill_name = resolve_skill_alias(skill_name)
+
+    prepared = _prepare_skill_run(
+        skill_name,
+        input_path=input_path,
+        input_paths=input_paths,
+        output_dir=output_dir,
+        demo=demo,
+        session_path=session_path,
+        extra_args=extra_args,
+        log_banner=False,
     )
+    if isinstance(prepared, SkillRunResult):
+        return prepared
 
-    if session_path and result.success:
-        _store_result_in_session(session_path, skill_name, final_out_dir)
+    t0 = time.time()
+    try:
+        proc = await adrive_subprocess(
+            prepared.cmd,
+            cwd=prepared.script_path.parent,
+            env=prepared.env,
+            out_dir=prepared.out_dir,
+        )
+    except asyncio.CancelledError:
+        # Re-raise so the awaiting task sees the cancellation. The driver
+        # already SIGTERM/SIGKILL'd the process group on its way out, so
+        # no child is left behind.
+        raise
+    except Exception as exc:
+        duration = time.time() - t0
+        return _err(skill_name, str(exc), duration=duration)
 
-    return result
+    duration = time.time() - t0
+    return _finalize_skill_run(prepared, proc, duration)
 
 
 def _store_result_in_session(session_path: str, skill_name: str, out_dir: Path) -> None:

--- a/omicsclaw/execution/executors/default.py
+++ b/omicsclaw/execution/executors/default.py
@@ -1,9 +1,16 @@
 """Default job executor wiring.
 
 The default local app/remote executor calls the shared
-``omicsclaw.core.skill_runner.run_skill`` contract directly. The legacy
-``default_command_factory`` remains available for external process executors
-such as SSH/Slurm wrappers that still need CLI argv.
+``omicsclaw.core.skill_runner.arun_skill`` contract — the async-native
+sibling of ``run_skill`` introduced in OMI-12 audit P1 #4. The previous
+``await asyncio.to_thread(run_skill)`` wrapping was the culprit behind
+ThreadPoolExecutor exhaustion under multi-user load (one parked worker
+per long-running skill); the async path spawns via
+``asyncio.create_subprocess_exec`` instead so concurrent skills only
+cost one event-loop task each.
+
+The legacy ``default_command_factory`` remains available for external
+process executors such as SSH/Slurm wrappers that still need CLI argv.
 
 Mapping from wire contract (``JobContext.inputs`` + ``JobContext.params``)
 to runner kwargs or CLI argv:
@@ -25,7 +32,6 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-import threading
 from pathlib import Path
 from typing import Any
 
@@ -88,19 +94,28 @@ def _params_to_extra_args(params: dict[str, Any]) -> list[str]:
 
 
 class SkillRunnerExecutor:
-    """Executor that invokes the shared in-process skill runner."""
+    """Executor that invokes the shared in-process skill runner.
+
+    Runs via ``omicsclaw.core.skill_runner.arun_skill`` (async-native) so
+    concurrent jobs cost one event-loop task each, not one parked
+    ``ThreadPoolExecutor`` worker per long-running skill — see OMI-12
+    audit P1 #4 for the original thread-pool-exhaustion regression.
+    """
 
     async def run(self, ctx: JobContext) -> JobOutcome:
+        # Late import so callers / tests that monkeypatch
+        # ``omicsclaw.core.skill_runner.arun_skill`` see the patched
+        # function at call time, the same way the previous
+        # ``run_skill`` monkeypatching worked.
         from omicsclaw.core import skill_runner
 
         input_path = ctx.inputs.get("input") or ctx.inputs.get("path")
         input_paths = ctx.inputs.get("inputs")
         demo = bool(ctx.inputs.get("demo"))
         extra_args = _params_to_extra_args(ctx.params)
-        cancel_event = threading.Event()
 
-        def _run() -> SkillRunResult:
-            return skill_runner.run_skill(
+        try:
+            run_result = await skill_runner.arun_skill(
                 ctx.skill,
                 input_path=str(input_path) if input_path else None,
                 input_paths=[str(item) for item in input_paths] if input_paths else None,
@@ -108,15 +123,11 @@ class SkillRunnerExecutor:
                 demo=demo,
                 session_path=str(ctx.inputs["session_path"]) if ctx.inputs.get("session_path") else None,
                 extra_args=extra_args or None,
-                cancel_event=cancel_event,
             )
-
-        try:
-            run_result = await asyncio.to_thread(_run)
         except asyncio.CancelledError:
-            # Forward asyncio cancellation to the worker thread / subprocess so
-            # the SIGTERM/SIGKILL path runs instead of leaking the child.
-            cancel_event.set()
+            # ``adrive_subprocess`` already SIGTERM/SIGKILL'd the process
+            # group before re-raising; just propagate so the jobs router
+            # records the cancelled-terminal state.
             raise
         except Exception as exc:
             text = f"skill_runner_failed: {exc}"

--- a/tests/test_async_subprocess_driver.py
+++ b/tests/test_async_subprocess_driver.py
@@ -1,0 +1,168 @@
+"""Tests for ``omicsclaw.core.runtime.async_subprocess_driver`` (OMI-12 audit P1 #4).
+
+The async driver replaces the ``asyncio.to_thread(run_skill)`` wrap that
+``SkillRunnerExecutor`` used to do — pin the four corners of its
+contract so a future "back to threads" change can't sneak in:
+
+1. Happy-path captures stdout + stderr separately and returns exit_code=0.
+2. ``-9 + result.json exists → 0`` legacy heuristic still fires (so
+   skills that don't yet emit ``status: ok`` keep behaving the same).
+3. ``status: ok`` overrides a non-zero exit code (the new P1 #2 contract
+   carries over).
+4. ``asyncio.CancelledError`` flows through and SIGTERMs the process
+   group — even when the child ignores SIGTERM, the grace-period
+   SIGKILL escalation closes the run promptly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from omicsclaw.core.runtime.async_subprocess_driver import adrive_subprocess
+
+
+def _write_script(tmp_path: Path, body: str) -> Path:
+    script = tmp_path / "fake_skill.py"
+    script.write_text(textwrap.dedent(body), encoding="utf-8")
+    return script
+
+
+def test_adrive_subprocess_captures_stdout_stderr_separately(tmp_path: Path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    script = _write_script(
+        tmp_path,
+        """
+        import sys
+        print("hello on stdout")
+        print("warning on stderr", file=sys.stderr)
+        """,
+    )
+    proc = asyncio.run(
+        adrive_subprocess(
+            [sys.executable, str(script)],
+            cwd=tmp_path,
+            env={},
+            out_dir=out_dir,
+        )
+    )
+    assert proc.returncode == 0
+    assert "hello on stdout" in proc.stdout
+    # stderr is captured separately — the executor merges them later when
+    # writing ``ctx.stdout_log``.
+    assert "warning on stderr" in proc.stderr
+
+
+def test_adrive_subprocess_keeps_minus_9_to_zero_heuristic(tmp_path: Path):
+    """When a skill exits via SIGKILL but already produced ``result.json``,
+    the driver classifies it as success — preserving the legacy heuristic
+    so the 89 skills that don't yet emit a status field don't regress."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # The script writes result.json then SIGKILLs itself so the runner
+    # observes exit code -9 with an existing envelope (no ``status``).
+    script = _write_script(
+        tmp_path,
+        f"""
+        import json, os, pathlib, signal
+        out = pathlib.Path({str(out_dir)!r})
+        (out / "result.json").write_text(json.dumps({{"skill": "stub"}}))
+        os.kill(os.getpid(), signal.SIGKILL)
+        """,
+    )
+    proc = asyncio.run(
+        adrive_subprocess(
+            [sys.executable, str(script)],
+            cwd=tmp_path,
+            env={},
+            out_dir=out_dir,
+        )
+    )
+    assert proc.returncode == 0, (
+        f"SIGKILL with existing result.json must map to success; got {proc.returncode}"
+    )
+
+
+def test_adrive_subprocess_honours_status_ok_over_non_zero_exit(tmp_path: Path):
+    """``status: ok`` short-circuits exit-code analysis — same semantics
+    the sync driver already exposes (OMI-12 P1 #2 carrying over)."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    script = _write_script(
+        tmp_path,
+        f"""
+        import json, pathlib, sys
+        out = pathlib.Path({str(out_dir)!r})
+        (out / "result.json").write_text(
+            json.dumps({{"skill": "stub", "status": "ok"}})
+        )
+        sys.exit(7)  # arbitrary non-zero
+        """,
+    )
+    proc = asyncio.run(
+        adrive_subprocess(
+            [sys.executable, str(script)],
+            cwd=tmp_path,
+            env={},
+            out_dir=out_dir,
+        )
+    )
+    assert proc.returncode == 0
+
+
+def test_adrive_subprocess_terminates_process_group_on_cancel(tmp_path: Path):
+    """``asyncio.CancelledError`` must propagate AND the child's process
+    group must die — including children that ignore SIGTERM (the
+    canonical "skill forked workers" case)."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Ignore SIGTERM so the driver has to escalate to the grace-period
+    # SIGKILL. Without process-group kill semantics this script would
+    # leak.
+    script = _write_script(
+        tmp_path,
+        """
+        import signal, time
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        # Sleep long enough that any successful cancel must be due to a
+        # forcible kill, not the script exiting on its own.
+        for _ in range(60):
+            time.sleep(0.5)
+        """,
+    )
+
+    async def driver() -> tuple[bool, float]:
+        cancelled = False
+        started = time.time()
+        task = asyncio.create_task(
+            adrive_subprocess(
+                [sys.executable, str(script)],
+                cwd=tmp_path,
+                env={},
+                out_dir=out_dir,
+            )
+        )
+        await asyncio.sleep(0.4)  # let the child install its SIGTERM handler
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            cancelled = True
+        return cancelled, time.time() - started
+
+    cancelled, elapsed = asyncio.run(driver())
+    assert cancelled, "adrive_subprocess must re-raise CancelledError"
+    # ``_CANCEL_GRACE_SECONDS`` is 5.0 — the child should be dead within
+    # roughly that grace + a bit of slack. Without SIGKILL escalation the
+    # script would sleep for 30s.
+    assert elapsed < 10.0, (
+        f"cancel did not kill the child within the grace period — "
+        f"elapsed {elapsed:.1f}s (expected < 10s)"
+    )

--- a/tests/test_execution_default_executor.py
+++ b/tests/test_execution_default_executor.py
@@ -151,9 +151,12 @@ def test_jobs_router_default_executor_is_skill_runner_executor() -> None:
     assert isinstance(jobs_module._DEFAULT_EXECUTOR, SkillRunnerExecutor)
 
 
-def test_skill_runner_executor_maps_job_context_to_run_skill(monkeypatch, tmp_path: Path) -> None:
+def test_skill_runner_executor_maps_job_context_to_arun_skill(monkeypatch, tmp_path: Path) -> None:
+    """OMI-12 audit P1 #4: the executor now invokes ``arun_skill`` directly
+    instead of wrapping the sync ``run_skill`` in ``asyncio.to_thread``. The
+    argument-forwarding contract is otherwise unchanged (minus
+    ``cancel_event``, which the async path doesn't need)."""
     import asyncio
-    import threading
 
     from omicsclaw.execution.executors import JobOutcome
     from omicsclaw.execution.executors.default import SkillRunnerExecutor
@@ -162,7 +165,7 @@ def test_skill_runner_executor_maps_job_context_to_run_skill(monkeypatch, tmp_pa
 
     from omicsclaw.core.skill_result import build_skill_run_result
 
-    def fake_run_skill(skill, **kwargs):
+    async def fake_arun_skill(skill, **kwargs):
         captured["skill"] = skill
         captured.update(kwargs)
         return build_skill_run_result(
@@ -174,7 +177,7 @@ def test_skill_runner_executor_maps_job_context_to_run_skill(monkeypatch, tmp_pa
             stderr="",
         )
 
-    monkeypatch.setattr("omicsclaw.core.skill_runner.run_skill", fake_run_skill)
+    monkeypatch.setattr("omicsclaw.core.skill_runner.arun_skill", fake_arun_skill)
 
     ctx = _make_ctx(
         tmp_path=tmp_path,
@@ -190,9 +193,6 @@ def test_skill_runner_executor_maps_job_context_to_run_skill(monkeypatch, tmp_pa
     assert "runner-ok" in outcome.stdout_text
     assert ctx.stdout_log.read_text(encoding="utf-8") == "runner-ok"
 
-    cancel_event = captured.pop("cancel_event")
-    assert isinstance(cancel_event, threading.Event)
-    assert not cancel_event.is_set()
     assert captured == {
         "skill": "literature",
         "input_path": None,
@@ -204,57 +204,90 @@ def test_skill_runner_executor_maps_job_context_to_run_skill(monkeypatch, tmp_pa
     }
 
 
-def test_skill_runner_executor_sets_cancel_event_on_asyncio_cancel(monkeypatch, tmp_path: Path) -> None:
-    """If the asyncio task running the executor is cancelled, the executor must
-    forward that cancellation to the runner by setting the ``cancel_event`` it
-    passed in. Otherwise the ``run_skill`` worker thread (and its subprocess)
-    would keep running after the user disconnected."""
+def test_skill_runner_executor_does_not_spawn_a_thread_pool_worker(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The whole point of OMI-12 audit P1 #4 is to keep concurrent skills
+    from parking ``ThreadPoolExecutor`` workers. If a future change
+    sneaks ``asyncio.to_thread(...)`` back in, this test must fail."""
     import asyncio
-    import threading
+
+    from omicsclaw.core.skill_result import build_skill_run_result
+    from omicsclaw.execution.executors.default import SkillRunnerExecutor
+
+    async def fake_arun_skill(skill, **_kwargs):
+        return build_skill_run_result(
+            skill=skill,
+            success=True,
+            exit_code=0,
+            output_dir=str(tmp_path / "artifacts"),
+            stdout="ok",
+        )
+
+    monkeypatch.setattr("omicsclaw.core.skill_runner.arun_skill", fake_arun_skill)
+
+    to_thread_calls: list[tuple] = []
+    original_to_thread = asyncio.to_thread
+
+    async def counting_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append((func, args, kwargs))
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", counting_to_thread)
+
+    ctx = _make_ctx(tmp_path=tmp_path, skill="literature", inputs={"demo": True})
+    asyncio.run(SkillRunnerExecutor().run(ctx))
+
+    assert to_thread_calls == [], (
+        f"SkillRunnerExecutor.run invoked asyncio.to_thread {len(to_thread_calls)} "
+        f"time(s); the async-native refactor must never block the default "
+        f"ThreadPoolExecutor: {to_thread_calls!r}"
+    )
+
+
+def test_skill_runner_executor_terminates_subprocess_on_asyncio_cancel(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """If the asyncio task running the executor is cancelled, the executor
+    must propagate ``CancelledError`` — and the underlying
+    ``adrive_subprocess`` is responsible for killing the process group
+    before the exception bubbles up. We assert the propagation here; the
+    SIGTERM/SIGKILL path is exercised in
+    ``test_async_subprocess_driver_terminates_process_group_on_cancel``."""
+    import asyncio
 
     from omicsclaw.execution.executors.default import SkillRunnerExecutor
 
-    captured_events: list[threading.Event] = []
+    arun_entered = asyncio.Event()
 
-    from omicsclaw.core.skill_result import build_skill_run_result
+    async def fake_arun_skill(_skill, **_kwargs):
+        arun_entered.set()
+        # Block until cancellation — the executor's await on us is the
+        # cancellation propagation surface we're testing.
+        await asyncio.sleep(60)
+        raise AssertionError("arun_skill was not cancelled")
 
-    def fake_run_skill(skill, **kwargs):
-        cancel_event = kwargs["cancel_event"]
-        captured_events.append(cancel_event)
-        # Block until the executor signals cancellation, with a safety timeout.
-        signaled = cancel_event.wait(timeout=10.0)
-        return build_skill_run_result(
-            skill=skill,
-            success=not signaled,
-            exit_code=137 if signaled else 0,
-            output_dir=str(tmp_path / "artifacts"),
-            stdout="",
-            stderr="cancelled" if signaled else "",
-        )
-
-    monkeypatch.setattr("omicsclaw.core.skill_runner.run_skill", fake_run_skill)
+    monkeypatch.setattr("omicsclaw.core.skill_runner.arun_skill", fake_arun_skill)
 
     ctx = _make_ctx(tmp_path=tmp_path, skill="literature", inputs={"demo": True})
 
+    cancelled = False
+
     async def driver() -> None:
+        nonlocal cancelled
         task = asyncio.create_task(SkillRunnerExecutor().run(ctx))
-        # Give the worker thread time to enter run_skill and capture the event.
-        for _ in range(50):
-            if captured_events:
-                break
-            await asyncio.sleep(0.02)
+        await asyncio.wait_for(arun_entered.wait(), timeout=5.0)
         task.cancel()
         try:
             await task
         except asyncio.CancelledError:
-            pass
+            cancelled = True
 
     asyncio.run(driver())
 
-    assert captured_events, "fake_run_skill was never invoked"
-    assert captured_events[0].is_set(), (
-        "cancel_event was not set when the executor's asyncio task was cancelled — "
-        "the underlying worker thread / subprocess would leak"
+    assert cancelled, (
+        "SkillRunnerExecutor.run did not propagate asyncio.CancelledError — "
+        "the jobs router relies on this to record the cancelled terminal state"
     )
 
 
@@ -265,7 +298,7 @@ def test_skill_runner_executor_normalizes_failed_zero_exit(monkeypatch, tmp_path
 
     from omicsclaw.core.skill_result import build_skill_run_result
 
-    def fake_run_skill(_skill, **_kwargs):
+    async def fake_arun_skill(_skill, **_kwargs):
         return build_skill_run_result(
             skill=_skill,
             success=False,
@@ -275,7 +308,7 @@ def test_skill_runner_executor_normalizes_failed_zero_exit(monkeypatch, tmp_path
             stderr="missing dependency",
         )
 
-    monkeypatch.setattr("omicsclaw.core.skill_runner.run_skill", fake_run_skill)
+    monkeypatch.setattr("omicsclaw.core.skill_runner.arun_skill", fake_arun_skill)
 
     ctx = _make_ctx(tmp_path=tmp_path, skill="literature", inputs={"demo": True})
     outcome = asyncio.run(SkillRunnerExecutor().run(ctx))


### PR DESCRIPTION
## Summary
OMI-12 audit 🟡 P1 #4 — last item in the post-P2.9 backlog. `SkillRunnerExecutor.run` used to do `await asyncio.to_thread(run_skill)`, which parks one `ThreadPoolExecutor` worker per active skill. Under multi-user app-server load with long-running skills (`velocity`, `pseudotime`, …) the default 32-worker pool can fill up and stall unrelated async work. This PR rewires the executor onto the same `asyncio.create_subprocess_exec` strategy that `SubprocessExecutor` already uses.

## What changes

| File | Change |
|---|---|
| `omicsclaw/core/runtime/async_subprocess_driver.py` | **New.** `adrive_subprocess` — async sibling of `drive_subprocess`. Same status-field + `-9 → 0` fallback semantics; `start_new_session=True` for process-group cancel; `asyncio.CancelledError` propagates after SIGTERM → grace → SIGKILL. |
| `omicsclaw/core/skill_runner.py` | Extracted `_prepare_skill_run` + `_finalize_skill_run` helpers so the sync `run_skill` and the new async `arun_skill` share the same skill resolution, argv build, env setup, and output-finalize logic. Added `arun_skill` as the async entry point. |
| `omicsclaw/execution/executors/default.py` | `SkillRunnerExecutor.run` now `await`s `arun_skill` directly. The blocking `_run` closure, the `asyncio.to_thread` wrap, and the `threading.Event` cancel-bridge are all gone. |

## What does NOT change

- The sync `run_skill` stays — CLI, bot, and pipeline-runner callers continue to use it. The bot's per-line `stdout_callback` / `stderr_callback` streaming flows through the sync subprocess driver as before.
- `_err`, `resolve_skill_alias`, pipeline dispatch (`<name>-pipeline`), and `SkillRunResult` return shape are preserved byte-for-byte.
- `JobOutcome` shape returned by `SkillRunnerExecutor` is unchanged — same `exit_code` / `error` / `stdout_text` fields.

## New tests

- **`tests/test_async_subprocess_driver.py` (4 tests)** — corner cases for `adrive_subprocess`:
  - stdout and stderr captured separately
  - legacy `-9 + result.json exists → 0` heuristic still fires
  - `status: ok` overrides a non-zero exit (P1 #2 contract preserved)
  - `asyncio.CancelledError` kills the process group even when the child ignores SIGTERM (the grace-period SIGKILL escalation closes the run within ~5s instead of leaking)
- **`tests/test_execution_default_executor.py`** — three existing tests rewritten to monkeypatch `arun_skill` instead of `run_skill` (no more `cancel_event` assertion since the async path doesn't need it). One **new** regression test counts `asyncio.to_thread` calls during `SkillRunnerExecutor.run` and fails if any sneak back in.

## Test plan
- [x] `pytest tests/test_async_subprocess_driver.py tests/test_execution_default_executor.py tests/test_execution_executors.py` — 20 passed, 1 skipped; 1 pre-existing env failure unrelated (`fastapi` missing).
- [x] Wider sweep across `tests/test_async_subprocess_driver.py tests/test_execution_*.py tests/test_skill_runner_contract.py tests/test_output_ux.py tests/test_result_status_contract.py tests/test_runtime_*.py tests/test_registry.py tests/test_capability_resolver*.py tests/test_routing_regression.py tests/test_bot_n_epochs_routing.py` — 132 passed, 2 skipped, 5 xfailed; 2 pre-existing env failures unrelated.
- [x] `pytest tests/bot/test_skill_orchestration.py tests/test_metadata_roundtrip.py tests/test_bot_runner_contract.py tests/test_interactive_omicsclaw_actions.py tests/test_autoagent_cli.py` — 107 passed; same 4 pre-existing failures as `main`.
- [x] `python omicsclaw.py list` — 89 skills × 8 domains.

## Backlog

This was the last item on the user's OMI-12 audit list (`P1 #4 SkillRunnerExecutor → async-native`). After this PR the original OMI-12 evaluation's P0/P1/P2 + audit-surfaced P0/P1 items are all landed:

- ✅ P0.1 stale `SKILLS` cache + P0.2 `import json` + P0.3 private-field poking (PR #181)
- ✅ P1.4 carve `run_skill` + P1.5 delete `LocalExecutor` (PR #182)
- ✅ P1.6 `run_skill` native `SkillRunResult` (PR #184)
- ✅ P2.7 YAML pipelines (PR #185)
- ✅ P2.8 documented weights + P2.9 golden routing snapshot (PR #186)
- ✅ Audit P0 WGCNA tie-break + bot dead branches (PR #187)
- ✅ Audit P1 #1 single iter + P1 #3 `should_search_web` default (PR #188)
- ✅ Audit P1 #2 `result.json` status contract (PR #189)
- ✅ Audit P1 #4 async-native executor (this PR)

P3 (structured event logs, per-skill timeout, embedding routing) was deferred at the user's request from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)