### PR TITLE
feat(doctor): add graph memory subsystem health check

### DIFF
--- a/omicsclaw/diagnostics.py
+++ b/omicsclaw/diagnostics.py
@@ -546,6 +546,232 @@ def _collect_knowledge_check() -> DiagnosticCheck:
     )
 
 
+def _resolve_memory_db_path(database_url: str) -> Path | None:
+    """Extract the SQLite file path from a memory DB URL.
+
+    Returns ``None`` for non-SQLite URLs (PostgreSQL, etc.) — the doctor's
+    local-file probe is meaningful only for SQLite.
+    """
+    if "sqlite" not in database_url:
+        return None
+    if "///" not in database_url:
+        return None
+    raw = database_url.split("///", 1)[-1]
+    return Path(raw).expanduser()
+
+
+def _redact_memory_db_url(database_url: str) -> str:
+    """Replace any embedded password with ``***`` for safe logging.
+
+    Mirrors ``omicsclaw/memory/database.py``'s redaction so doctor
+    output never echoes credentials.
+    """
+    if "@" not in database_url or ":" not in database_url:
+        return database_url
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(database_url)
+        if parsed.password:
+            return database_url.replace(f":{parsed.password}@", ":***@")
+    except Exception:
+        pass
+    return database_url
+
+
+_MEMORY_REQUIRED_TABLES: tuple[str, ...] = (
+    "nodes",
+    "memories",
+    "edges",
+    "paths",
+    "_schema_version",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MemorySchemaProbe:
+    missing_tables: tuple[str, ...]
+    schema_version: str | None
+    migrations_applied: int
+    shared_paths: int
+    kh_seed_paths: int
+
+
+def _probe_memory_schema(db_path: Path) -> _MemorySchemaProbe:
+    """Read-only probe of the memory SQLite database schema and content.
+
+    Reports missing required tables, the highest applied migration
+    version and total migration count, plus ``__shared__`` path
+    population (overall and specifically the KH bootstrap seeds at
+    ``core://kh/*``). Raises ``sqlite3.Error`` if the database cannot
+    be opened.
+    """
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        present = {row[0] for row in rows}
+        missing = tuple(t for t in _MEMORY_REQUIRED_TABLES if t not in present)
+
+        schema_version: str | None = None
+        migrations_applied = 0
+        if "_schema_version" in present:
+            version_rows = connection.execute(
+                "SELECT version FROM _schema_version"
+            ).fetchall()
+            versions = [str(r[0]) for r in version_rows if r[0] is not None]
+            migrations_applied = len(versions)
+            if versions:
+                schema_version = max(versions)
+
+        shared_paths = 0
+        kh_seed_paths = 0
+        if "paths" in present:
+            shared_paths = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM paths WHERE namespace=?",
+                    ("__shared__",),
+                ).fetchone()[0]
+            )
+            kh_seed_paths = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM paths "
+                    "WHERE namespace=? AND domain=? AND path LIKE 'kh/%'",
+                    ("__shared__", "core"),
+                ).fetchone()[0]
+            )
+        return _MemorySchemaProbe(
+            missing_tables=missing,
+            schema_version=schema_version,
+            migrations_applied=migrations_applied,
+            shared_paths=shared_paths,
+            kh_seed_paths=kh_seed_paths,
+        )
+    finally:
+        connection.close()
+
+
+def _collect_memory_check() -> DiagnosticCheck:
+    """Health-probe the graph memory subsystem.
+
+    Side-effect-free: reads the on-disk SQLite database without invoking
+    ``init_db`` so the doctor stays a read-only diagnostic. PostgreSQL
+    deployments degrade to an info status since the file probe doesn't
+    apply.
+    """
+    try:
+        from omicsclaw.memory.database import _get_database_url
+    except Exception as exc:
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Memory subsystem import failed: {exc}",
+        )
+
+    database_url = _get_database_url()
+    db_path = _resolve_memory_db_path(database_url)
+
+    if db_path is None:
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_INFO,
+            summary="Graph memory configured for a non-SQLite backend.",
+            details=(
+                f"url={_redact_memory_db_url(database_url)}",
+                "Non-SQLite backend — file probe skipped.",
+            ),
+        )
+
+    details = [f"path={db_path}"]
+    parent = db_path.parent
+    if not parent.exists():
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Memory DB directory is missing: {parent}",
+            details=tuple(details),
+        )
+    if not os.access(parent, os.W_OK):
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Memory DB directory is not writable: {parent}",
+            details=tuple(details),
+        )
+
+    if not db_path.exists():
+        details.append("Database has not been created yet; it will be initialized on first memory write.")
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_WARN,
+            summary="Memory database path is writable but not yet initialized.",
+            details=tuple(details),
+        )
+    if not db_path.is_file():
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Expected a file but found a non-file path: {db_path}",
+            details=tuple(details),
+        )
+    if not os.access(db_path, os.R_OK | os.W_OK):
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Memory database is not readable/writable: {db_path}",
+            details=tuple(details),
+        )
+
+    details.append(f"size={db_path.stat().st_size} bytes")
+
+    try:
+        probe = _probe_memory_schema(db_path)
+    except sqlite3.Error as exc:
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_FAIL,
+            summary=f"Memory database exists but could not be opened: {exc}",
+            details=tuple(details),
+        )
+
+    if probe.missing_tables:
+        details.append(f"missing_tables={','.join(probe.missing_tables)}")
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_WARN,
+            summary="Memory database is missing required tables; rerun init.",
+            details=tuple(details),
+        )
+
+    details.append(f"schema_version={probe.schema_version or 'baseline'}")
+    details.append(f"migrations_applied={probe.migrations_applied}")
+    details.append(f"shared_paths={probe.shared_paths}")
+    details.append(f"kh_seed_paths={probe.kh_seed_paths}")
+
+    if probe.shared_paths > 0 and probe.kh_seed_paths == 0:
+        return DiagnosticCheck(
+            name="Graph Memory",
+            status=DIAGNOSTIC_STATUS_WARN,
+            summary=(
+                "Memory database has __shared__ entries but no KH bootstrap seeds — "
+                "rerun a surface (CLI/Desktop/Bot) to reseed."
+            ),
+            details=tuple(details),
+        )
+
+    return DiagnosticCheck(
+        name="Graph Memory",
+        status=DIAGNOSTIC_STATUS_OK,
+        summary=(
+            f"Memory database OK (schema={probe.schema_version or 'baseline'}, "
+            f"migrations={probe.migrations_applied}, "
+            f"shared={probe.shared_paths}, kh_seeds={probe.kh_seed_paths})"
+        ),
+        details=tuple(details),
+    )
+
+
 def _resolve_project_root(omicsclaw_dir: str) -> Path:
     text = str(omicsclaw_dir or "").strip()
     if text:
@@ -895,6 +1121,7 @@ def build_doctor_report(
     checks.append(_collect_provider_check())
     checks.append(_collect_session_db_check())
     checks.append(_collect_knowledge_check())
+    checks.append(_collect_memory_check())
     checks.append(_collect_skill_catalog_check(str(omicsclaw_dir or "").strip()))
     checks.append(_collect_graphify_check(str(omicsclaw_dir or "").strip()))
     checks.append(_collect_extensions_check(str(omicsclaw_dir or "").strip()))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -149,6 +149,11 @@ def test_build_doctor_report_flags_invalid_installed_extensions(tmp_path, monkey
     )
     monkeypatch.setattr(
         diagnostics,
+        "_collect_memory_check",
+        lambda: DiagnosticCheck("Graph Memory", DIAGNOSTIC_STATUS_OK, "ok"),
+    )
+    monkeypatch.setattr(
+        diagnostics,
         "_collect_mcp_check",
         lambda: DiagnosticCheck("MCP Config", DIAGNOSTIC_STATUS_OK, "ok"),
     )
@@ -163,6 +168,192 @@ def test_build_doctor_report_flags_invalid_installed_extensions(tmp_path, monkey
     assert extensions_check.status == DIAGNOSTIC_STATUS_WARN
     assert "1 installed" in extensions_check.summary
     assert "bad-ext" in extensions_check.details[0]
+
+
+def test_collect_memory_check_warns_when_db_not_yet_created(tmp_path, monkeypatch):
+    db_dir = tmp_path / "memdb"
+    db_dir.mkdir()
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL",
+        f"sqlite+aiosqlite:///{db_dir / 'memory.db'}",
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.name == "Graph Memory"
+    assert check.status == DIAGNOSTIC_STATUS_WARN
+    assert "not yet initialized" in check.summary
+
+
+def test_collect_memory_check_info_for_postgres_backend(monkeypatch):
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL",
+        "postgresql+asyncpg://user:pw@example.com:5432/memdb",
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == diagnostics.DIAGNOSTIC_STATUS_INFO
+    assert "non-SQLite" in check.summary
+
+
+def test_collect_memory_check_redacts_password_in_postgres_url(monkeypatch):
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL",
+        "postgresql+asyncpg://alice:s3cret@example.com:5432/memdb",
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    detail_text = "\n".join(check.details)
+    assert "s3cret" not in detail_text
+    assert "alice:***@example.com" in detail_text
+
+
+def _build_memory_sqlite(
+    db_path: Path,
+    *,
+    applied_versions: list[str] | None = None,
+    shared_paths: list[tuple[str, str]] | None = None,
+) -> None:
+    """Create a minimal SQLite DB that mirrors the memory subsystem schema.
+
+    Only the tables the doctor probes are created — enough to drive
+    schema-version, table-presence, and shared-namespace checks without
+    pulling in the full SQLAlchemy stack. ``shared_paths`` seeds
+    ``(domain, path)`` rows into the ``__shared__`` namespace.
+    """
+    import sqlite3 as _sqlite3
+
+    connection = _sqlite3.connect(db_path)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE nodes (uuid TEXT PRIMARY KEY);
+            CREATE TABLE memories (id INTEGER PRIMARY KEY);
+            CREATE TABLE edges (id INTEGER PRIMARY KEY);
+            CREATE TABLE paths (
+                namespace TEXT NOT NULL,
+                domain TEXT NOT NULL,
+                path TEXT NOT NULL,
+                PRIMARY KEY (namespace, domain, path)
+            );
+            CREATE TABLE _schema_version (
+                version TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );
+            """
+        )
+        for v in applied_versions or []:
+            connection.execute(
+                "INSERT INTO _schema_version (version, applied_at) VALUES (?, ?)",
+                (v, "2026-01-01T00:00:00+00:00"),
+            )
+        for domain, path in shared_paths or []:
+            connection.execute(
+                "INSERT INTO paths (namespace, domain, path) VALUES (?, ?, ?)",
+                ("__shared__", domain, path),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_collect_memory_check_reports_schema_version_when_initialized(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _build_memory_sqlite(db_path, applied_versions=["001", "002"])
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}"
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == DIAGNOSTIC_STATUS_OK
+    assert "schema=002" in check.summary
+    assert "migrations=2" in check.summary
+    detail_text = "\n".join(check.details)
+    assert "schema_version=002" in detail_text
+    assert "migrations_applied=2" in detail_text
+
+
+def test_collect_memory_check_reports_shared_and_kh_counts(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _build_memory_sqlite(
+        db_path,
+        applied_versions=["001"],
+        shared_paths=[
+            ("core", "kh"),
+            ("core", "kh/data-analysis-best-practices"),
+            ("core", "kh/de-padj-guardrails"),
+            ("analysis", "sc-preprocessing"),
+        ],
+    )
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}"
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == DIAGNOSTIC_STATUS_OK
+    assert "shared=4" in check.summary
+    assert "kh_seeds=2" in check.summary
+    detail_text = "\n".join(check.details)
+    assert "shared_paths=4" in detail_text
+    assert "kh_seed_paths=2" in detail_text
+
+
+def test_collect_memory_check_warns_when_shared_lacks_kh_seeds(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _build_memory_sqlite(
+        db_path,
+        applied_versions=["001"],
+        shared_paths=[("analysis", "sc-preprocessing")],
+    )
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}"
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == DIAGNOSTIC_STATUS_WARN
+    assert "no KH bootstrap seeds" in check.summary
+
+
+def test_collect_memory_check_ok_for_empty_initialized_store(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _build_memory_sqlite(db_path, applied_versions=["001"])
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}"
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == DIAGNOSTIC_STATUS_OK
+    assert "shared=0" in check.summary
+    assert "kh_seeds=0" in check.summary
+
+
+def test_collect_memory_check_warns_when_required_tables_missing(tmp_path, monkeypatch):
+    import sqlite3 as _sqlite3
+
+    db_path = tmp_path / "memory.db"
+    connection = _sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE _schema_version (version TEXT, applied_at TEXT)")
+        connection.commit()
+    finally:
+        connection.close()
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", f"sqlite+aiosqlite:///{db_path}"
+    )
+
+    check = diagnostics._collect_memory_check()
+
+    assert check.status == DIAGNOSTIC_STATUS_WARN
+    assert "missing required tables" in check.summary
+    detail_text = "\n".join(check.details)
+    for table in ("nodes", "memories", "edges", "paths"):
+        assert table in detail_text
 
 
 def test_build_context_report_surfaces_plan_layer_and_budget_warning(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`oc doctor` covered Session DB, Knowledge Index, Skill Catalog, Graphify, MCP, and workspace directories — but the **graph memory subsystem (`omicsclaw/memory/`) had no health probe**, despite owning its own SQLite database and being the focus of every recent refactor (Phase 2a → 2b → 2c → 3 in PRs #173–#175). A schema/migration/KH-bootstrap breakage had no surfaced signal.

This PR adds a read-only `_collect_memory_check()` slotted between the existing Knowledge Index and Skill Catalog checks.

## What the probe reports

```
[OK] Graph Memory: Memory database OK (schema=001_namespace, migrations=1, shared=61, kh_seeds=49)
  path=/home/.../.config/omicsclaw/memory.db
  size=806912 bytes
  schema_version=001_namespace
  migrations_applied=1
  shared_paths=61
  kh_seed_paths=49
```

| Condition | Status |
|---|---|
| DB exists, all required tables, KH seeds present | OK |
| `__shared__` populated but `kh_seed_paths == 0` (stale bootstrap) | WARN |
| Required tables missing (`nodes`/`memories`/`edges`/`paths`/`_schema_version`) | WARN |
| DB file not yet created | WARN |
| Directory missing / not writable / corrupt DB | FAIL |
| Non-SQLite backend (e.g. PostgreSQL) | INFO (file probe N/A) |

## Design notes

- **Side-effect-free.** Opens SQLite via `file:...?mode=ro` and reads `sqlite_master`, `_schema_version`, and `paths`. Does NOT call `init_db`, run migrations, or seed anything — doctor stays a pure diagnostic.
- **No new dependencies.** Uses the project's existing `sqlite3` stdlib path (same as `_collect_session_db_check`).
- **Credential safety.** Mirrors the password-redaction pattern from `omicsclaw/memory/database.py:152-159` (`_redact_memory_db_url`) so PostgreSQL URLs never echo credentials in doctor output. Local SQLite branches don't echo the URL at all — only the resolved file path, matching Session DB / Knowledge Index conventions.
- **Schema introspection helper** (`_probe_memory_schema` + private `_MemorySchemaProbe` dataclass) kept inline in `diagnostics.py` since this is the only caller today. Easy to lift to `omicsclaw/memory/health.py` if memory-server admin UI ever wants the same data.

## Test plan

- [x] `pytest tests/test_diagnostics.py` — **16 pass** (8 new)
  - `test_collect_memory_check_warns_when_db_not_yet_created`
  - `test_collect_memory_check_info_for_postgres_backend`
  - `test_collect_memory_check_redacts_password_in_postgres_url` *(regression guard for the URL-leak class)*
  - `test_collect_memory_check_reports_schema_version_when_initialized`
  - `test_collect_memory_check_reports_shared_and_kh_counts`
  - `test_collect_memory_check_warns_when_shared_lacks_kh_seeds`
  - `test_collect_memory_check_ok_for_empty_initialized_store`
  - `test_collect_memory_check_warns_when_required_tables_missing`
- [x] `pytest tests/memory/` — **253 pass** (no regressions)
- [x] `ruff check omicsclaw/diagnostics.py tests/test_diagnostics.py` — clean
- [x] Live `oc doctor` against the real working DB — `Overall: OK (fail=0, warn=0)`; new entry reports `schema=001_namespace, migrations=1, shared=61, kh_seeds=49` (matches independently-verified KH bootstrap of 49 seeds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Graph Memory" diagnostic to the doctor tool that validates database integrity, checks required schemas, and reports configuration status.

* **Tests**
  * Added comprehensive test coverage for the memory diagnostic feature, including validation scenarios and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->