### PR TITLE
test: refresh stale docstring after Optional fix landed (#194 follow-up)

### DIFF
--- a/tests/test_knowledge_registry.py
+++ b/tests/test_knowledge_registry.py
@@ -4,17 +4,10 @@ from omicsclaw.knowledge.registry import KnowledgeRegistry, validate_frontmatter
 
 
 def test_knowledge_registry_lookup_annotations_resolve():
-    """``KnowledgeRegistry.lookup`` declares ``skill: Optional[str] = None``
-    et al., but the module never imports ``Optional`` — only
-    ``from typing import Any`` (registry.py:15). Currently masked by
-    ``from __future__ import annotations`` (PEP 563 deferred evaluation),
-    so the bare ``Optional`` reference does not fire at import time.
-
-    The crash surfaces the moment anyone resolves the annotations eagerly
-    via ``typing.get_type_hints`` — e.g. Pydantic, FastAPI, attrs-style
-    helpers, or simply removing the future-import on a Python upgrade.
-
-    Pin the contract: the annotations must resolve cleanly."""
+    """Pin the contract: ``KnowledgeRegistry.lookup`` annotations resolve
+    cleanly under eager evaluation via ``typing.get_type_hints`` (the
+    path Pydantic / FastAPI / attrs-style helpers take, and the path a
+    future ``from __future__ import annotations`` removal would force)."""
     hints = typing.get_type_hints(KnowledgeRegistry.lookup)
     assert "skill" in hints, (
         f"KnowledgeRegistry.lookup type hints missing 'skill'; got: {hints!r}"


### PR DESCRIPTION
## Summary

Follow-up to #194. The test ``test_knowledge_registry_lookup_annotations_resolve`` carried a 10-line docstring describing the broken state #194 just fixed (\"module never imports ``Optional``\"). Now that the import is in place the narrative no longer matches the code. Replace with one sentence stating the contract the test pins: annotations resolve cleanly under eager evaluation via ``typing.get_type_hints``.

CodeRabbit Minor catch surfaced post-#194 merge. Docstring-only change, no behavior touched.

## Test plan

- [x] ``python -m pytest tests/test_knowledge_registry.py -v`` — 3/3 pass (unchanged behavior).