### PR TITLE
fix(bot): clean up bot-core carve-out fallout (NameErrors + stale-reference + dead code)

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -570,7 +570,13 @@ def __getattr__(name: str):
     if name == "TOOL_RUNTIME":
         return get_tool_runtime()
     if name == "TOOLS":
-        return get_tools()
+        # ``get_tools`` lives in bot.agent_loop, which is reached lazily
+        # via _AGENT_LOOP_REEXPORTS below. Resolve through that path —
+        # a direct ``get_tools()`` call here raises NameError because
+        # the name was never imported at module scope.
+        import bot.agent_loop
+        value = bot.agent_loop.get_tools()
+        return value
     if name == "TOOL_EXECUTORS":
         return get_tool_executors()
     if name in _AGENT_LOOP_REEXPORTS:

--- a/bot/path_validation.py
+++ b/bot/path_validation.py
@@ -82,9 +82,13 @@ def _build_trusted_dirs() -> list[Path]:
 
 
 def _ensure_trusted_dirs():
-    global TRUSTED_DATA_DIRS
+    # Mutate in place — bot.core / bot.tool_executors / omicsclaw.app.server
+    # all import ``TRUSTED_DATA_DIRS`` by reference at module load time.
+    # A rebind here would leave those importers stuck on the original empty
+    # list, defeating the trusted-dir check (and silently breaking server.py's
+    # workspace.append() handshake).
     if not TRUSTED_DATA_DIRS:
-        TRUSTED_DATA_DIRS = _build_trusted_dirs()
+        TRUSTED_DATA_DIRS[:] = _build_trusted_dirs()
         logger.info(f"Trusted data dirs: {[str(d) for d in TRUSTED_DATA_DIRS]}")
 
 

--- a/bot/tool_executors.py
+++ b/bot/tool_executors.py
@@ -1303,7 +1303,6 @@ async def execute_make_directory(args: dict) -> str:
     ):
         dirs_str = ", ".join(str(d) for d in TRUSTED_DATA_DIRS)
         return f"Access denied: {target_path} is not in trusted directories ({dirs_str})"
-        target_path = DATA_DIR / target_path
 
     try:
         target_path.mkdir(parents=True, exist_ok=True)

--- a/bot/tool_executors.py
+++ b/bot/tool_executors.py
@@ -55,15 +55,33 @@ import bot.core as _core
 # is pulled in via re-export.
 from bot.core import (
     DATA_DIR,
+    DEEP_LEARNING_METHODS,
     EXAMPLES_DIR,
     OMICSCLAW_DIR,
+    OMICSCLAW_PY,
     OUTPUT_DIR,
+    _path_names,
     audit,
     get_skill_runner_python,
     pending_media,
     pending_preflight_requests,
     pending_text,
     received_files,
+)
+
+# Path-validation helpers carved out to bot.path_validation per ADR 0001.
+# Import directly (not via bot.core) since bot.core only re-exports them
+# *after* this module finishes loading — by the time these executors run,
+# the bot.core re-export has resolved but lookups inside execute_* bodies
+# resolve against this module's globals, not bot.core's.
+from bot.path_validation import (
+    TRUSTED_DATA_DIRS,
+    _ensure_trusted_dirs,
+    discover_file,
+    resolve_dest,
+    sanitize_filename,
+    validate_input_path,
+    validate_path,
 )
 
 from omicsclaw.common.report import build_output_dir_name
@@ -91,11 +109,13 @@ from bot.skill_orchestration import (
     _format_auto_disambiguation,
     _format_auto_route_banner,
     _format_next_steps,
+    _infer_skill_for_method,
     _lookup_skill_info,
     _normalize_extra_args,
     _read_result_json,
     _resolve_last_output_dir,
     _run_omics_skill_step,
+    _run_skill_via_shared_runner,
     _update_preprocessing_state,
     OutputMediaPaths,
 )
@@ -103,6 +123,7 @@ from omicsclaw.runtime.preflight.sc_batch import (
     _auto_prepare_sc_batch_integration,
     _maybe_require_batch_integration_workflow,
     _maybe_require_batch_key_selection,
+    _resolve_requested_batch_key,
 )
 
 logger = logging.getLogger("omicsclaw.bot.tool_executors")

--- a/omicsclaw/knowledge/registry.py
+++ b/omicsclaw/knowledge/registry.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/tests/bot/test_tool_executors.py
+++ b/tests/bot/test_tool_executors.py
@@ -272,3 +272,109 @@ def test_tool_executors_dispatch_table_lists_all_24_executors():
     # Spot-check a few canonical entries
     for name in ("omicsclaw", "save_file", "inspect_data", "remember", "consult_knowledge"):
         assert name in table, f"Tool name '{name}' missing from dispatch table"
+
+
+# ---------------------------------------------------------------------------
+# Regression: path_validation helpers must be importable from bot.tool_executors
+# ---------------------------------------------------------------------------
+
+
+PATH_VALIDATION_SYMBOLS = (
+    "_ensure_trusted_dirs",
+    "TRUSTED_DATA_DIRS",
+    "validate_input_path",
+    "discover_file",
+    # Also missed by the carve-out — used by execute_save_file /
+    # execute_write_file / execute_generate_audio (lines ~758, 787, 814).
+    "resolve_dest",
+    "sanitize_filename",
+    "validate_path",
+)
+
+
+# Symbols from bot.core / bot.skill_orchestration / preflight.sc_batch that
+# the carve-out left as bare references inside ``execute_*`` bodies. Each
+# one is an unexercised NameError waiting for the right tool call. Pinning
+# them at module level catches the whole class of bug, not just the
+# _ensure_trusted_dirs incident.
+CARVED_OUT_SIBLING_SYMBOLS = (
+    # bot.core
+    "DEEP_LEARNING_METHODS",
+    "OMICSCLAW_PY",
+    "_path_names",
+    # bot.skill_orchestration
+    "_infer_skill_for_method",
+    "_run_skill_via_shared_runner",
+    # omicsclaw.runtime.preflight.sc_batch
+    "_resolve_requested_batch_key",
+)
+
+
+def test_tool_executors_imports_path_validation_helpers():
+    """bot.tool_executors uses ``_ensure_trusted_dirs`` / ``TRUSTED_DATA_DIRS``
+    / ``validate_input_path`` / ``discover_file`` in several executors (lines
+    ~140, 224, 1012, 1057, 1088, 1277, 1307, 1334, 1361, 1666, 1786, 1788 at
+    the time of writing). When the module was carved out of bot.core per
+    ADR 0001, the import of these names was left behind in bot.core. Every
+    call into ``execute_omicsclaw`` with ``mode='file'`` (no staged input)
+    fires ``_ensure_trusted_dirs()`` and raises ``NameError`` instead of
+    returning the friendly 'place your file in a data directory' message.
+
+    Pin the contract: the four names must resolve as module-level
+    attributes on bot.tool_executors."""
+    import bot.core  # noqa: F401 — load bot.core first (production order)
+    import bot.tool_executors
+
+    missing = [
+        name for name in PATH_VALIDATION_SYMBOLS
+        if not hasattr(bot.tool_executors, name)
+    ]
+    assert not missing, (
+        f"bot.tool_executors is missing path_validation symbols: {missing}. "
+        f"Add them to the `from bot.path_validation import ...` block."
+    )
+
+
+def test_tool_executors_imports_carved_out_sibling_helpers():
+    """Same bug class as ``test_tool_executors_imports_path_validation_helpers``,
+    but covers the carve-out leftovers from bot.core / bot.skill_orchestration
+    / preflight.sc_batch. Each is referenced bare inside an ``execute_*``
+    body and would raise NameError on the first call that exercises it
+    (pyflakes audit on 2026-05-13)."""
+    import bot.core  # noqa: F401 — load bot.core first (production order)
+    import bot.tool_executors
+
+    missing = [
+        name for name in CARVED_OUT_SIBLING_SYMBOLS
+        if not hasattr(bot.tool_executors, name)
+    ]
+    assert not missing, (
+        f"bot.tool_executors is missing carve-out sibling symbols: {missing}. "
+        f"Each one is an unexercised NameError waiting for the right tool "
+        f"call. Add them to the existing per-module import blocks at the "
+        f"top of bot/tool_executors.py."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_omicsclaw_file_mode_without_input_returns_friendly_error():
+    """End-to-end regression for the 2026-05-13 incident: user invoked
+    ``omicsclaw({"mode": "file", "skill": "sc-standardize-input", ...})``
+    and got ``NameError: name '_ensure_trusted_dirs' is not defined``
+    instead of the documented 'no input file' guidance.
+
+    Contract: when ``mode='file'`` and nothing is staged for the session,
+    the executor returns a human-readable error string starting with
+    'No input file available' — never raises NameError."""
+    import bot.core  # noqa: F401 — load bot.core first (production order)
+    from bot.tool_executors import execute_omicsclaw
+
+    result = await execute_omicsclaw(
+        args={"mode": "file", "skill": "sc-standardize-input"},
+        session_id="missing-session-for-regression-test",
+    )
+    assert isinstance(result, str), f"expected str, got {type(result).__name__}"
+    assert "No input file available" in result, (
+        f"execute_omicsclaw did not return the friendly no-input-file guidance; "
+        f"got: {result!r}"
+    )

--- a/tests/bot/test_tool_executors.py
+++ b/tests/bot/test_tool_executors.py
@@ -356,6 +356,65 @@ def test_tool_executors_imports_carved_out_sibling_helpers():
     )
 
 
+def test_trusted_data_dirs_mutation_visible_to_tool_executors():
+    """``_ensure_trusted_dirs()`` populates ``bot.path_validation.TRUSTED_DATA_DIRS``,
+    but if it *rebinds* the global instead of mutating in place, modules
+    that imported the name (bot.tool_executors, bot.core,
+    omicsclaw.app.server) stay stuck on the original empty list.
+
+    Symptom observed via the executor probe on 2026-05-13:
+        Trusted data dirs: ['/.../data', '/.../examples', ...]   (path_validation)
+        Access denied: /.../data is not in trusted directories ()  (tool_executors)
+
+    omicsclaw/app/server.py:686-691 also relies on appending to
+    ``bot.core.TRUSTED_DATA_DIRS`` being visible to ``validate_input_path``
+    — same root cause.
+
+    Contract: after the helper runs, every module's view is non-empty and
+    is the *same list object* as ``bot.path_validation.TRUSTED_DATA_DIRS``."""
+    import bot.core
+    import bot.path_validation
+    import bot.tool_executors
+
+    bot.path_validation._ensure_trusted_dirs()
+
+    pv = bot.path_validation.TRUSTED_DATA_DIRS
+    assert pv, "Sanity: path_validation.TRUSTED_DATA_DIRS unexpectedly empty after _ensure"
+
+    assert bot.tool_executors.TRUSTED_DATA_DIRS, (
+        "bot.tool_executors.TRUSTED_DATA_DIRS is empty after _ensure_trusted_dirs() "
+        "ran in bot.path_validation. The helper rebinds the global instead of "
+        "mutating in place — fix it with `TRUSTED_DATA_DIRS[:] = _build_trusted_dirs()`."
+    )
+    assert bot.tool_executors.TRUSTED_DATA_DIRS is pv, (
+        "bot.tool_executors.TRUSTED_DATA_DIRS diverged from "
+        "bot.path_validation.TRUSTED_DATA_DIRS — they must be the same list "
+        "object so server.py's runtime append() is visible to validate_input_path."
+    )
+    assert bot.core.TRUSTED_DATA_DIRS is pv, (
+        "bot.core.TRUSTED_DATA_DIRS diverged from path_validation. server.py "
+        "appends workspace dirs to bot.core.TRUSTED_DATA_DIRS — that mutation "
+        "must propagate to validate_input_path."
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_list_directory_allows_data_dir_after_ensure():
+    """Behavioral consequence of the rebind bug: ``execute_list_directory``
+    rejects the legit DATA_DIR with 'Access denied ... is not in trusted
+    directories ()' because its module-local TRUSTED_DATA_DIRS view is still
+    the empty list. Once the helper mutates in place, DATA_DIR is trusted
+    and the listing proceeds."""
+    import bot.core
+    from bot.tool_executors import execute_list_directory
+
+    result = await execute_list_directory({"path": str(bot.core.DATA_DIR)})
+    assert "Access denied" not in result, (
+        f"execute_list_directory denied access to DATA_DIR — the trusted-dirs "
+        f"check is reading a stale empty list. Got: {result!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_omicsclaw_file_mode_without_input_returns_friendly_error():
     """End-to-end regression for the 2026-05-13 incident: user invoked

--- a/tests/test_bot_core_import_behavior.py
+++ b/tests/test_bot_core_import_behavior.py
@@ -48,3 +48,34 @@ def test_bot_core_loads_registry_on_demand(monkeypatch):
 
     assert tool_registry is not None
     assert len(calls) >= 1
+
+
+def test_bot_core_lazy_TOOLS_attribute_resolves_without_nameerror():
+    """``bot.core.TOOLS`` is a legacy lazy re-export of the tools-list
+    produced by ``bot.agent_loop.get_tools()``. The ``__getattr__`` branch
+    at bot/core.py:572-573 calls ``get_tools()`` directly, but ``get_tools``
+    is only available through the ``_AGENT_LOOP_REEXPORTS`` lazy-import
+    path further down — it is *not* in module scope at line 573. Result:
+    every access to ``bot.core.TOOLS`` raises NameError.
+
+    Sibling lazy attributes ``TOOL_RUNTIME`` and ``TOOL_EXECUTORS`` work
+    because their backing functions are imported eagerly from
+    ``bot.tool_executors`` at the top of the file.
+
+    Caught by pyflakes audit on 2026-05-13."""
+    core = _fresh_import_bot_core()
+
+    tools = core.TOOLS  # must not raise
+    assert isinstance(tools, list), (
+        f"bot.core.TOOLS should be a list of tool definitions; "
+        f"got {type(tools).__name__}: {tools!r}"
+    )
+    # Sanity: at least the core omicsclaw tool should be registered.
+    assert any(
+        isinstance(t, dict)
+        and t.get("function", {}).get("name") == "omicsclaw"
+        for t in tools
+    ), (
+        f"bot.core.TOOLS missing the 'omicsclaw' tool — get_tools() likely "
+        f"returned an unrelated value. Tools: {tools!r}"
+    )

--- a/tests/test_knowledge_registry.py
+++ b/tests/test_knowledge_registry.py
@@ -1,4 +1,24 @@
+import typing
+
 from omicsclaw.knowledge.registry import KnowledgeRegistry, validate_frontmatter
+
+
+def test_knowledge_registry_lookup_annotations_resolve():
+    """``KnowledgeRegistry.lookup`` declares ``skill: Optional[str] = None``
+    et al., but the module never imports ``Optional`` — only
+    ``from typing import Any`` (registry.py:15). Currently masked by
+    ``from __future__ import annotations`` (PEP 563 deferred evaluation),
+    so the bare ``Optional`` reference does not fire at import time.
+
+    The crash surfaces the moment anyone resolves the annotations eagerly
+    via ``typing.get_type_hints`` — e.g. Pydantic, FastAPI, attrs-style
+    helpers, or simply removing the future-import on a Python upgrade.
+
+    Pin the contract: the annotations must resolve cleanly."""
+    hints = typing.get_type_hints(KnowledgeRegistry.lookup)
+    assert "skill" in hints, (
+        f"KnowledgeRegistry.lookup type hints missing 'skill'; got: {hints!r}"
+    )
 
 
 def test_registry_normalizes_kh_alias_fields_and_phase_alias(tmp_path):


### PR DESCRIPTION
## Summary

Six fixes landing as three logical commits, all under one root cause: the
``bot/core.py → bot/tool_executors.py + bot/path_validation.py + …``
carve-out per ADR 0001 (#120 / #192 / #193) left several module-level
names un-imported in the carved-out files, and one helper (``_ensure_trusted_dirs``)
rebound a shared global instead of mutating in place. Each one was a
latent runtime bug — only the first one had been observed in production
so far (2026-05-13 user incident).

## What was wrong

| # | Bug | Where | Symptom |
|---|---|---|---|
| 1 | ``_ensure_trusted_dirs`` / ``TRUSTED_DATA_DIRS`` / ``validate_input_path`` / ``discover_file`` / ``resolve_dest`` / ``sanitize_filename`` / ``validate_path`` un-imported | ``bot/tool_executors.py`` | ``NameError: name '_ensure_trusted_dirs' is not defined`` on ``omicsclaw({"mode":"file"})`` |
| 2 | ``DEEP_LEARNING_METHODS`` / ``OMICSCLAW_PY`` / ``_path_names`` / ``_infer_skill_for_method`` / ``_run_skill_via_shared_runner`` / ``_resolve_requested_batch_key`` un-imported | ``bot/tool_executors.py`` | Latent NameError on the matching execute_* code paths |
| 3 | ``_ensure_trusted_dirs`` rebound the global instead of mutating in place | ``bot/path_validation.py`` | ``execute_list_directory`` rejects legit DATA_DIR with ``Access denied … is not in trusted directories ()`` — list shown empty even though path_validation's own copy is populated |
| 4 | ``bot.core.TOOLS`` ``__getattr__`` branch calls ``get_tools()`` without importing it | ``bot/core.py`` | ``NameError: name 'get_tools' is not defined`` on every ``bot.core.TOOLS`` access |
| 5 | ``Optional`` used five times but never imported (PEP 563 masks it) | ``omicsclaw/knowledge/registry.py`` | Latent — fires on ``typing.get_type_hints`` (Pydantic / FastAPI / future-import removal) |
| 6 | Dead branch ``target_path = DATA_DIR / target_path`` after a ``return`` | ``bot/tool_executors.py`` (``execute_make_directory``) | Forgotten fallback; current hard-deny behavior is already safe |

## Methodology

- **TDD red-green-refactor** for each fix: write a failing regression
  test that pins the runtime contract (not just import-time presence),
  apply the minimal fix, re-run the test.
- **pyflakes** sweep across ``bot/`` and ``omicsclaw/`` to find the rest
  of the same class of bug (undefined names).
- **Dynamic ``execute_*`` harness** (``/tmp/oc_executor_probe.py`` —
  not committed) ran 36 minimal-arg scenarios across all 24 executors;
  no remaining ``NameError`` / ``AttributeError`` on our own symbols.
- **AST sweep** for ``statement-after-terminator`` flagged the one dead
  branch.
- **``global X; X = build()`` rebind-pattern audit** across 11 sites in
  the repo — all others use a getter or aren't imported by reference,
  so #3 is the only stale-reference bug.

## Test plan

- [x] ``pytest tests/bot/test_tool_executors.py`` (4 new tests pass, plus
      existing identity / dispatch tests)
- [x] ``pytest tests/test_bot_core_import_behavior.py`` (1 new test pass,
      plus existing 2 import-behavior tests)
- [x] ``pytest tests/test_knowledge_registry.py`` (1 new test pass, plus
      existing 2 frontmatter tests)
- [x] Wider bot suite: net **+7 passing, 0 regressed** (baseline failures
      are a pre-existing pydantic-v2 env issue and a test-isolation
      issue in ``test_context_layer_predicate.py`` — both unrelated)
- [x] CLI smoke: ``python omicsclaw.py list`` and ``omicsclaw doctor``
      run clean
- [x] Dynamic harness: all 36 ``execute_*`` probe scenarios return
      strings; ``execute_list_directory(DATA_DIR)`` now returns the
      actual file listing instead of ``Access denied … ()``

## Commits

1. **fix(bot): restore path_validation + carved-out sibling imports in tool_executors**
   — addresses #1 and #2 above
2. **fix(bot): in-place TRUSTED_DATA_DIRS mutation + lazy bot.core.TOOLS resolution**
   — addresses #3 and #4 above
3. **chore(bot+registry): import Optional in knowledge.registry + drop dead branch in make_directory**
   — addresses #5 and #6 above

## Known related issue (out of scope)

``omicsclaw/runtime/context_layers/__init__.py:573`` uses
``Callable[["events.LifecycleEvent"], None]`` without importing the
``events`` submodule. Tried to fix; the eager import triggers a real
circular load (``omicsclaw.runtime.__init__`` re-enters
``context_layers`` mid-load), breaking
``test_predicate_evaluation_emits_hit_and_miss_events``. The existing
``# local import to avoid cycles`` comment was load-bearing. Kept latent
— no current call site touches ``get_type_hints`` on the signature.
Worth tracking separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path validation and trusted directory checks for file operations and tool execution.
  * Improved reliability of tool availability and error messaging when executing certain operations without required inputs.
  * Enhanced directory handling to ensure validation checks remain effective across modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->