### PR TITLE
fix(providers): make /providers/test tolerate reasoning-model outputs

### DIFF
--- a/omicsclaw/app/server.py
+++ b/omicsclaw/app/server.py
@@ -3871,9 +3871,17 @@ async def test_provider(req: ProviderTestRequest):
         response = await client.chat.completions.create(
             model=runtime.model,
             messages=[{"role": "user", "content": "Say OK"}],
-            max_tokens=8,
+            max_tokens=64,
         )
-        content = str(response.choices[0].message.content or "").strip()
+        choice = response.choices[0]
+        message = choice.message
+        content = str(getattr(message, "content", "") or "").strip()
+        # Reasoning models (DeepSeek-R1, etc.) may emit final text in a
+        # non-standard `reasoning_content` field while leaving `content`
+        # empty when the token budget is consumed by chain-of-thought.
+        reasoning = str(getattr(message, "reasoning_content", "") or "").strip()
+        tool_calls = getattr(message, "tool_calls", None) or []
+        finish_reason = str(getattr(choice, "finish_reason", "") or "").strip()
     except Exception as exc:
         duration_ms = int((time.monotonic() - start) * 1000)
         return {
@@ -3890,16 +3898,29 @@ async def test_provider(req: ProviderTestRequest):
             await client.close()
 
     duration_ms = int((time.monotonic() - start) * 1000)
-    if not content:
+    has_signal = bool(content) or bool(reasoning) or bool(tool_calls)
+    if not has_signal:
+        hint = f" (finish_reason={finish_reason})" if finish_reason else ""
         return {
             "ok": False,
             "status": "failed",
             "provider": runtime.provider,
             "model": runtime.model,
             "base_url": runtime.base_url,
-            "message": "Live provider test returned an empty response.",
+            "message": f"Live provider test returned no content{hint}.",
             "duration_ms": duration_ms,
         }
+
+    detail_bits: list[str] = []
+    if content:
+        detail_bits.append("content")
+    if reasoning:
+        detail_bits.append("reasoning_content")
+    if tool_calls:
+        detail_bits.append("tool_calls")
+    if finish_reason:
+        detail_bits.append(f"finish_reason={finish_reason}")
+    detail = ", ".join(detail_bits)
 
     return {
         "ok": True,
@@ -3908,6 +3929,7 @@ async def test_provider(req: ProviderTestRequest):
         "model": runtime.model,
         "base_url": runtime.base_url,
         "message": "Live provider test passed.",
+        "detail": detail,
         "duration_ms": duration_ms,
     }
 

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -2044,6 +2044,111 @@ async def test_provider_test_closes_async_openai_client(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_provider_test_accepts_reasoning_only_response(monkeypatch):
+    """Reasoning models (DeepSeek-R1, etc.) emit final text in
+    `reasoning_content` when the `max_tokens` budget is spent on
+    chain-of-thought — that must still count as PASSED, not empty."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        async def _create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content="",
+                            reasoning_content="Thinking about OK...",
+                            tool_calls=None,
+                        ),
+                        finish_reason="length",
+                    )
+                ]
+            )
+
+        async def close(self):
+            pass
+
+    class FakeCore:
+        LLM_PROVIDER_NAME = ""
+        OMICSCLAW_MODEL = ""
+
+    monkeypatch.setattr(server, "_get_core", lambda: FakeCore())
+    monkeypatch.setattr(server, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    result = await server.test_provider(
+        server.ProviderTestRequest(
+            provider="custom",
+            model="deepseek-reasoner",
+            base_url="https://api.deepseek.com/v1",
+            api_key="sk-test",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "passed"
+    assert "reasoning_content" in result.get("detail", "")
+    assert "finish_reason=length" in result.get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_provider_test_empty_response_includes_finish_reason(monkeypatch):
+    """When everything is empty, surface finish_reason so the user can
+    tell e.g. content_filter from length cap."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.app import server
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        async def _create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content="",
+                            reasoning_content="",
+                            tool_calls=None,
+                        ),
+                        finish_reason="content_filter",
+                    )
+                ]
+            )
+
+        async def close(self):
+            pass
+
+    class FakeCore:
+        LLM_PROVIDER_NAME = ""
+        OMICSCLAW_MODEL = ""
+
+    monkeypatch.setattr(server, "_get_core", lambda: FakeCore())
+    monkeypatch.setattr(server, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    result = await server.test_provider(
+        server.ProviderTestRequest(
+            provider="custom",
+            model="qwen-plus",
+            base_url="https://api.example.com/v1",
+            api_key="sk-test",
+        )
+    )
+
+    assert result["ok"] is False
+    assert "finish_reason=content_filter" in result["message"]
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_omits_adaptive_thinking_for_siliconflow(monkeypatch):
     """SiliconFlow gateway rejects non-standard thinking types — adaptive must omit."""
     pytest.importorskip("fastapi")


### PR DESCRIPTION
## Problem

OmicsClaw Desktop App's settings → connection diagnostic always returns

> Live provider test returned an empty response.

whenever the active provider is **`deepseek-v4-flash`** or **`deepseek-v4-pro`**, even with valid credentials and a reachable endpoint. The user can chat normally, but the diagnostic falsely reports a failure.

## Root cause

`omicsclaw/app/server.py::test_provider` issued the smallest possible probe — `messages=[{"Say OK"}], max_tokens=8` — and judged success solely by whether `message.content` came back non-empty.

Two assumptions break for the DeepSeek V4 series:

1. **The visible answer is on `message.content`.** V4-flash / V4-pro are thinking-mode endpoints; the chain-of-thought output is on a non-standard **`message.reasoning_content`** field. The codebase already documents this quirk in `omicsclaw/core/llm_patches.py` ("DeepSeek V3.x/V4 thinking-mode endpoints…").
2. **8 tokens is enough.** V4 burns the entire budget on internal reasoning and emits `finish_reason="length"` before any visible content can land in either channel.

So the API call succeeds, credentials and routing are verified, but the test reports "empty response" because the success criterion was too narrow.

## Fix

Treat `/providers/test` as a **connectivity probe**, not a literal-text validator.

| Change | Reason |
|---|---|
| `max_tokens` 8 → 64 | Reasoning models keep room for a visible final answer after thinking |
| Accept `content` **or** `reasoning_content` **or** `tool_calls` as a pass signal | All three are legitimate "the model responded" shapes (V4, R1, function-calling models) |
| On failure, append `finish_reason` to the message | Lets users distinguish `length` (raise max_tokens), `content_filter` (provider blocked the prompt), and `stop` (model genuinely returned nothing) |
| On success, return a `detail` field listing which signals hit | Surfaces diagnostic context in the App's doctor panel (e.g. `"reasoning_content, finish_reason=length"`) |

All extractions use `getattr(..., default)` so providers without `reasoning_content` (OpenAI, Anthropic-via-proxy, etc.) just see `""` and fall back to `content` — no behavior change on the OpenAI happy path.

## Verification

```
$ pytest tests/test_app_server.py -k provider_test
3 passed in 2.87s
```

| Test | What it locks down |
|---|---|
| `test_provider_test_closes_async_openai_client` *(existing)* | OpenAI-shape happy path + resource cleanup — unchanged contract |
| `test_provider_test_accepts_reasoning_only_response` *(new)* | V4 thinking shape: `content=""`, `reasoning_content` populated, `finish_reason="length"` → **PASSED** with `detail` listing the signal |
| `test_provider_test_empty_response_includes_finish_reason` *(new)* | Truly-empty path → **FAILED** with `finish_reason=content_filter` surfaced in the message |

## Risk / Compatibility

- **API-shape additive only**: success payload gains a `detail` field; existing consumers ignoring unknown fields are unaffected.
- **Non-DeepSeek providers**: `getattr(message, "reasoning_content", "")` returns `""` when the attribute doesn't exist, so the OpenAI / Anthropic-compatible path keeps using `content` exactly as before.
- **Companion Desktop App work**: the new `detail` field flows through the existing `src/app/api/providers/doctor/route.ts` handler in OmicsClaw-App with no app-side change required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OpenAI-compatible provider response handling to properly recognize and process responses containing content, reasoning signals, and tool calls
  * Improved error diagnostics with detailed feedback on detected response components for better troubleshooting

* **Tests**
  * Added test coverage for reasoning-only response scenarios and empty response handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/205)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
