### PR TITLE
fix(oc-chat): surface actionable LLM-init diagnostics

### DIFF
--- a/bot/agent_loop.py
+++ b/bot/agent_loop.py
@@ -807,7 +807,13 @@ For more info: https://github.com/TianGzlab/OmicsClaw"""
 
     _ensure_system_prompt()
     if _core.llm is None:
-        return "Error: LLM client not initialised. Call core.init() first."
+        return (
+            "⚠ LLM is not configured.\n"
+            "\n"
+            "Set LLM_API_KEY (or OPENAI_API_KEY) in your environment or "
+            ".env file, then restart `oc chat`. To configure interactively, "
+            "run `oc onboard`."
+        )
 
     transcript_store.max_history = MAX_HISTORY
     transcript_store.max_history_chars = MAX_HISTORY_CHARS or None

--- a/omicsclaw/interactive/interactive.py
+++ b/omicsclaw/interactive/interactive.py
@@ -1395,6 +1395,12 @@ def _init_llm(config: dict) -> tuple[str, str]:
         return core.OMICSCLAW_MODEL, core.LLM_PROVIDER_NAME
     except Exception as e:
         logger.warning("LLM init error: %s", e)
+        console.print(
+            f"[yellow]⚠ LLM init failed:[/yellow] {e}\n"
+            "[yellow]Set [bold]LLM_API_KEY[/bold] (or [bold]OPENAI_API_KEY[/bold]) "
+            "in your environment or .env file, then restart `oc chat`.\n"
+            "To configure interactively, run [bold]oc onboard[/bold].[/yellow]"
+        )
         return os.environ.get("OMICSCLAW_MODEL", "unknown"), os.environ.get("LLM_PROVIDER", "")
 
 

--- a/tests/bot/test_agent_loop.py
+++ b/tests/bot/test_agent_loop.py
@@ -114,6 +114,41 @@ def test_extract_timeout_seconds_from_text_recognises_timeout_phrases():
     assert _extract_timeout_seconds_from_text(None) is None
 
 
+def test_llm_tool_loop_returns_actionable_message_when_llm_uninitialised():
+    """If ``bot.core.llm`` is ``None`` (e.g. ``oc chat`` started without an
+    API key), sending a message must return an actionable hint — naming
+    the env var to set and the onboard command — rather than the cryptic
+    ``Error: LLM client not initialised. Call core.init() first.`` that
+    blames the user for not running a function they cannot reach.
+    """
+    import asyncio
+    import bot.agent_loop as agent_loop
+    import bot.core as core
+
+    saved = core.llm
+    core.llm = None
+    try:
+        result = asyncio.run(
+            agent_loop.llm_tool_loop(
+                chat_id="__test_uninitialised__",
+                user_content="hi",
+            )
+        )
+    finally:
+        core.llm = saved
+
+    lower = result.lower()
+    assert "call core.init" not in lower, (
+        f"message still tells the user to call a private function: {result!r}"
+    )
+    assert "llm_api_key" in lower or "openai_api_key" in lower, (
+        f"message must name the env var to set: {result!r}"
+    )
+    assert "onboard" in lower, (
+        f"message must point at the onboard remediation: {result!r}"
+    )
+
+
 def test_format_llm_api_error_message_provides_actionable_text_for_common_errors():
     """When the OpenAI SDK raises, this formatter turns the exception into
     a user-facing message with hints (rate limit, auth, network). The

--- a/tests/test_interactive_llm_init_diagnostics.py
+++ b/tests/test_interactive_llm_init_diagnostics.py
@@ -1,0 +1,54 @@
+"""Tests for ``oc chat`` LLM-init diagnostics.
+
+When ``omicsclaw/interactive/interactive._init_llm`` fails to construct
+the LLM client — typically because the user is running ``oc chat`` before
+configuring an API key — the CLI must surface an actionable diagnostic
+inline. Logging a ``WARNING`` is not enough; the CLI logger config drops
+WARNING-level lines below the banner, so the user sees ``Model: unknown``
+and only learns the real cause after submitting their first prompt.
+
+These tests pin the user-visible contract — they do not constrain how
+the diagnostic is rendered (rich `console.print`, plain `print`, or
+`stderr.write` are all acceptable).
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_init_llm_surfaces_actionable_message_when_core_init_fails(
+    monkeypatch, capsys
+):
+    """If ``bot.core.init`` raises (e.g. ``OpenAIError: Missing credentials``),
+    ``_init_llm`` must print a user-visible diagnostic naming the env var
+    to set and the onboard remediation. The fallback ``(model, provider)``
+    return is still ``("unknown", ...)`` so the banner can keep rendering.
+    """
+    import omicsclaw.interactive.interactive as interactive
+
+    sys.path.insert(0, str(interactive._OMICSCLAW_DIR))
+    import bot.core as core
+
+    def _boom(**_kw):
+        raise core.OpenAIError(
+            "Missing credentials. Please pass an `api_key`, "
+            "`workload_identity`, `admin_api_key`, or set the "
+            "`OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable."
+        )
+
+    monkeypatch.setattr(core, "init", _boom)
+
+    model, _provider = interactive._init_llm({})
+
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+
+    assert "LLM_API_KEY" in output or "OPENAI_API_KEY" in output, (
+        f"diagnostic must name the env var to set; got: {output!r}"
+    )
+    assert "onboard" in output.lower(), (
+        f"diagnostic must point at the onboard remediation; got: {output!r}"
+    )
+    # Banner-render fallback contract preserved
+    assert model in ("unknown", "") or isinstance(model, str)


### PR DESCRIPTION
## Summary

`oc chat` had two layers of confusing UX when no API key is configured:

1. `_init_llm` in `omicsclaw/interactive/interactive.py` caught `OpenAIError` but only emitted a `WARNING` to the logger — the CLI logger config drops that below the banner, so the user saw `Model: unknown` with no actionable hint at startup.
2. After the user sent their first message, `bot/agent_loop.py` returned `Error: LLM client not initialised. Call core.init() first.` — a private-API instruction the user cannot act on.

## What changed

Both surfaces now tell the user exactly what to do:

- `_init_llm` adds a yellow `console.print` warning under the banner that names `LLM_API_KEY` / `OPENAI_API_KEY` and points at `oc onboard`.
- `llm_tool_loop` returns the same actionable text when `_core.llm is None` instead of the cryptic developer message.

## Tests

TDD red→green; one focused test per behaviour:

- `tests/bot/test_agent_loop.py::test_llm_tool_loop_returns_actionable_message_when_llm_uninitialised` — pins the return text and explicitly forbids `Call core.init` reappearing.
- `tests/test_interactive_llm_init_diagnostics.py::test_init_llm_surfaces_actionable_message_when_core_init_fails` (new file) — monkeypatches `core.init` to raise `OpenAIError`, calls `_init_llm({})`, asserts the user-visible output contains the env-var name and `onboard` hint.

## Test plan

- [x] `pytest tests/bot/test_agent_loop.py tests/test_interactive_llm_init_diagnostics.py` → 14 passed
- [x] `pytest -k 'interactive or agent_loop'` (excluding pre-existing pydantic-v2 collection errors that also fail on `main`) → 144 passed, 10 skipped, 0 failed
- [x] Live smoke: deleted `LLM_API_KEY` env var, stubbed `core.init` to raise `OpenAIError`, called `_init_llm({})` — the yellow diagnostic prints to stdout
- [x] Live smoke: set `core.llm = None` and called `llm_tool_loop` — returns the actionable hint, no `Call core.init` text

## Before / after

Before:
```
Model: unknown
❯ hi
Error: LLM client not initialised. Call core.init() first.
```

After:
```
⚠ LLM init failed: Missing credentials. ...
Set LLM_API_KEY (or OPENAI_API_KEY) in your environment or .env file,
then restart `oc chat`. To configure interactively, run `oc onboard`.
Model: deepseek-v4-pro
❯ hi
⚠ LLM is not configured.
Set LLM_API_KEY (or OPENAI_API_KEY) in your environment or .env file,
then restart `oc chat`. To configure interactively, run `oc onboard`.
```