### PR TITLE
fix(memory): break "记住" ambiguity that routed remember requests to task_create

### DIFF
--- a/omicsclaw/runtime/bot_tools.py
+++ b/omicsclaw/runtime/bot_tools.py
@@ -530,7 +530,8 @@ def build_bot_tool_specs(context: BotToolContext) -> list[ToolSpec]:
             name="remember",
             description=(
                 "Save important information to persistent memory so you can recall it "
-                "in future conversations. Use this to remember: user preferences "
+                "in future conversations. Call this (not `task_create`) for "
+                "'记住 X' / 'remember X' requests. Use to remember: user preferences "
                 "(language, default methods, DPI settings), biological insights "
                 "(cell type annotations, spatial domains found), and project context "
                 "(research goals, species, tissue type, disease model). "

--- a/omicsclaw/runtime/context_layers/__init__.py
+++ b/omicsclaw/runtime/context_layers/__init__.py
@@ -950,11 +950,13 @@ _PREDICATE_GATED_RULES: dict[str, str] = {
     ),
     "memory_hygiene_rule": (
         "## Memory Hygiene\n"
-        "- Use `remember` for stable preferences, confirmed biological insights, "
-        "and durable project context. Never store secrets, API keys, PII, "
-        "transient file paths, temporary errors, or unconfirmed annotations.\n"
-        "- Treat injected `## Scoped Memory` as local project/dataset/lab "
-        "heuristics, not general scientific knowledge."
+        "- \"记住 X\" / \"remember X\" / \"save X for me\" → call `remember`, "
+        "NEVER `task_create` (which is for multi-step engineering work only).\n"
+        "- `remember` is for stable preferences, biological insights, durable "
+        "project context. Never store secrets, API keys, PII, transient "
+        "paths, or unconfirmed annotations.\n"
+        "- Scoped Memory = local project/dataset heuristics, not general "
+        "scientific knowledge."
     ),
     "capability_routing_hint_rule": (
         "## Capability Routing\n"

--- a/omicsclaw/runtime/engineering_tools.py
+++ b/omicsclaw/runtime/engineering_tools.py
@@ -279,7 +279,10 @@ def build_engineering_tool_specs() -> list[ToolSpec]:
         ),
         ToolSpec(
             name="task_create",
-            description="Create a persisted engineering task for the current session.",
+            description=(
+                "Create a persisted engineering task for the current session. "
+                "Not for '记住 X' / 'remember X' — use `remember` for those."
+            ),
             parameters={
                 "type": "object",
                 "properties": {

--- a/tests/fixtures/tool_list/baseline_bot.json
+++ b/tests/fixtures/tool_list/baseline_bot.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 7731,
+  "total_chars": 7941,
   "tool_count": 8,
   "tool_names": [
     "consult_knowledge",
@@ -24,7 +24,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_bulkrna_de.json
+++ b/tests/fixtures/tool_list/realistic_bot_bulkrna_de.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 12457,
+  "total_chars": 12667,
   "tool_count": 20,
   "tool_names": [
     "consult_knowledge",
@@ -36,7 +36,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_code_edit_intent.json
+++ b/tests/fixtures/tool_list/realistic_bot_code_edit_intent.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 9993,
+  "total_chars": 10203,
   "tool_count": 10,
   "tool_names": [
     "consult_knowledge",
@@ -26,7 +26,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_pdf_paper.json
+++ b/tests/fixtures/tool_list/realistic_bot_pdf_paper.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 13480,
+  "total_chars": 13690,
   "tool_count": 22,
   "tool_names": [
     "consult_knowledge",
@@ -38,7 +38,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_plot_intent.json
+++ b/tests/fixtures/tool_list/realistic_bot_plot_intent.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 10289,
+  "total_chars": 10499,
   "tool_count": 10,
   "tool_names": [
     "consult_knowledge",
@@ -26,7 +26,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_save_intent.json
+++ b/tests/fixtures/tool_list/realistic_bot_save_intent.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 9993,
+  "total_chars": 10203,
   "tool_count": 10,
   "tool_names": [
     "consult_knowledge",
@@ -26,7 +26,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_scde.json
+++ b/tests/fixtures/tool_list/realistic_bot_scde.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 12452,
+  "total_chars": 12662,
   "tool_count": 20,
   "tool_names": [
     "consult_knowledge",
@@ -36,7 +36,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_web_intent.json
+++ b/tests/fixtures/tool_list/realistic_bot_web_intent.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "",
     "capability_context": ""
   },
-  "total_chars": 9980,
+  "total_chars": 10190,
   "tool_count": 12,
   "tool_names": [
     "consult_knowledge",
@@ -28,7 +28,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/fixtures/tool_list/realistic_bot_workspace.json
+++ b/tests/fixtures/tool_list/realistic_bot_workspace.json
@@ -7,7 +7,7 @@
     "pipeline_workspace": "/tmp/run42",
     "capability_context": ""
   },
-  "total_chars": 10978,
+  "total_chars": 11246,
   "tool_count": 14,
   "tool_names": [
     "consult_knowledge",
@@ -30,7 +30,7 @@
       "type": "function",
       "function": {
         "name": "omicsclaw",
-        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
+        "description": "Run an OmicsClaw multi-omics analysis skill.\n\n(test)\n\nPREFER `skill='auto'` + `query=<user request>` (auto-routes deterministically). Pick a specific skill only if the user named it. `mode='demo'` ONLY when explicitly asked. For a server-side file, use `mode='path'` and pass the path at the top level as `file_path='/abs/path.h5ad'` — do NOT nest args under a `params` key. `mode='file'` is only for files the user uploaded via chat. `return_media` empty = text summary; pass a keyword ('umap','qc','cluster',comma-sep) or 'all' for figures. For sc-batch-integration upstream-prep pause, rerun with `auto_prepare=true`. Preserve exact numbers, warnings, errors, and file paths when relaying results.",
         "parameters": {
           "type": "object",
           "properties": {
@@ -350,7 +350,7 @@
       "type": "function",
       "function": {
         "name": "task_create",
-        "description": "Create a persisted engineering task for the current session.",
+        "description": "Create a persisted engineering task for the current session. Not for '记住 X' / 'remember X' — use `remember` for those.",
         "parameters": {
           "type": "object",
           "properties": {

--- a/tests/test_predicate_gated_injectors.py
+++ b/tests/test_predicate_gated_injectors.py
@@ -162,6 +162,22 @@ def test_memory_hygiene_rule_content() -> None:
     assert "scoped" in text or "preference" in text or "transient" in text
 
 
+def test_memory_hygiene_rule_disambiguates_task_create() -> None:
+    """Regression for the chat path where the LLM routed "记住 X" requests
+    to ``task_create`` instead of ``remember`` (session 945434f1 in the
+    desktop trace). The rule must explicitly name the wrong tool so the
+    model breaks the tie correctly when both are visible.
+    """
+    req = ContextAssemblyRequest(surface="bot", query="please remember my preference")
+    text = _layer_text(req, "memory_hygiene_rule")
+    assert "remember" in text.lower()
+    assert "task_create" in text.lower(), (
+        "memory_hygiene_rule must name ``task_create`` explicitly as the "
+        "wrong tool — naming only ``remember`` is not enough to break the "
+        "ambiguity in practice."
+    )
+
+
 # --- non_trivial_no_capability → capability_routing_hint_rule ---------------
 
 


### PR DESCRIPTION
## Summary

Sessions trace on the desktop surface shows the LLM frequently picks `task_create` when the user says `"记住 X"` / `"remember X"` — saving the user's preference as an engineering todo (e.g. session `945434f1`: `"记住我需要你用中文回答"` became a task titled `"用户语言偏好：中文回答"` saved under `engineering_tasks/`, never reaching `memory.db`). The user sees a green "success" event from the wrong tool and the Memory page stays empty.

## Defense in depth

1. **`memory_hygiene_rule`** (system prompt, gated by the memory-keyword predicate) now names `task_create` explicitly as the wrong tool, tying the disambiguation to the rule the LLM already sees when the trigger fires. Rule still under the 400-char budget.
2. **`remember` description** tells the LLM "Call this (not `task_create`) for '记住 X' / 'remember X' requests".
3. **`task_create` description** tells the LLM "Not for '记住 X' / 'remember X' — use `remember` for those".

Adds a regression test asserting the rule names `task_create` explicitly; the prior content assertions still pass. Snapshot fixtures regenerated.

## Test plan
- [x] `pytest tests/test_predicate_gated_injectors.py` — 16/16 pass (incl. new `test_memory_hygiene_rule_disambiguates_task_create`)
- [x] `pytest tests/test_tool_list_snapshots.py` — 14/14 snapshot tests pass; regenerated fixtures included
- [x] Manual reproduction on the failing session pattern (verified via sessions.db transcript)

## Note on pre-existing failure
`test_realistic_scde_tool_list_under_phase2_budget` reports 12662 chars vs 12500 budget. This failure pre-dates this commit (the sc-de scenario triggers many file-path tools that together blow the budget; `remember`/`task_create` are not in that selected set, so this PR does not move that number). Tracked separately.

## Pairing
Pairs with frontend commit on https://github.com/zhou-1314/OmicsClaw-App (`fix(memory): auto-refresh Memory page when chat tools mutate memory.db`) which adds a `refresh-memory` window event so the Memory page re-fetches after a successful `remember`/`forget` tool call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)