### PR TITLE
fix(memory): restore memory_store init + clarify disabled-store hint

### DIFF
--- a/bot/session.py
+++ b/bot/session.py
@@ -302,9 +302,8 @@ def init(
             from omicsclaw.memory.database import DatabaseManager as _DatabaseManager
             from omicsclaw.memory.search import SearchIndexer as _SearchIndexer
             from omicsclaw.memory.glossary import GlossaryService as _GlossaryService
-            from omicsclaw.memory.graph import GraphService as _GraphService
 
-            del _DatabaseManager, _SearchIndexer, _GlossaryService, _GraphService
+            del _DatabaseManager, _SearchIndexer, _GlossaryService
 
             db_url = os.getenv("OMICSCLAW_MEMORY_DB_URL")
 

--- a/bot/tool_executors.py
+++ b/bot/tool_executors.py
@@ -129,6 +129,21 @@ from omicsclaw.runtime.preflight.sc_batch import (
 
 logger = logging.getLogger("omicsclaw.bot.tool_executors")
 
+# Returned by execute_remember / execute_recall / execute_forget when
+# bot.core.memory_store is None. Default is OMICSCLAW_MEMORY_ENABLED=true,
+# so reaching this branch usually means init failed silently at startup
+# (e.g. stale import, missing dep, unreachable DB) — the bot logs carry
+# the actual reason. Naming the real env vars saves users a doc dive
+# through .env.example.
+_MEMORY_DISABLED_HINT = (
+    "Memory system is not initialized. It defaults to enabled, so this "
+    "usually means initialization failed silently at startup — check the "
+    'bot logs for "Memory init failed" or "Memory dependencies not '
+    'installed". Verify OMICSCLAW_MEMORY_ENABLED is not set to "false" '
+    "and that OMICSCLAW_MEMORY_DB_URL points at a reachable database "
+    '(see .env.example § "Graph Memory System").'
+)
+
 
 # Runtime-internal flags injected by the preflight chain (not part of
 # the LLM-facing tool schema). Validator accepts them so auto-prep
@@ -1467,7 +1482,7 @@ async def execute_get_file_size(args: dict) -> str:
 async def execute_remember(args: dict, session_id: str = None) -> str:
     """Save information to persistent memory (preferences, insights, project context)."""
     if not _core.memory_store:
-        return "Memory system not enabled. Set OMICSCLAW_MEMORY_BACKEND=sqlite in .env"
+        return _MEMORY_DISABLED_HINT
     if not session_id:
         return "Memory save requires an active session (user_id + platform)."
 
@@ -1554,7 +1569,7 @@ async def execute_remember(args: dict, session_id: str = None) -> str:
 async def execute_recall(args: dict, session_id: str = None) -> str:
     """Retrieve memories from persistent storage."""
     if not _core.memory_store:
-        return "Memory system not enabled."
+        return _MEMORY_DISABLED_HINT
 
     try:
         mem_type = args.get("memory_type", "")
@@ -1615,7 +1630,7 @@ async def execute_recall(args: dict, session_id: str = None) -> str:
 async def execute_forget(args: dict, session_id: str = None) -> str:
     """Delete a specific memory by searching for it."""
     if not _core.memory_store:
-        return "Memory system not enabled."
+        return _MEMORY_DISABLED_HINT
 
     memory_id = args.get("memory_id", "")
     query = args.get("query", "")

--- a/tests/bot/test_tool_executors.py
+++ b/tests/bot/test_tool_executors.py
@@ -257,6 +257,51 @@ async def test_execute_remember_preference_update_versions_existing_value(
     assert "Chinese" in deprecated[0].content
 
 
+# ---------------------------------------------------------------------------
+# Disabled-memory-store user message: actionable + names real env vars
+# (regression for "Set OMICSCLAW_MEMORY_BACKEND=sqlite in .env" — that env
+# var never existed; the real switches are OMICSCLAW_MEMORY_ENABLED and
+# OMICSCLAW_MEMORY_DB_URL, documented under §"Graph Memory System" in
+# .env.example.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "executor_name, kwargs",
+    [
+        ("execute_remember", {"args": {"memory_type": "preference"}, "session_id": "s1"}),
+        ("execute_recall", {"args": {}, "session_id": "s1"}),
+        ("execute_forget", {"args": {"query": "x"}, "session_id": "s1"}),
+    ],
+)
+async def test_memory_tools_disabled_message_names_real_env_vars(
+    executor_name, kwargs, monkeypatch
+):
+    import bot.core
+    import bot.tool_executors
+
+    monkeypatch.setattr(bot.core, "memory_store", None)
+    executor = getattr(bot.tool_executors, executor_name)
+
+    result = await executor(**kwargs)
+
+    assert isinstance(result, str)
+    assert "OMICSCLAW_MEMORY_BACKEND" not in result, (
+        f"{executor_name} still names the bogus env var "
+        f"OMICSCLAW_MEMORY_BACKEND. Real switches are "
+        f"OMICSCLAW_MEMORY_ENABLED + OMICSCLAW_MEMORY_DB_URL."
+    )
+    assert "OMICSCLAW_MEMORY_ENABLED" in result, (
+        f"{executor_name} disabled-message should name the real switch "
+        f"OMICSCLAW_MEMORY_ENABLED so users know what to inspect."
+    )
+    assert "OMICSCLAW_MEMORY_DB_URL" in result, (
+        f"{executor_name} disabled-message should name the DB URL var so "
+        f"users can verify it points at a reachable database."
+    )
+
+
 def test_tool_executors_dispatch_table_lists_all_24_executors():
     """``_available_tool_executors()`` returns the full dispatch map.
     The lazy ``bot.core.TOOL_EXECUTORS`` attribute also adds the

--- a/tests/test_bot_core_timeout.py
+++ b/tests/test_bot_core_timeout.py
@@ -103,6 +103,47 @@ def test_init_uses_generic_custom_env_without_explicit_args(monkeypatch):
     assert captured["base_url"] == "https://custom.example.com/v1"
 
 
+def test_init_populates_memory_store_when_dependencies_available(monkeypatch):
+    """Regression: stale ``from omicsclaw.memory.graph import GraphService``
+    in ``bot/session.py`` raised ``ModuleNotFoundError`` (graph module was
+    retired in c5987a5); the ``except ImportError`` arm silently set
+    ``memory_store = None``, so the interactive CLI's ``remember`` tool
+    bottomed out on "Memory system not enabled" even though deps were
+    installed and ``OMICSCLAW_MEMORY_ENABLED`` defaulted to ``true``.
+    """
+    captured: dict[str, object] = {}
+
+    class _FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setattr(core, "AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr(core, "memory_store", None)
+    monkeypatch.setattr(core, "session_manager", None)
+    monkeypatch.setenv("OMICSCLAW_MEMORY_ENABLED", "true")
+    monkeypatch.setenv(
+        "OMICSCLAW_MEMORY_DB_URL", "sqlite+aiosqlite:///:memory:"
+    )
+
+    core.init(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test-model",
+        provider="custom",
+    )
+
+    from omicsclaw.memory.compat import CompatMemoryStore
+
+    assert captured["api_key"] == "test-key"
+    assert core.memory_store is not None, (
+        "memory init silently failed — check bot/session.py memory-init "
+        "block for stale imports against omicsclaw.memory.*"
+    )
+    assert isinstance(core.memory_store, CompatMemoryStore)
+    assert core.session_manager is not None
+
+
 def test_init_disables_memory_when_graph_dependencies_missing(monkeypatch):
     captured: dict[str, object] = {}
     original_import = builtins.__import__


### PR DESCRIPTION
## Summary

Two related fixes for the persistent-memory subsystem, each with a TDD-style regression test.

### 1. Restore `memory_store` initialization (root cause)

After commit `c5987a5` retired `omicsclaw.memory.graph.GraphService`, `bot/session.py` still imported it as a startup probe. The bare `except ImportError` arm in the memory-init block swallowed the resulting `ModuleNotFoundError` and logged the misleading **"Memory dependencies not installed"** warning, leaving `_core.memory_store=None` for every user who actually had the deps installed.

User-visible symptom: the interactive CLI's `remember` tool failed with *"Memory system not enabled"* even though `OMICSCLAW_MEMORY_ENABLED` defaulted to `true` and `OMICSCLAW_MEMORY_DB_URL` was set.

Fix: delete the stale import.

### 2. Replace bogus env-var name in the disabled-store hint

`execute_remember` / `execute_recall` / `execute_forget` returned

> `Memory system not enabled. Set OMICSCLAW_MEMORY_BACKEND=sqlite in .env`

when `bot.core.memory_store` was `None`. **That env var has never existed in the codebase** — the real switches are `OMICSCLAW_MEMORY_ENABLED` and `OMICSCLAW_MEMORY_DB_URL`, both documented under §"Graph Memory System" in `.env.example`. Users following the hint hit a dead end (`.env.example` has no such field).

Fix: extract a shared `_MEMORY_DISABLED_HINT` module constant that names the real env vars, references the log strings produced by the memory-init block (so users can grep their logs), and points at the existing `.env.example` section.

### Diff scope

| File | + / − | Purpose |
|---|---|---|
| `bot/session.py` | 1 / 2 | drop stale `omicsclaw.memory.graph` import |
| `bot/tool_executors.py` | 18 / 3 | shared actionable hint constant |
| `tests/test_bot_core_timeout.py` | 41 / 0 | regression: `init` populates `memory_store` when deps present |
| `tests/bot/test_tool_executors.py` | 45 / 0 | regression: 3 disabled-store hints name real env vars |

## Test plan

- [x] `pytest tests/bot/test_tool_executors.py tests/test_bot_core_timeout.py` — 25 passed
- [x] `pytest tests/bot/ tests/memory/ tests/test_bot_core_timeout.py` — 339 passed (wider regression sweep)
- [x] RED proven before GREEN for both fixes (failing test → fix → passing test)
- [x] Manual repro on interactive CLI: `remember` tool now succeeds against the user's real `.env`

## Follow-up (not in this PR)

The `except ImportError` arm at `bot/session.py:317` still logs *"Memory dependencies not installed"* without the actual exception — that's what let this bug hide. Worth a separate PR to include the exception message in the warning so the next stale import or missing dep is self-diagnosing.