### PR TITLE
fix(memory): expose remember tool on declarative preference statements

### DIFF
--- a/omicsclaw/runtime/predicates.py
+++ b/omicsclaw/runtime/predicates.py
@@ -42,6 +42,35 @@ _MEMORY_KEYWORDS_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Catches statements of *persistent* preferences without an explicit
+# 记住 / remember cue. Used to gate the ``remember`` tool so the LLM can
+# proactively persist a preference the user states declaratively
+# (e.g. "以后请用中文回答", "from now on use DESeq2"). Deliberately
+# narrower than "anything containing 总是/always": each branch requires
+# a preference verb / preference-shaped collocation so that scientific
+# phrasings like "cells are always changing" or "以后再说" don't fire.
+_PREFERENCE_STATEMENT_RE = re.compile(
+    # English: temporal-scope leaders ("from now on", "going forward")
+    r"\b(from now on|going forward)\b|"
+    # English: always/never/usually + preference verb
+    r"\b(always|never|usually)\s+"
+    r"(use|do|run|reply|respond|answer|chat|talk|skip|avoid|prefer|set|show)\b|"
+    # English: "I prefer/usually/like/want to ..." + verb
+    r"\bi\s+(prefer|usually|always|like|want)\s+(to\s+\w+|using\s+|\w+ing)\b|"
+    # English: "prefer to ...", "default to ...", "please always/never ..."
+    r"\b(prefer\s+to|default\s+to|please\s+(always|never))\b|"
+    # Chinese: persistent-scope adverb + preference verb
+    r"(以后|今后|始终|一直|总是|每次)\s*(都|请|改|帮我)?\s*"
+    r"(用|不用|不要|要|改用|换成|采用|设为|设成|配置)|"
+    # Chinese: "默认" as a verb / setting ("默认用 X", "默认是 X")
+    r"默认\s*(用|是|为|采用|设|配置)|"
+    # Chinese: I-prefer constructions
+    r"我(习惯|喜欢|偏好|常用)|"
+    # Chinese: "请用 X / 帮我把 X / 请帮我记 X"
+    r"(请|帮我)(用|改用|换成|总是|始终|一直|把|记)",
+    re.IGNORECASE,
+)
+
 _PLOT_KEYWORDS_RE = re.compile(
     # Plot-type words that are unambiguous (violin/heatmap/barplot/boxplot).
     # ``umap`` / ``tsne`` excluded — algorithm names without plot intent.
@@ -148,6 +177,18 @@ def memory_in_use(req: ContextAssemblyRequest) -> bool:
     Triggers the memory hygiene rule (no secrets / PII / transient errors).
     """
     return bool(_MEMORY_KEYWORDS_RE.search(req.query or ""))
+
+
+def preference_statement_intent(req: ContextAssemblyRequest) -> bool:
+    """Fires when the user *declaratively* expresses a persistent preference,
+    without uttering a 记住 / remember trigger word.
+
+    Gates the ``remember`` tool so the LLM can persist preferences like
+    "以后请用中文回答" or "from now on use DESeq2" proactively. ``recall`` /
+    ``forget`` remain gated by ``memory_in_use`` alone — those are
+    explicit user actions, not LLM-initiated.
+    """
+    return bool(_PREFERENCE_STATEMENT_RE.search(req.query or ""))
 
 
 def plot_intent(req: ContextAssemblyRequest) -> bool:

--- a/omicsclaw/runtime/tool_predicates.py
+++ b/omicsclaw/runtime/tool_predicates.py
@@ -33,6 +33,20 @@ def _audio_intent(req: ContextAssemblyRequest) -> bool:
     return bool(_AUDIO_KEYWORDS_RE.search(req.query or ""))
 
 
+def _remember_intent(req: ContextAssemblyRequest) -> bool:
+    """Gate for the ``remember`` tool.
+
+    Fires on either an explicit memory keyword (``记住 / remember`` ...) OR
+    a declarative preference statement (``以后请用中文`` / ``from now on
+    use ...``). The OR matters because LLM-initiated preference writes
+    must work without the user uttering a trigger word — otherwise a
+    user stating "以后请用中文回答" silently never gets persisted (the
+    desktop-app bug). ``recall`` and ``forget`` keep ``memory_in_use``
+    alone — those are explicit user actions, not LLM-initiated.
+    """
+    return _pred.memory_in_use(req) or _pred.preference_statement_intent(req)
+
+
 # --- The mapping -------------------------------------------------------------
 
 TOOL_PREDICATE_MAP: dict[str, Callable[[ContextAssemblyRequest], bool]] = {
@@ -51,8 +65,8 @@ TOOL_PREDICATE_MAP: dict[str, Callable[[ContextAssemblyRequest], bool]] = {
     # PDF / paper → pdf_or_paper_intent
     "parse_literature": _pred.pdf_or_paper_intent,
     "fetch_geo_metadata": _pred.pdf_or_paper_intent,
-    # Memory → memory_in_use
-    "remember": _pred.memory_in_use,
+    # Memory → memory_in_use (remember widens to preference-statement intent).
+    "remember": _remember_intent,
     "recall": _pred.memory_in_use,
     "forget": _pred.memory_in_use,
     # Implementation intent → custom code execution

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -190,6 +190,92 @@ def test_memory_in_use_quiet_on_empty_query() -> None:
     assert memory_in_use(_req(query="")) is False
 
 
+# --- preference_statement_intent ---------------------------------------------
+# Gates the ``remember`` tool when the user states a persistent preference
+# without uttering an explicit "记住 / remember" trigger. Co-exists with
+# ``memory_in_use`` — ``remember`` fires on either predicate.
+
+def test_preference_statement_fires_on_chinese_persistent_preference() -> None:
+    from omicsclaw.runtime.predicates import preference_statement_intent
+
+    # Real symptom from the desktop-app bug: user states a language preference
+    # in Chinese without saying 记住.
+    assert preference_statement_intent(_req(query="以后请用中文回答")) is True
+    assert preference_statement_intent(_req(query="今后都用 DESeq2 跑 DE")) is True
+    assert preference_statement_intent(_req(query="总是用 harmony 做整合")) is True
+    assert preference_statement_intent(_req(query="默认用 leiden 聚类")) is True
+    assert preference_statement_intent(_req(query="我习惯把 DPI 设成 300")) is True
+
+
+def test_preference_statement_fires_on_english_persistent_preference() -> None:
+    from omicsclaw.runtime.predicates import preference_statement_intent
+
+    assert preference_statement_intent(
+        _req(query="from now on use DESeq2 for DE")
+    ) is True
+    assert preference_statement_intent(
+        _req(query="going forward, please reply in English")
+    ) is True
+    assert preference_statement_intent(
+        _req(query="always use harmony for batch correction")
+    ) is True
+    assert preference_statement_intent(
+        _req(query="I prefer to skip the doublet step")
+    ) is True
+    assert preference_statement_intent(
+        _req(query="default to leiden clustering")
+    ) is True
+
+
+def test_preference_statement_quiet_on_non_preference_query() -> None:
+    """Probes for false-positive triggers — common scientific phrasings
+    that contain ``以后``/``默认``/``always`` as time/state adverbs rather
+    than expressed preferences. These must NOT fire."""
+    from omicsclaw.runtime.predicates import preference_statement_intent
+
+    assert preference_statement_intent(_req(query="run sc-de")) is False
+    assert preference_statement_intent(_req(query="explain UMAP")) is False
+    # "以后" + 时间名词（不是动词）
+    assert preference_statement_intent(_req(query="以后再说")) is False
+    # "默认" 作形容词修饰参数名
+    assert preference_statement_intent(
+        _req(query="show me the default parameters")
+    ) is False
+    # bare "always" without a preference verb
+    assert preference_statement_intent(
+        _req(query="cells are always changing during differentiation")
+    ) is False
+
+
+def test_preference_statement_quiet_on_empty_query() -> None:
+    from omicsclaw.runtime.predicates import preference_statement_intent
+
+    assert preference_statement_intent(_req(query="")) is False
+
+
+def test_preference_statement_acceptable_overfire_on_casual_taste() -> None:
+    """Documents an intentional, low-cost over-fire boundary.
+
+    Casual personal-taste statements ("我喜欢 X", "我习惯 X", momentary
+    "请用 X" / "帮我把 X") fire this predicate even though they are not
+    workflow preferences. The cost of an over-fire is one tool's schema
+    (~600 tokens) briefly visible to the LLM, which still has to decide
+    whether to actually call ``remember`` with a valid ``memory_type``
+    (preference / insight / project_context). Keeping the regex
+    permissive here trades a small context cost for not missing real
+    declarative preferences — narrowing this would risk regressing the
+    fix for the desktop-app silent-preference-loss bug.
+
+    Future contributors: do not tighten without checking the regression
+    suite in ``test_tool_list_lazy_exposure.py`` still passes.
+    """
+    from omicsclaw.runtime.predicates import preference_statement_intent
+
+    assert preference_statement_intent(_req(query="我喜欢这首歌")) is True
+    assert preference_statement_intent(_req(query="我习惯早起")) is True
+    assert preference_statement_intent(_req(query="请用 git 提交这条")) is True
+
+
 # --- non_trivial_no_capability ------------------------------------------------
 
 def test_non_trivial_no_capability_fires_on_substantive_query_without_capability_block() -> None:

--- a/tests/test_tool_list_lazy_exposure.py
+++ b/tests/test_tool_list_lazy_exposure.py
@@ -129,6 +129,44 @@ def test_memory_tool_hidden_on_unrelated_query(tool: str) -> None:
     assert tool not in _selected_names(query="run sc-de")
 
 
+# Regression: desktop-app users state preferences declaratively
+# ("以后请用中文回答") without saying 记住/remember. Before, none of the
+# 3 memory tools were exposed, so LLM-initiated persistence silently
+# failed. Now ``remember`` co-gates on ``preference_statement_intent``,
+# but ``recall`` / ``forget`` stay strict — those are explicit user
+# actions, not LLM-initiated.
+
+PREFERENCE_STATEMENT_QUERIES = (
+    "以后请用中文回答",
+    "from now on use DESeq2 for DE",
+    "总是用 harmony 做整合",
+    "I prefer to skip the doublet step",
+    "默认用 leiden 聚类",
+)
+
+
+@pytest.mark.parametrize("query", PREFERENCE_STATEMENT_QUERIES)
+def test_remember_appears_on_preference_statement(query: str) -> None:
+    assert "remember" in _selected_names(query=query), (
+        f"remember tool must be exposed on declarative preference "
+        f"statement {query!r} so the LLM can persist it without the "
+        f"user uttering 记住/remember explicitly."
+    )
+
+
+@pytest.mark.parametrize("query", PREFERENCE_STATEMENT_QUERIES)
+def test_recall_forget_hidden_on_preference_statement(query: str) -> None:
+    selected = _selected_names(query=query)
+    assert "recall" not in selected, (
+        f"recall is an explicit-user-action tool; should NOT be exposed "
+        f"merely because the user stated a preference: {query!r}"
+    )
+    assert "forget" not in selected, (
+        f"forget is an explicit-user-action tool; should NOT be exposed "
+        f"merely because the user stated a preference: {query!r}"
+    )
+
+
 # --- Lazy-load mapping: implementation intent --------------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes a silent persistence-failure bug visible in the desktop app: when a user states a persistent preference declaratively ("以后请用中文回答", "from now on use DESeq2") **without** uttering a 记住/remember trigger word, the LLM was unable to persist it — the `remember` tool was filtered out of its tool list by the keyword-gated `memory_in_use` predicate. The LLM would reply with a verbal "got it" not backed by a DB write, and the next session lost the preference. The desktop "memory module" UI thus never showed the user's stated preference.

### Root cause

`omicsclaw/runtime/tool_predicates.py` mapped `remember` → `memory_in_use`, which fires only on `\b(remember|forget|recall|memorize)\b|记住|忘记|忘掉|回忆`. Declarative preferences without these keywords were silently dropped.

### Fix

Introduce a new `preference_statement_intent` predicate that catches declarative persistent-preference language in Chinese (`以后/今后/始终/一直/总是/每次` + preference verb, `默认 + 用/是/为`, `我习惯/喜欢/偏好`, `请/帮我` + verb) and English (`from now on`, `always/never/usually` + preference verb, `I prefer/usually/like/want to ...`, `default to ...`, `please always/never ...`).

`remember` is now gated by a new private `_remember_intent` that ORs `memory_in_use` with `preference_statement_intent`. `recall` / `forget` keep `memory_in_use` alone — those are explicit user actions, not LLM-initiated.

### Design alternative rejected

Making `remember` always-on. It blew Phase 2's context budget:

| Scenario | Before | After (always-on) | Budget |
|---|---|---|---|
| baseline | ~8000 chars | 10210 (+27%) | 8000 |
| realistic sc-de | ~12500 chars | 14931 (+20%) | 12500 |

The OR-predicate route keeps `remember` lazy-loaded so default-baseline cost is unchanged.

### Files changed

| File | Purpose |
|---|---|
| `omicsclaw/runtime/predicates.py` | Add `_PREFERENCE_STATEMENT_RE` regex + `preference_statement_intent()` |
| `omicsclaw/runtime/tool_predicates.py` | Add `_remember_intent` (OR-composition); switch `TOOL_PREDICATE_MAP["remember"]` to use it |
| `tests/test_predicates.py` | 5 unit tests: ZH-fires / EN-fires / false-positive probes / empty / acceptable-overfire boundary doc |
| `tests/test_tool_list_lazy_exposure.py` | End-to-end parametrize (5 preference queries × {remember appears, recall/forget hidden}) |

## Test plan

- [x] `pytest tests/test_predicates.py` — 48 passed (4 new unit tests + 1 boundary doc test)
- [x] `pytest tests/test_tool_list_lazy_exposure.py` — 86 passed (10 new parametrize cases)
- [x] `pytest tests/test_predicate_gated_injectors.py` — 29 passed
- [x] Wider regression: `pytest tests/test_tool_list_snapshots.py tests/bot/ tests/memory/ tests/test_bot_core_timeout.py` — 514 pass overall
- [x] TDD discipline: RED proven before GREEN at both layers (predicate + tool exposure)
- [x] Probed regex against 25 false-positive vectors including `"以后再说"`, `"the cells are always changing"`, `"默认值"`, `"I prefer the second option"`, `"一直跑不通"` — all correctly rejected

## Telemetry note

`predicate_hit / predicate_miss` events for `remember` now bucket under `_remember_intent` instead of `memory_in_use`. Any dashboard aggregating memory-keyword triggers will see the `remember` slice break out separately.

## Known pre-existing failure (out of scope)

`tests/test_tool_list_snapshots.py::test_realistic_scde_tool_list_under_phase2_budget` fails (12662 chars vs 12500 budget, +162 chars / +1.3%). **Pre-existing on `upstream/main` `b32540e` before any changes here** — confirmed by stashing my work and re-running. Worth filing a separate cleanup issue to either shave a tool description or revisit the Phase 2 budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now recognizes when you express persistent preferences (e.g., "I prefer," "from now on") and automatically enables the remember tool. Supports both English and Chinese preference statements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/203)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->