### PR TITLE
sync(infra): ADR 0008→0009 — run_query_engine decomposition + cancel_event wiring

### DIFF
--- a/docs/adr/0008-decompose-run-query-engine-into-helpers.md
+++ b/docs/adr/0008-decompose-run-query-engine-into-helpers.md
@@ -1,0 +1,480 @@
+# Decompose `run_query_engine` into four private helpers
+
+## Status
+
+Accepted (2026-05-16).
+
+## Context
+
+ADR 0007 §Costs deferred a known problem:
+
+> *`run_query_engine` gains a `state: LoopState` parameter and three
+> detection / injection touchpoints inside its body. The function
+> itself does not shrink — `LoopState` is additive surface, not a
+> refactor of the existing body. The 460+ line readability problem
+> is left for a separate ADR.*
+
+This is that ADR.
+
+`omicsclaw/runtime/agent/query_engine.py:520` (`run_query_engine`)
+now spans **491 lines of body** (lines 520–1011 in the post-L1 file).
+The function is the single entry point that drives one chat turn
+through "LLM call → tool exec → result handling" until a final reply
+or the iteration cap. Every Surface, every detector, every
+cross-cutting concern ultimately bottoms out here.
+
+A structural read of the function identifies **seven natural phases**:
+
+| # | Phase | Location | Lines | Density |
+|---|---|---|---|---|
+| 0 | Setup (callbacks, hooks, transcript priming, `LoopState`) | 520–591 | 63 | Linear |
+| 1 | Per-iteration message preparation | 592–620 | 28 | Linear |
+| 2 | LLM call + reactive-compact retry loop | 621–696 | 75 | **Dense** — nested `try/while/break`, 3-way control flow |
+| 3 | Assistant response persistence | 697–714 | 17 | Linear |
+| 4 | No-tool-calls → terminate | 715–728 | 13 | Linear |
+| 5 | Tool execution request build | 729–793 | 64 | Mid — nested loop over `tool_calls` |
+| 6 | Tool execution + approval resolution | 794–875 | 81 | **Dense** — 4-level nesting in approval flow |
+| 7 | Per-result post-processing + pathology | 876–1000 | 124 | **Dense** — hook events, store, callbacks, LoopState recording, interruption check, pathology detect + inject |
+
+Three of the seven phases (2, 6, 7) plus the long build phase (5)
+account for the bulk of cognitive load. They share a pattern: dense
+nested control flow + state that crosses phase boundaries.
+
+The pain surfaces during routine maintenance. Wiring the L1 pathology
+hook in ADR 0007 required reading every phase to find a safe
+insertion point, even though the actual change was 7 lines. The next
+detector (wall-clock timeout, per-tool token budget — both listed in
+ADR 0007 §Open questions) will repeat the same archaeology against
+a function that is now 491 lines instead of 460.
+
+### Why not the CellClaw approach
+
+CellClaw's analog `DecisionExecutionEngine`
+(`agent/execution_engine.py:49`) reaches **1348 lines** and uses
+class methods + Template Method hooks (`_before_iteration`,
+`_after_decision`, `_handle_terminal_decision`) to split concerns.
+ADR 0007 §Q3 explicitly rejected importing that shape because
+OmicsClaw runs a single execution mode (no direct-vs-queue split
+that motivated CellClaw's class hierarchy), and because
+`QueryEngineCallbacks` already provides composition-style variation.
+Reaffirming here: this ADR does **not** promote `run_query_engine`
+to a class. The decomposition is into free private async functions
+in the same module.
+
+## Decision
+
+Extract **four private async helpers** in `query_engine.py`,
+covering the four densest sub-flows identified in §Context. The
+main `run_query_engine` body shrinks from 491 → ~250 lines while
+remaining a single async function with the same external signature.
+
+The four design decisions resolved in the grilling session, in
+dependency order:
+
+**Q1 — Goal: pure readability.** Not testability (we already have
+65 close-net tests covering every external behaviour through
+`run_query_engine`'s seam), not extension surface (ADR 0007 §Q3
+explicitly rejected designing for hypothetical future hooks). The
+single forcing function is "the function is too long to navigate
+when adding a 7-line hook." Picking one driver keeps the refactor
+narrow; testability and extension-friendliness are byproducts that
+arrive for free without dictating the cut lines.
+
+**Q2 — Strategy: surgical extraction, not blanket per-phase
+decomposition.** Three alternative strategies were considered:
+
+- **Per-phase (7–8 helpers)** — rejected because phases 3 (17 lines)
+  and 4 (13 lines) are short and linear; extracting them is
+  ceremony with no payoff.
+- **Grouped-by-verb (4 helpers: setup / plan / execute / process)** —
+  rejected because the cross-phase state pressure forces a private
+  `_RunContext` dataclass to keep signatures sane (the "plan turn"
+  group spans 3 phases and reads/writes 7+ variables). Such a
+  carrier is one step away from the class promotion ADR 0007 §Q3
+  rejected.
+- **Surgical (extract only the dense lumps)** — accepted. Targets
+  exactly the four sub-flows whose density makes the function hard
+  to navigate. Each extracted helper has narrow inputs (≤13
+  parameters) and clear single-value or tuple returns. The leftover
+  main body shrinks proportionally without inheriting any new
+  abstraction.
+
+**Q3 — Module location: same file, `_`-prefixed private functions.**
+`query_engine.py` already hosts 19 underscore-prefixed module-level
+helpers (`_extract_completion_tokens`, `_materialize_message`,
+`_persist_prepared_compaction`, …) — adding four more aligns with
+the existing convention. Splitting to `query_engine_helpers.py` or
+to topical files (`_llm_call.py`, `_approval.py`, `_tool_outcome.py`)
+was rejected: the helpers are tightly coupled to the same private
+types (`MaterializedMessage`, `ToolExecutionRequest`,
+`QueryEngineCallbacks`) and live within the same conceptual unit;
+fragmenting them costs import overhead without buying any module
+boundary.
+
+**Q4 — Migration: one helper per commit (4 commits) + ADR
+doc commit = 5 commits total.** Single-commit landing (~250 line
+diff) was considered and rejected — bisectability matters when
+mechanical refactors silently break a subtle control-flow assumption
+(the `has_attempted_reactive_compact` flag, the `current_policy_state`
+mutation chain, the `interruption_message` early-return semantics
+are all the kind of state that a careless extraction can drop on
+the floor). Per-helper commits also mirror the phased pattern
+established in ADRs 0004 / 0006 / 0007, which a future reader can
+bisect through `git log` without context switching.
+
+### The four helpers
+
+#### 1. `_call_llm_with_reactive_compact_retry`
+
+Extracts phase 2 (`query_engine.py:621–696`, ~75 lines).
+
+```python
+async def _call_llm_with_reactive_compact_retry(
+    *,
+    llm,
+    config: QueryEngineConfig,
+    callbacks: QueryEngineCallbacks,
+    system_prompt: str,
+    history: list,
+    chat_id: int | str,
+    tool_result_store: ToolResultStore,
+    transcript_store: TranscriptStore,
+    compaction_metadata: dict | None,
+    compaction_workspace: str | None,
+    request_tools: list,
+    on_usage_delta: Callable,
+    has_attempted_reactive_compact: bool,
+) -> tuple[MaterializedMessage, bool]:
+    """One LLM turn with on-demand reactive compaction.
+
+    Returns the materialised assistant message plus the (possibly
+    flipped) ``has_attempted_reactive_compact`` flag.
+    """
+```
+
+13 inputs is the largest signature of the four. Every input is
+load-bearing — reactive compaction needs `compaction_metadata`,
+`compaction_workspace`, and the `context_compaction` portion of
+config; the inner `try/except llm_error_types` branch needs both
+the LLM client and the on-error callback. Accepting the wide
+signature is the cost of NOT introducing a `_RunContext` carrier;
+the carrier would have hidden the same dependencies behind a single
+parameter without removing them.
+
+The `(message, flag)` tuple return preserves the one-shot semantics
+of reactive compact: once the flag is set in this run, the helper
+will not retry compaction on a subsequent LLM error. The caller
+mirrors the flag back into its own local before the next iteration.
+
+#### 2. `_resolve_tool_approval_flow`
+
+Extracts phase 6 (`query_engine.py:796–875`, ~80 lines — the body
+of the `if callbacks.request_tool_approval is not None:` block).
+
+```python
+async def _resolve_tool_approval_flow(
+    *,
+    execution_results: list[ToolExecutionResult],
+    callbacks: QueryEngineCallbacks,
+    context: QueryEngineContext,
+    current_policy_state: ToolPolicyState | None,
+) -> tuple[list[ToolExecutionResult], ToolPolicyState | None]:
+    """Drive ``request_tool_approval`` for any REQUIRE_APPROVAL
+    results. Returns (resolved_results, possibly_updated_policy_state)."""
+```
+
+4 inputs, 2 outputs — the cleanest signature of the four, which
+itself validates the surgical strategy: the densest visible
+sub-flow turns out to have the narrowest natural seam. The
+4-level nesting in the original (loop over results → check policy
+→ call approval callback → conditional re-execute) collapses into
+one helper that reads as "process this list of results through the
+approval pipeline."
+
+#### 3. `_record_tool_outcome`
+
+Extracts the body of phase 7's per-result loop
+(`query_engine.py:877–950`, the body of
+`for execution_result in execution_results:` ~74 lines, **excluding**
+the `interruption_message` early-return check and the pathology
+detect+inject that follow the loop and stay in the main body).
+
+```python
+async def _record_tool_outcome(
+    *,
+    execution_result: ToolExecutionResult,
+    context: QueryEngineContext,
+    callbacks: QueryEngineCallbacks,
+    tool_runtime_context: dict | None,
+    tool_result_store: ToolResultStore,
+    transcript_store: TranscriptStore,
+    hook_runtime,
+    tool_state: Any,
+    state: LoopState,
+) -> str:
+    """Persist one tool result, fire hooks and after_tool callback,
+    record into LoopState. Returns the per-result candidate
+    interruption_message ('' if none)."""
+```
+
+9 inputs is "medium" — the inflation comes from the three coexisting
+"after-tool" mechanisms this code path has accreted (hook_runtime
+events, pre-call rule preamble injection from
+`tool_runtime/execution_hooks.py`, the legacy `after_tool` callback).
+Untangling those three is **out of scope** for this ADR — it is its
+own historical-debris cleanup that needs ADR 0009 or later.
+
+The interruption-message check itself stays in the main body; the
+helper returns the candidate string and the caller decides what to
+do with it (preserving the original "first non-empty wins"
+semantics).
+
+#### 4. `_build_execution_requests`
+
+Extracts phase 5 (`query_engine.py:741–794`, ~52 lines). The
+"bonus" fourth helper agreed on in Q3.1 of the session.
+
+```python
+async def _build_execution_requests(
+    *,
+    tool_calls: list,
+    context: QueryEngineContext,
+    callbacks: QueryEngineCallbacks,
+    tool_runtime: ToolRuntime,
+    tool_runtime_context: dict | None,
+    current_policy_state: ToolPolicyState | None,
+    hook_runtime,
+) -> tuple[list[ToolExecutionRequest], dict[str, Any]]:
+    """Parse each assistant tool_call into a ToolExecutionRequest,
+    emit EVENT_TOOL_BEFORE hooks, and run before_tool callbacks.
+    Returns (requests, tool_states_by_call_id)."""
+```
+
+7 inputs, 2 outputs. The `tool_states` dict carries
+before_tool-callback return values keyed by `call_id`; the caller
+later threads it into `after_tool` invocations (currently inside
+`_record_tool_outcome`). Including this helper takes the main body
+from ~150 → ~110 lines, which is the point where the for-loop
+becomes a 5-verb narrative: prepare → call → persist → execute →
+process.
+
+### Migration phases
+
+Five commits, each independently green on CI.
+
+    ADR  docs(adr): record run_query_engine decomposition as ADR 0008
+
+    L1   refactor(query_engine): extract _call_llm_with_reactive_compact_retry
+    L2   refactor(query_engine): extract _resolve_tool_approval_flow
+    L3   refactor(query_engine): extract _record_tool_outcome
+    L4   refactor(query_engine): extract _build_execution_requests
+
+Order is chosen by *density* (largest control-flow lump first): the
+LLM-call retry block is the riskiest to extract correctly (nested
+try/while/break with reactive compact recovery), so it lands first
+while the surrounding context is still maximally familiar. The
+build phase is the cleanest and lands last as a low-risk
+victory-lap commit. Any commit can be reverted independently
+without unwinding the others.
+
+Each commit body:
+- pulls a contiguous block of code out of `run_query_engine` into a
+  new module-level `_`-prefixed async function
+- replaces the original block with a single `await _helper(...)` call
+- runs `pytest tests/test_query_engine*.py tests/test_query_engine_pathology.py tests/test_agent_dispatcher.py tests/test_query_engine_compaction_callback.py tests/test_query_engine_deepseek_passback.py tests/test_query_engine_reasoning_capture.py tests/test_query_engine_stream_usage.py` (65 tests) and confirms green
+
+After L4, one final regression matches the post-ADR-0007 baseline
+(25 pre-existing failures, 0 new).
+
+## Considered Options
+
+- **Option Class-Promotion — make `run_query_engine` a class with
+  Template Method hooks.** Mirrors CellClaw's
+  `DecisionExecutionEngine`. Rejected for the same reason ADR 0007
+  §Q3 rejected it: composition via `QueryEngineCallbacks` already
+  provides variation; class promotion would create two ways to do
+  one thing. Reaffirmed here.
+
+- **Option Per-Phase — extract one helper per natural phase
+  (7–8 helpers).** Rejected because phases 3 and 4 (17 and 13
+  lines respectively, both linear) gain nothing from extraction.
+  YAGNI applied at the helper level: only extract where the cost
+  of inline reading exceeds the cost of a function call.
+
+- **Option Grouped-by-Verb — 4 helpers along setup / plan /
+  execute / process verbs.** Cleanest narrative on paper but
+  forces a `_RunContext` dataclass to keep signatures sane (the
+  "plan turn" helper would have 10+ inputs). The carrier is a
+  class in all but name; ADR 0007 §Q3 ruled against that line.
+
+- **Option Carrier-Pattern — introduce `_RunContext` dataclass
+  threaded through every helper.** Hides the wide signatures
+  behind a single parameter. Rejected because the wide signatures
+  are *honest*: they declare exactly what each helper depends on.
+  A carrier would make every helper appear to depend on the entire
+  context, defeating the readability win.
+
+- **Option Split-File — move helpers to
+  `query_engine_helpers.py`.** Rejected: 19 existing private
+  helpers already live in `query_engine.py`; splitting four off
+  would fragment a logical unit and add cross-file import
+  overhead. The file size (currently ~1010 lines, ~960 after L4
+  because some local variables in `run_query_engine` get
+  reorganised) is a separate concern. Splitting for size alone
+  is treating the symptom, not the cause.
+
+- **Option Topical-Split — three new files
+  `_llm_call.py` / `_approval.py` / `_tool_outcome.py`.**
+  Rejected as scope creep beyond the smallest clear change. The
+  test directory structure would also have to absorb the split,
+  and the helpers' tight coupling to private types makes the
+  module boundary nominal rather than meaningful.
+
+- **Option Single-Commit — land all four extractions in one
+  commit.** ~250 line diff. Rejected because the four extractions
+  are independent and mechanical: per-commit landing buys real
+  bisectability against subtle control-flow regressions
+  (`has_attempted_reactive_compact` flag flow, `current_policy_state`
+  mutation chain, `interruption_message` early-return semantics
+  are exactly the kind of state that an inattentive extraction
+  drops). Same reasoning ADR 0006 §Q8 used to choose L0-L4 phased
+  landing over atomic landing.
+
+- **Option Add-Helper-Unit-Tests — write a dedicated test file
+  exercising each helper in isolation.** Out of scope for this
+  ADR. Q1 picked "pure readability" as the driver; testability is
+  a byproduct that arrives because helpers can now be mocked
+  individually, but adding tests proactively pivots the goal to
+  Q1=B (testability) and inflates the PR with code that the
+  existing 65 integration tests already exercise. Reintroduce
+  if and when a regression slips past the integration suite that
+  a helper unit test would have caught.
+
+## Consequences
+
+**Wins**
+
+- `run_query_engine` body shrinks from 491 → ~250 lines. The
+  main for-loop becomes a 5-verb narrative (prepare → call →
+  persist → execute → process) that a new reader can trace in
+  one screen rather than scrolling.
+- Future detectors and callbacks have a smaller insertion target.
+  When the wall-clock timeout detector or per-tool budget detector
+  from ADR 0007 §Open questions lands, the contributor reads
+  `_record_tool_outcome` (74 lines) rather than archaeology
+  through 491.
+- Bisectability: a regression introduced by any single extraction
+  is isolated to that L1-L4 commit. ADR 0006's "smallest clear
+  change" principle applies at the commit level, not just at the
+  ADR level.
+- The cleanest helper (`_resolve_tool_approval_flow`, 4 inputs)
+  validates the surgical strategy: density does correlate with
+  natural seams, and we are extracting along those seams.
+- The 19 existing module-level `_`-prefixed helpers in
+  `query_engine.py` now have four more in the same style; the
+  module's internal organisation becomes more consistent rather
+  than less.
+
+**Costs**
+
+- `query_engine.py` total line count is roughly unchanged (~1010 →
+  ~960). The win is in function-level cognitive load, not in file
+  size. A reader who navigates by line count rather than function
+  scope will not perceive a win.
+- Four new module-level names (`_call_llm_with_reactive_compact_retry`,
+  `_resolve_tool_approval_flow`, `_record_tool_outcome`,
+  `_build_execution_requests`). Anyone reading the function inline
+  must now context-switch to the helper definitions to read the
+  details — the tradeoff against scrolling-through-491-lines.
+- The largest helper signature (`_call_llm_with_reactive_compact_retry`,
+  13 inputs) is wide enough to invite future "wrap this in a
+  carrier" pressure. The ADR-level decision is explicitly that the
+  width is honest declaration of dependencies, not a code smell to
+  fix — but the line will need defending in code review.
+- The 3-mechanism after-tool layer in `_record_tool_outcome`
+  (hook_runtime events + pre-call rule preamble + legacy
+  `after_tool` callback) survives intact. Untangling that knot is
+  its own ADR.
+
+**Alternatives are catalogued under §Considered Options above.**
+
+## Verification
+
+Per-phase gates, mirroring the per-L gate pattern of ADR 0006 and
+ADR 0007.
+
+- **L1:** `pytest tests/test_query_engine.py
+  tests/test_query_engine_compaction_callback.py
+  tests/test_query_engine_deepseek_passback.py
+  tests/test_query_engine_reasoning_capture.py
+  tests/test_query_engine_stream_usage.py
+  tests/test_query_engine_pathology.py
+  tests/test_agent_dispatcher.py` — 65 tests must remain green.
+  The reactive-compact path is exercised by
+  `test_query_engine_compaction_callback.py` (5 cases); the
+  retry-on-prompt-too-long path is exercised by the
+  `_FakePromptTooLongError` fixture in `test_query_engine.py`.
+
+- **L2:** Same 65-test invocation green. The approval flow is
+  exercised by `test_run_query_engine_records_policy_blocked_tool_results`
+  and any test using `REQUIRE_APPROVAL` policy decisions in
+  `test_query_engine.py`.
+
+- **L3:** Same 65-test invocation green. Per-result handling is
+  exercised by every test that runs at least one tool, including
+  `test_run_query_engine_executes_tools_and_records_transcript`
+  and the four pathology tests in
+  `test_query_engine_pathology.py` (which depend critically on
+  `ToolCallRecord` / `ToolErrorRecord` being appended into
+  `LoopState`).
+
+- **L4:** Same 65-test invocation green. The tool-request build
+  path is exercised by every test that emits tool_calls.
+
+- **Final:** Full regression
+  `pytest tests/ --ignore=tests/integration --ignore=tests/eval
+  --deselect tests/test_autoagent_runtime.py::test_call_llm_reuses_active_provider_runtime`
+  — result must match the post-ADR-0007 baseline (25 pre-existing
+  failures, 0 new; 2677 passed). Any deviation indicates a
+  refactor regression and the offending L-commit can be reverted
+  in isolation.
+
+A `/graphify` re-index lands after L4 so that knowledge-graph
+queries for "LLM call retry" / "tool approval flow" return the new
+helper anchors rather than the buried original blocks.
+
+## Open questions
+
+Tracked but not resolved here:
+
+- **`query_engine.py` total file size.** Stays at ~960 lines after
+  L4. Splitting the module is a separate decision driven by
+  module-boundary semantics (does anything in this file belong in
+  a different conceptual unit?), not by line count. No current
+  signal forces the split.
+
+- **The three-mechanism after-tool layer in `_record_tool_outcome`.**
+  `hook_runtime` events, pre-call rule preamble injection from
+  `tool_runtime/execution_hooks.py`, and the legacy `after_tool`
+  callback all fire on every tool result. Consolidating them is
+  its own historical-debris cleanup; this ADR preserves the
+  existing 3-way fan-out verbatim inside the helper.
+
+- **Helper unit tests.** Each helper is now individually mockable.
+  Whether to add per-helper unit tests is a Q1=B (testability)
+  decision; Q1=A (readability) deferred it. Reintroduce when a
+  regression slips past the 65 integration tests in a way that a
+  unit test would have caught.
+
+- **`_RunContext` carrier.** The widest helper signature
+  (`_call_llm_with_reactive_compact_retry`, 13 inputs) is honest
+  about dependencies but invites code-review pressure to "tidy it
+  up." That pressure should be deflected: ADR 0007 §Q3 and this
+  ADR §Q2 both ruled against state-carrier classes. Document the
+  rationale once in code comments if the question recurs in review.
+
+- **Cross-file split for further growth.** If any of the four
+  helpers grows past ~100 lines on its own (e.g.
+  `_resolve_tool_approval_flow` if the approval semantics expand),
+  a `query_engine_approval.py` could become justified. Not
+  motivated by current code state.

--- a/docs/adr/0009-wire-cancel-event-through-dispatch.md
+++ b/docs/adr/0009-wire-cancel-event-through-dispatch.md
@@ -1,0 +1,515 @@
+# Wire `cancel_event` from `MessageEnvelope` through `dispatch()` down to the skill subprocess driver
+
+## Status
+
+Accepted (2026-05-18).
+
+## Context
+
+ADR 0006 §"Open questions" left one item explicitly deferred:
+
+> *Cancellation contract.* Desktop has `pending_preflight_requests` and
+> a chat-stream cancel endpoint; CLI has Ctrl-C; Channel has nothing.
+> A unified cancel token would naturally live on the `MessageEnvelope`,
+> but no Surface today consumes it consistently enough to motivate
+> the contract. Revisit when a real cross-Surface cancel concern
+> emerges.
+
+Two days later (2026-05-18) a grilling session against CellClaw's
+`agent/tools/base.py:execute_with_cancel_check` re-opened the question.
+The session produced two findings that together cross the "real concern
+emerged" bar:
+
+**Finding 1 — long bioinformatics jobs are uncancellable end-to-end.**
+The skills under `skills/spatial-velocity/`, `skills/sc-pseudotime/`,
+`skills/bulkrna-survival/`, etc. spawn Python subprocesses that run
+5–15 minutes (scVelo CNV inference, scanpy harmony integration,
+pyDESeq2 with 50k+ genes). A user who realises mid-run that they
+passed the wrong `--method` argument has no way to stop the burn:
+the LLM stream continues, the subprocess continues, and on shared
+hardware the GPU memory stays pinned.
+
+**Finding 2 — the Desktop `/chat/abort` endpoint is wired but断链 ("broken
+chain").** `omicsclaw/surfaces/desktop/server.py:1946-1954` defines
+`POST /chat/abort` which looks up the session's `asyncio.Task` from
+`_active_sessions` and calls `task.cancel()`. That raises
+`asyncio.CancelledError` at the next await point in `dispatch()` —
+which `runtime/agent/dispatcher.py:126` catches at the outermost
+level — but the `skill.runner.run_skill()` call that is currently
+streaming subprocess stdout into the tool result never sees the
+cancellation. The subprocess keeps running in its detached process
+group even though the user pressed the abort button.
+
+The grilling session then surfaced a third finding that reshaped the
+ADR from "introduce CellClaw's mechanism" to "wire OmicsClaw's existing
+chain":
+
+**Finding 3 — OmicsClaw already has a more thorough subprocess-level
+cancel than CellClaw.** A trace of `cancel_event` references through
+the tree shows two disconnected halves:
+
+| Side | Files | What it does |
+|---|---|---|
+| **Producer** | `autoagent/api.py:75`, `autoagent/runner.py:47`, `autoagent/optimization_loop.py`, `autoagent/harness_loop.py` | Holds a `threading.Event`, signals `cancel_event.set()` on user / API request, plumbs it through every layer |
+| **Consumer** | `skill/runner.py:289-361`, `skill/execution/subprocess_driver.py:70`, `skill/execution/async_subprocess_driver.py:59-83` | `start_new_session=True` + `os.killpg(pgid, SIGTERM)` → 2s grace → `os.killpg(pgid, SIGKILL)`, reaches every grandchild |
+
+Both halves are reachable from the **`autoagent` automated-optimization
+path** (harness experiments, optimization loops). Neither half is
+reachable from the **`runtime/agent/dispatcher → query_engine →
+execute_tool_requests → tool executor`** path that the three live
+Surfaces (Channel, Desktop, CLI) actually exercise. A `grep -rn
+"cancel_event" omicsclaw/runtime/` returns only two hits, both inside
+`dispatcher.py`'s outermost `try/except asyncio.CancelledError`
+clean-up — zero in `query_engine.py`, zero in `runtime/tools/`.
+
+In other words: the cancellation infrastructure is **stronger than
+CellClaw's** (CellClaw's `execute_with_cancel_check` only `task.cancel()`s
+the coroutine; OmicsClaw's `subprocess_driver` actively `killpg`s the
+process group). The gap is structural, not capability — the chat
+loop and the skill runner have never been wired together for cancel
+even though both individually support it.
+
+### Why not import CellClaw's mechanism
+
+CellClaw's `execute_with_cancel_check` (`agent/tools/base.py:100-156`)
+is a 56-line `asyncio.wait_for + asyncio.shield` polling wrapper that
+checks `cancel_event` every 50ms. It is a perfect fit for cooperative
+cancellation of pure-coroutine tools that do not spawn subprocesses.
+OmicsClaw's three live Surfaces drive subprocess-heavy tools through
+`skill.runner.run_skill()`, which already does the harder work: killpg
+on a process group spawned with `start_new_session=True`, with a
+SIGTERM→grace→SIGKILL escalation ladder. Importing `execute_with_cancel_check`
+would solve the smaller problem (pure-coroutine tools) at the cost of
+introducing a parallel cancel mechanism alongside the killpg one.
+After this ADR the pure-coroutine case is left as a follow-up: a
+later detector pass (`grep` for tools that do not bottom out at
+`skill.runner.run_skill`) can decide whether enough of them exist to
+motivate the polling wrapper.
+
+## Decision
+
+Add a single `cancel_event: threading.Event | None = None` field to
+`MessageEnvelope`, thread it through `dispatch()` →
+`QueryEngineCallbacks` → `execute_tool_requests` →
+`tool_runtime.executors[*]` → `skill.runner.run_skill(cancel_event=…)`,
+and wire `Desktop /chat/abort` and `CLI SIGINT` to call
+`envelope.cancel_event.set()`.
+
+`Channel Surface` is **out of scope** for this ADR — the 10 IM adapters
+have no native cancel UI primitive (a `/stop` slash command is the
+closest, but routing it through the dispatcher loop is its own
+design tree). Adding cancel to Channel will be a follow-up ADR if
+and when a real adapter user requests it; the closed-bracket precedent
+is ADR 0007 §"Open questions" where `PathologyDetected` rendering on
+Channel is similarly deferred.
+
+The five design decisions resolved in the grilling session, in
+dependency order:
+
+**Q1 — Forcing function: two concrete pains, not one architectural
+itch.** The session considered four candidate forcing functions —
+(1) long bioinformatics jobs, (2) zombie subprocesses, (3) Telegram
+session timeouts, (4) Desktop断链. Picked (1) + (4) because each
+on its own is dismissible ("add a timeout!" / "fix the bug!"); only
+the two together explain why this is a *contract* issue and not a
+patch. (2) and (3) are downstream beneficiaries called out in
+§Consequences but not used as drivers.
+
+**Q2 — Scope: wire the existing chain, do not introduce CellClaw's
+`execute_with_cancel_check`.** The grilling session found OmicsClaw's
+`skill/execution/async_subprocess_driver.py:59-83` already implements
+SIGTERM→grace→SIGKILL via `os.killpg`, reaching grandchild processes
+via `start_new_session=True`. CellClaw's wrapper is a coarser-grained
+`task.cancel()` + 2s wait. Importing the latter on top of the former
+would create two cancel mechanisms for the same concern — the same
+"parallel variation mechanism" anti-pattern ADR 0007 §Q3 and ADR
+0008 §Q2 both rejected. The ADR therefore becomes a wiring change,
+not a mechanism import.
+
+**Q3 — Location: `MessageEnvelope.cancel_event`, per-request lifetime.**
+ADR 0006 §"Open questions" already telegraphed this: *"A unified cancel
+token would naturally live on the `MessageEnvelope`."* The field
+joins the existing 18 fields on the `frozen=True` dataclass
+(`runtime/agent/envelope.py:18-42`). `threading.Event` is a mutable
+object whose **reference** does not change after construction — the
+frozen contract is preserved (no field reassignment), only the
+event's internal flag mutates via `.set()`. A short docstring note
+on the field makes this explicit.
+
+Two alternatives were rejected:
+
+- **Option `RuntimeContext` carrier** — a new dataclass holding
+  `cancel_event` plus future `started_at`, `request_id`, etc. Rejected
+  because ADR 0007 §Q4 already designated `LoopState` as the
+  per-iteration carrier for `started_at`/timeout-detector state; a
+  second carrier would split the per-request state surface across two
+  classes with no clear rule for which goes where. Reaffirming Q4 here:
+  one field is enough; future fields go on the existing carrier whose
+  role matches their lifetime.
+- **Option Session-level registry** — store `cancel_event` in a
+  `chat_id → Event` dict on the session store. Rejected because ADR
+  0006 §Q3 fixed the dispatcher's lifecycle as *"construct-run-discard
+  per inbound message,"* and a session-spanning registry violates that
+  invariant. The `_active_sessions: dict[session_id, asyncio.Task]`
+  that already lives at `surfaces/desktop/server.py:1949` is the
+  closest equivalent today; in Q4 below we reuse it to look up the
+  envelope alongside the task rather than creating a parallel dict.
+
+**Q4 — Surface scope: Desktop + CLI; Channel deferred.** Desktop has
+the `/chat/abort` endpoint (`server.py:1946`) and the
+`_active_sessions` registry — the wiring is a 3-line change inside
+the existing endpoint. CLI has six existing `KeyboardInterrupt`
+handlers in `surfaces/cli/interactive.py` (lines 844, 1332, 1577,
+1589, 2194, 2282); the relevant one for in-flight dispatch is the
+ESC/Ctrl+C branch at line 1577-1589 — also a 3-line change.
+
+Channel Surface has no parallel:
+- 10 adapters under `surfaces/channels/{telegram, feishu, slack, …}.py`
+- No native "stop generating" affordance in any IM platform's chat UI
+- A `/stop` slash command would need to be parsed inside `loop.py:62-63`
+  (the slash-command dispatcher) and routed back through the
+  `_active_sessions`-style registry per chat_id — at least 50-100 LOC
+  per adapter once edge cases (mid-tool-execution `/stop`, dedup,
+  rate-limit interaction) are handled
+- No user has asked for it; the forcing functions in Q1 are both
+  Desktop+CLI scenarios
+
+The same precedent ADR 0007 set for `PathologyDetected` rendering
+applies: "Channel may choose to ignore … initially if the Telegram
+render budget is tight." Cancel for Channel becomes a follow-up ADR
+when a real user complaint surfaces.
+
+**Q5 — Migration: five-step phased, no atomic landing.** Mirrors the
+L0-L4 pattern of ADRs 0006, 0007, and 0008. Each step independently
+green on CI:
+
+```
+ADR   docs(adr): record cancel_event wiring as ADR 0009 (this file)
+L1    runtime/agent/envelope.py: add MessageEnvelope.cancel_event field
+      + frozen-dataclass-with-mutable-Event docstring note
+      + unit test that field defaults to None and is keyword-constructible
+      + unit test that frozen=True still rejects field reassignment
+L2    runtime/agent/dispatcher.py + query_engine.py + tools/orchestration.py:
+      thread envelope.cancel_event through:
+        - dispatch() → llm_tool_loop() (loop.py gains a kwarg)
+        - llm_tool_loop() → QueryEngineCallbacks new field cancel_event
+        - run_query_engine() → execute_tool_requests(requests, cancel_event=…)
+        - execute_tool_requests → tool_runtime.executors[*] via
+          tool_runtime_context["cancel_event"] (already a dict, no
+          signature change for executors)
+      + integration test: fake 5-second sleep skill subprocess,
+        envelope.cancel_event.set() after 1 second, assert
+        Final event NOT emitted, Error(asyncio.CancelledError) IS
+        emitted, ps -o pid,sid shows no orphaned subprocess
+L3    surfaces/desktop/server.py: /chat/abort sets envelope.cancel_event
+      before task.cancel(); store envelope alongside task in
+      _active_sessions so the endpoint can look it up
+      + smoke test: POST /chat/stream with a long-running skill, POST
+        /chat/abort after 1 second, verify SSE stream ends with
+        Error frame and the subprocess is killpg'd
+L4    surfaces/cli/interactive.py: ESC/Ctrl+C handler in the streaming
+      branch sets envelope.cancel_event in addition to its existing
+      task cancel; preserve KeyboardInterrupt semantics at the REPL
+      level (those are out-of-dispatch and unchanged)
+      + manual smoke: `oc interactive` with a long-running skill,
+        press Ctrl+C, verify prompt returns and the subprocess is gone
+```
+
+L2 is the riskiest commit (touches three modules across two packages);
+L1 and L4 are surgical; L3 is mechanical. The ordering is dependency-
+forced (L1 must precede L2 must precede L3/L4); within L3/L4 the
+order is arbitrary and both can land in parallel PRs.
+
+### The signature changes
+
+#### `MessageEnvelope` (`runtime/agent/envelope.py`)
+
+```python
+@dataclass(frozen=True)
+class MessageEnvelope:
+    # … 18 existing fields …
+    cancel_event: threading.Event | None = None
+    """Set by the Surface to request mid-flight cancellation.
+
+    The dataclass is frozen, but ``threading.Event`` is a mutable
+    object — only its internal flag changes via ``.set()``, never
+    the field's reference. This preserves the frozen contract
+    (no reassignment) while allowing the live cancel signal.
+
+    None means cancellation is not supported by the calling Surface
+    (Channel Surface today). The dispatch chain treats None as
+    "never cancelled" and skips all cancel-check logic.
+    """
+```
+
+#### `QueryEngineCallbacks` (`runtime/agent/query_engine.py`)
+
+```python
+@dataclass
+class QueryEngineCallbacks:
+    # … 8 existing fields …
+    cancel_event: threading.Event | None = None
+    """Forwarded from MessageEnvelope. Threaded into
+    execute_tool_requests via tool_runtime_context."""
+```
+
+#### `execute_tool_requests` (`runtime/tools/orchestration.py:650`)
+
+```python
+async def execute_tool_requests(
+    requests: list[ToolExecutionRequest],
+    *,
+    cancel_event: threading.Event | None = None,
+) -> list[ToolExecutionResult]:
+    """… existing docstring … plus:
+
+    When ``cancel_event`` is set mid-execution, in-flight tools that
+    bottom out at ``skill.runner.run_skill`` get killpg'd; the function
+    returns whatever results completed before the signal, plus a
+    cancellation-marker result for the in-flight one.
+    """
+```
+
+The cancel_event reaches the skill driver via the existing
+`tool_runtime_context: dict[str, Any]` channel that already plumbs
+`workspace`, `pipeline_workspace`, etc. through to each executor.
+Adding one key (`"cancel_event"`) avoids changing 60+ executor
+signatures.
+
+## Considered Options
+
+- **Option CellClaw-Mechanism — import `execute_with_cancel_check`.**
+  56-line `asyncio.wait_for + shield` polling wrapper. Rejected because
+  `skill/execution/async_subprocess_driver.py:59-83` already implements
+  stronger subprocess-level cancel via killpg; importing the wrapper
+  would create two cancel mechanisms for the same concern (the
+  parallel-variation anti-pattern ADRs 0007 §Q3 and 0008 §Q2 both
+  rejected). Reintroduce only if a meaningful population of pure-
+  coroutine tools (no subprocess) emerges that the killpg path
+  cannot cover.
+
+- **Option RuntimeContext-Carrier — new dataclass holding cancel_event +
+  future per-request fields.** Rejected because ADR 0007 §Q4 already
+  designated `LoopState` as the per-request/iteration carrier for
+  state that detectors consume; a second carrier with no clear rule
+  for which fields go where would re-create the split-state problem
+  ADR 0007 §Q4 solved. A single field on `MessageEnvelope` is the
+  honest declaration of where this dependency comes from.
+
+- **Option Session-Registry — `chat_id → cancel_event` dict on the
+  session store.** Rejected because ADR 0006 §Q3 fixed the dispatcher's
+  lifecycle as construct-run-discard per inbound message; a session-
+  spanning registry would silently extend cancel state across turns
+  in a way that breaks the per-turn isolation. The existing
+  `_active_sessions: dict[session_id, asyncio.Task]` on Desktop is
+  retained but kept scoped to its current purpose (look up the task
+  to cancel); cancel state stays on the envelope it travels with.
+
+- **Option All-Surfaces — wire Channel adapters too.** Rejected per
+  Q4: no Channel adapter has a native cancel UI primitive; a `/stop`
+  slash command would need slash-dispatcher rework plus per-adapter
+  edge-case handling (mid-tool `/stop`, dedup, rate-limit interaction),
+  estimated 500-1000 LOC across 10 adapters. No user has asked. ADR
+  0007 set the precedent for deferring Channel rendering of cross-
+  cutting concerns until a real user request lands.
+
+- **Option Atomic — land L1-L4 in one commit.** ~150-200 LOC across
+  five files. Rejected because the four phases are independently
+  shippable (each one valid and CI-green on its own), and the L2
+  signature change is the largest risk surface — bisectability across
+  L1/L2/L3/L4 buys real value when a regression surfaces. Same
+  reasoning ADRs 0006, 0007, 0008 used.
+
+- **Option asyncio.Event instead of threading.Event.** Cleaner asyncio
+  semantics on the dispatch side. Rejected because `skill.runner.run_skill`,
+  `subprocess_driver.drive_subprocess`, and the entire `autoagent/`
+  cancel chain already consume `threading.Event` (~12 call sites).
+  Switching to `asyncio.Event` would require either dual-typing every
+  consumer or converting at the boundary; the conversion would
+  introduce a bridging actor that this ADR exists to avoid. Stay
+  consistent with the existing chain; the dispatcher already runs
+  inside an event loop and `Event.set()` is thread-safe-callable from
+  either side.
+
+- **Option Add `cancel_event` to every executor signature.** More
+  explicit than threading through `tool_runtime_context`. Rejected
+  because 60+ executors in `runtime/tools/builders/agent_executors.py`
+  would all need their signatures updated, and most never spawn
+  subprocesses — they would ignore the field. Threading through the
+  existing dict gives the same capability where it matters
+  (executors that call `skill.runner.run_skill`) without the
+  60-file edit.
+
+- **Option Skip the ADR, just fix /chat/abort as a bug.** Rejected
+  because the fix is necessarily structural: `task.cancel()` does not
+  propagate to a subprocess in another process group, so the
+  "single-line bug fix" is impossible. The minimal fix is the field
+  + the threading + the wire-up, which is exactly what this ADR
+  proposes. Recording it as an ADR ensures a future reader who finds
+  `threading.Event` on a frozen dataclass understands why.
+
+## Consequences
+
+**Wins**
+
+- Closes ADR 0006 §"Open questions" entry on the Cancellation
+  contract. The 4-day-old deferral resolves with a concrete contract.
+- Long bioinformatics jobs (`skills/spatial-velocity`, `skills/sc-pseudotime`,
+  `skills/bulkrna-survival`, `skills/sc-de`, all of which spawn
+  Python subprocesses for 5–15 minutes) become user-cancellable
+  end-to-end. The GPU-memory-pinning scenario in Finding 1 closes:
+  user presses abort → subprocess group receives SIGTERM →
+  scanpy/pyDESeq2 release GPU memory within the 2-second grace
+  before SIGKILL.
+- Desktop `/chat/abort` (`server.py:1946`) goes from "broken chain"
+  to working end-to-end. The fix is a 3-line change in the
+  endpoint plus the L2 plumbing.
+- Zero new cancel mechanism. The wiring composes two existing
+  mechanisms (the `autoagent` cancel_event producer side and the
+  `subprocess_driver` killpg consumer side) that already work
+  individually.
+- The `cancel_event` field on `MessageEnvelope` becomes the natural
+  home for any future Surface to opt into cancellation (e.g.
+  Channel's hypothetical `/stop` command in a follow-up ADR). The
+  contract is fixed; only the Surface-side wire-up is the new work.
+- The `tool_runtime_context: dict` injection point at
+  `runtime/agent/query_engine.py:104` already exists and already
+  passes `workspace`/`pipeline_workspace`/etc.; adding one key
+  is structurally trivial and a precedent for future per-request
+  data needs.
+
+**Costs**
+
+- `MessageEnvelope` grows from 18 fields to 19. The new field
+  carries the only mutable-internal-state field on the otherwise-
+  immutable dataclass; the docstring note is load-bearing
+  documentation that must survive future field reorderings or
+  documentation rewrites.
+- `QueryEngineCallbacks` grows by one optional field (`cancel_event`),
+  mirroring the additive growth pattern ADR 0007 §Costs flagged
+  for `on_pathology_signal`. External code that constructs the
+  dataclass positionally would break; a grep over the tree shows
+  all constructions are keyword-style (same as ADR 0007's grep),
+  so the additive field is safe.
+- `execute_tool_requests` gains a keyword-only kwarg. All current
+  call sites (`query_engine.py:1100`, two test sites) need updating
+  in L2.
+- `tool_runtime_context: dict[str, Any]` gains one reserved key
+  (`"cancel_event"`). Any downstream consumer of that dict that
+  iterates keys will see the extra entry — none currently iterate
+  (grep), but the convention now is "the dict carries cancel signal
+  too" which a future contributor needs to know.
+- Channel Surface remains cancel-less. Telegram / Feishu / etc.
+  users who run a 10-minute spatial-velocity command and want to
+  stop it have no recourse this PR — same as today. Documented as
+  intentional in Q4 with a forward pointer to the follow-up ADR.
+- Pure-coroutine tools (if any are added later) are not covered.
+  The killpg path is subprocess-shaped; a future tool that holds
+  the asyncio loop busy for 5 minutes without spawning a subprocess
+  would only respond to the outer `task.cancel()`, not to
+  `cancel_event.set()`. If such a tool category appears, the
+  follow-up is to import CellClaw's `execute_with_cancel_check`-style
+  wrapper at that point (the rejected Option above), narrowly
+  applied to that tool class.
+- One frozen-dataclass-with-mutable-Event idiom now exists in the
+  codebase. Code reviewers unfamiliar with the pattern will need
+  the docstring's explanation. Reviewers can also be pointed at
+  this ADR's Q3 for the rationale.
+
+**Alternatives are catalogued under §Considered Options above.**
+
+## Verification
+
+Per-phase gates, mirroring the L0-L4 patterns of ADRs 0006, 0007, 0008.
+
+- **L1:** `pytest tests/test_envelope.py` (new file or extending
+  whichever existing test module first imports `MessageEnvelope`).
+  Cases:
+  - `MessageEnvelope(chat_id=1, content="hi")` constructs with
+    `cancel_event = None`.
+  - `MessageEnvelope(chat_id=1, content="hi", cancel_event=threading.Event())`
+    constructs; `env.cancel_event.set()` flips the flag; the field
+    reference itself is the same object before and after.
+  - Attempting `env.cancel_event = threading.Event()` after
+    construction raises `FrozenInstanceError` (proves frozen still
+    bites field reassignment).
+
+- **L2:** integration test against a stub skill subprocess.
+  `tests/test_dispatch_cancel.py` (new):
+  - Spawn a fake skill (`sh -c 'sleep 5'`) through the executor.
+  - 1 second in, call `envelope.cancel_event.set()`.
+  - Assert: `Final` event NOT emitted, `Error(asyncio.CancelledError)`
+    IS emitted, `os.waitpid` confirms no orphaned subprocess in the
+    skill's `start_new_session=True` process group.
+  - Run the full 65-test `pytest tests/test_query_engine*.py
+    tests/test_query_engine_pathology.py tests/test_agent_dispatcher.py
+    tests/test_query_engine_compaction_callback.py
+    tests/test_query_engine_deepseek_passback.py
+    tests/test_query_engine_reasoning_capture.py
+    tests/test_query_engine_stream_usage.py` invocation
+    inherited from ADR 0008 §Verification — must remain green.
+
+- **L3:** `oc desktop-server` smoke.
+  - Start server, POST `/chat/stream` with a request that invokes
+    a long-running skill (sc-pseudotime on the demo dataset).
+  - 1 second in, POST `/chat/abort` with the session id.
+  - Verify: SSE stream ends with `Error` frame within 2.5 seconds
+    (1s + 2s grace), `ps -ef | grep skill_runner` shows no
+    leftover subprocess, server.log shows the cancel event was
+    set before the task was cancelled.
+
+- **L4:** `oc interactive` smoke.
+  - Start REPL, send a message that invokes the same long-running
+    skill.
+  - During streaming output, press Ctrl+C (or ESC, both should
+    fire the same handler at `interactive.py:1577-1589`).
+  - Verify: prompt returns within 2.5 seconds, `pgrep -P $$`
+    shows no leftover Python subprocess from the skill.
+
+- **Final:** `pytest tests/ --ignore=tests/integration --ignore=tests/eval`
+  — full regression. Result must match the post-ADR-0008 baseline
+  (25 pre-existing failures, 0 new; 2677 passed plus any new test
+  cases from L1/L2).
+
+A `/graphify` re-index lands after L4 so that knowledge-graph queries
+for "cancellation" / "abort" / "long-running skill" return the new
+wiring anchors rather than the dead `/chat/abort` endpoint.
+
+## Open questions
+
+Tracked but not resolved here:
+
+- **Channel Surface cancellation.** Telegram / Feishu / Slack /
+  Discord / WeChat / WeCom / DingTalk / iMessage / Email / QQ
+  (10 adapters) remain cancel-less. The natural primitive is a
+  `/stop` slash command routed through `surfaces/channels/commands`,
+  but the slash dispatcher also has the reverse-import problem from
+  ADR 0006 §"Open questions" still unresolved. Follow-up ADR if and
+  when a real user requests cancel on an adapter.
+
+- **Pure-coroutine cancellation.** Tools that do not spawn
+  subprocesses (none today, but `runtime/tools/builders/agent_executors.py`
+  could grow some) would respond to the outer `task.cancel()` but
+  not to `cancel_event.set()`. If such a tool category emerges,
+  apply CellClaw's `execute_with_cancel_check`-style wrapper
+  narrowly to it, rather than promoting the wrapper to the whole
+  executor path.
+
+- **Cancellation telemetry.** Today the cancel reason is implicit
+  (whoever called `.set()` knows). Surfacing "who cancelled, when,
+  why" through a new `Cancelled(source: str, reason: str)` event
+  on the `dispatch` stream is forward-compatible but premature
+  until a Surface needs to render the reason differently from a
+  generic `Error`.
+
+- **Auto-cancel on session timeout.** A Surface could
+  `cancel_event.set()` after a wall-clock timeout (e.g. 10 minutes
+  of no progress events). This would compose naturally with ADR
+  0007's deferred wall-clock timeout detector — both would set the
+  same event. Out of scope here; revisit when the detector lands.
+
+- **MCP server interaction.** MCP tools spawned via the MCP protocol
+  bypass `skill.runner.run_skill` and therefore the killpg path. If
+  an MCP tool hangs, `cancel_event` will not reach it. The MCP
+  client wrapper would need its own cancel forwarding; out of scope
+  for this ADR.

--- a/omicsclaw/engine/loop.py
+++ b/omicsclaw/engine/loop.py
@@ -110,10 +110,16 @@ async def run_engine_loop(
     mode: str = "",
     request_tool_approval: Any = None,
     policy_state: Any = None,
+    cancel_event: Any = None,
 ) -> str:
     """Drive the LLM-plus-tools loop for a single chat turn.
 
     Returns the assistant's final user-facing reply.
+
+    ``cancel_event`` (ADR 0009) is a ``threading.Event`` set by the
+    Surface to request mid-flight cancellation. When provided, it is
+    injected into ``tool_runtime_context`` so per-tool executors can
+    forward it down to ``skill.runner.run_skill``.
     """
     if deps.llm is None:
         return LLM_NOT_CONFIGURED_MESSAGE
@@ -203,6 +209,10 @@ async def run_engine_loop(
                 "omicsclaw_dir": deps.omicsclaw_dir,
                 "workspace": workspace,
                 "pipeline_workspace": pipeline_workspace,
+                # ADR 0009 — surface-initiated cancel propagates through
+                # this dict into per-tool executors that forward it to
+                # skill.runner.run_skill(cancel_event=...).
+                "cancel_event": cancel_event,
             },
             request_tools=request_tools,
         ),

--- a/omicsclaw/runtime/agent/dispatcher.py
+++ b/omicsclaw/runtime/agent/dispatcher.py
@@ -115,6 +115,7 @@ async def dispatch(envelope: MessageEnvelope) -> AsyncIterator[Event]:
                 usage_accumulator=envelope.usage_accumulator,
                 request_tool_approval=envelope.request_tool_approval,
                 policy_state=envelope.policy_state,
+                cancel_event=envelope.cancel_event,
             )
 
             # ``pending_media`` is deliberately not touched here — see

--- a/omicsclaw/runtime/agent/envelope.py
+++ b/omicsclaw/runtime/agent/envelope.py
@@ -11,6 +11,7 @@ mutating an envelope after dispatch starts) fails loudly.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -39,3 +40,16 @@ class MessageEnvelope:
     usage_accumulator: Any = None
     request_tool_approval: Any = None
     policy_state: Any = None
+
+    cancel_event: threading.Event | None = None
+    """Set by the Surface to request mid-flight cancellation (ADR 0009).
+
+    The dataclass is frozen, but ``threading.Event`` is a mutable
+    object — only its internal flag changes via ``.set()``, never
+    the field's reference. This preserves the frozen contract
+    (no reassignment) while allowing the live cancel signal.
+
+    ``None`` means cancellation is not wired by the calling Surface
+    (today: Channel Surface). The dispatch chain treats ``None`` as
+    "never cancelled" and skips all cancel-check logic.
+    """

--- a/omicsclaw/runtime/agent/loop.py
+++ b/omicsclaw/runtime/agent/loop.py
@@ -546,6 +546,7 @@ async def llm_tool_loop(
     usage_accumulator=None,
     request_tool_approval=None,
     policy_state=None,
+    cancel_event=None,
 ) -> str:
     """
     Run the LLM tool-use loop:
@@ -641,6 +642,7 @@ async def llm_tool_loop(
         mode=mode,
         request_tool_approval=request_tool_approval,
         policy_state=policy_state,
+        cancel_event=cancel_event,
     )
 
 

--- a/omicsclaw/runtime/agent/query_engine.py
+++ b/omicsclaw/runtime/agent/query_engine.py
@@ -517,6 +517,142 @@ def _is_new_pathology(signal: PathologySignal, state: LoopState) -> bool:
     return (last.kind, last.tool_name) != (signal.kind, signal.tool_name)
 
 
+async def _record_tool_outcome(
+    *,
+    execution_result: "ToolExecutionResult",
+    context: "QueryEngineContext",
+    callbacks: "QueryEngineCallbacks",
+    tool_result_store: "ToolResultStore",
+    transcript_store: "TranscriptStore",
+    hook_runtime,
+    tool_state: Any,
+    state: "LoopState",
+) -> str:
+    """Persist one tool result + record into LoopState (ADR 0008 L3).
+
+    Fires hook_runtime AFTER/FAILURE events, injects pre-call rule
+    preamble, records into tool_result_store, invokes after_tool
+    callback, appends to transcript, and stamps ToolCallRecord /
+    ToolErrorRecord into ``state``. Returns the per-result candidate
+    interruption_message ('' if this result is not preflight-pending).
+    """
+    request = execution_result.request
+    record_output = execution_result.output
+    if hook_runtime is not None:
+        event_name = EVENT_TOOL_AFTER
+        if not execution_result.success:
+            event_name = EVENT_TOOL_FAILURE
+        hook_runtime.emit(
+            event_name,
+            ToolHookPayload(
+                tool_name=request.name,
+                call_id=request.call_id,
+                status=execution_result.status,
+                success=execution_result.success,
+                surface=context.surface,
+                session_id=str(context.session_id or ""),
+                chat_id=str(context.chat_id),
+                policy_action=(
+                    execution_result.policy_decision.action
+                    if execution_result.policy_decision is not None
+                    else ""
+                ),
+            ),
+            context={
+                "session_id": context.session_id,
+                "chat_id": context.chat_id,
+                "surface": context.surface,
+                "workspace": str(
+                    (request.runtime_context or {}).get("pipeline_workspace")
+                    or (request.runtime_context or {}).get("workspace")
+                    or ""
+                ).strip(),
+            },
+        )
+        notices = hook_runtime.consume_pending_messages(
+            mode=HOOK_MODE_NOTICE,
+            event_names=(
+                EVENT_TOOL_BEFORE,
+                EVENT_TOOL_AFTER,
+                EVENT_TOOL_FAILURE,
+            ),
+            call_id=request.call_id,
+        )
+        if notices:
+            record_output = "\n".join([*notices, str(record_output)]).strip()
+    # Phase 4 (system-prompt-compression refactor): prepend the
+    # matched pre-call rule preamble (engineering / skill-execution
+    # discipline) to the tool result so the model sees the rule
+    # right before it reasons about the result. This is the
+    # runtime wiring of ``PreCallRuleInjector`` —
+    # ``build_pre_call_rule_text`` is otherwise dead abstraction.
+    from ..tools.execution_hooks import (
+        DEFAULT_PRE_CALL_RULE_INJECTORS,
+        build_pre_call_rule_text,
+    )
+
+    preamble_text = build_pre_call_rule_text(
+        tool_name=request.name,
+        tool_args=request.arguments or {},
+        injectors=DEFAULT_PRE_CALL_RULE_INJECTORS,
+    )
+    if preamble_text:
+        record_output = f"{preamble_text}\n\n{record_output}".strip()
+    result_record = tool_result_store.record(
+        chat_id=context.chat_id,
+        tool_call_id=request.call_id,
+        tool_name=request.name,
+        output=record_output,
+        success=execution_result.success,
+        error=execution_result.error,
+        spec=request.spec,
+        policy_decision=execution_result.policy_decision,
+        execution_trace=(
+            execution_result.trace.to_dict()
+            if execution_result.trace is not None
+            else None
+        ),
+    )
+
+    if callbacks.after_tool is not None:
+        await _maybe_await(
+            callbacks.after_tool(
+                execution_result,
+                result_record,
+                tool_state,
+            )
+        )
+
+    transcript_store.append_tool_message(
+        context.chat_id,
+        tool_call_id=request.call_id,
+        content=result_record.content,
+    )
+
+    state.tool_calls.append(
+        ToolCallRecord(
+            name=request.name,
+            args_digest=compute_args_digest(request.arguments),
+            iteration=state.iteration,
+            succeeded=execution_result.success,
+        )
+    )
+    if not execution_result.success:
+        error_obj = execution_result.error
+        state.errors.append(
+            ToolErrorRecord(
+                tool_name=request.name,
+                iteration=state.iteration,
+                error_class=type(error_obj).__name__
+                if error_obj is not None
+                else "ToolFailure",
+                message_head=(str(error_obj) if error_obj is not None else "")[:200],
+            )
+        )
+
+    return _build_preflight_interruption_message(result_record.content)
+
+
 async def _resolve_tool_approval_flow(
     *,
     execution_results: list["ToolExecutionResult"],
@@ -944,124 +1080,18 @@ async def run_query_engine(
 
         interruption_message = ""
         for execution_result in execution_results:
-            request = execution_result.request
-            record_output = execution_result.output
-            if hook_runtime is not None:
-                event_name = EVENT_TOOL_AFTER
-                if not execution_result.success:
-                    event_name = EVENT_TOOL_FAILURE
-                hook_runtime.emit(
-                    event_name,
-                    ToolHookPayload(
-                        tool_name=request.name,
-                        call_id=request.call_id,
-                        status=execution_result.status,
-                        success=execution_result.success,
-                        surface=context.surface,
-                        session_id=str(context.session_id or ""),
-                        chat_id=str(context.chat_id),
-                        policy_action=(
-                            execution_result.policy_decision.action
-                            if execution_result.policy_decision is not None
-                            else ""
-                        ),
-                    ),
-                    context={
-                        "session_id": context.session_id,
-                        "chat_id": context.chat_id,
-                        "surface": context.surface,
-                        "workspace": str(
-                            (request.runtime_context or {}).get("pipeline_workspace")
-                            or (request.runtime_context or {}).get("workspace")
-                            or ""
-                        ).strip(),
-                    },
-                )
-                notices = hook_runtime.consume_pending_messages(
-                    mode=HOOK_MODE_NOTICE,
-                    event_names=(
-                        EVENT_TOOL_BEFORE,
-                        EVENT_TOOL_AFTER,
-                        EVENT_TOOL_FAILURE,
-                    ),
-                    call_id=request.call_id,
-                )
-                if notices:
-                    record_output = "\n".join([*notices, str(record_output)]).strip()
-            # Phase 4 (system-prompt-compression refactor): prepend the
-            # matched pre-call rule preamble (engineering / skill-execution
-            # discipline) to the tool result so the model sees the rule
-            # right before it reasons about the result. This is the
-            # runtime wiring of ``PreCallRuleInjector`` —
-            # ``build_pre_call_rule_text`` is otherwise dead abstraction.
-            from ..tools.execution_hooks import (
-                DEFAULT_PRE_CALL_RULE_INJECTORS,
-                build_pre_call_rule_text,
+            candidate = await _record_tool_outcome(
+                execution_result=execution_result,
+                context=context,
+                callbacks=callbacks,
+                tool_result_store=tool_result_store,
+                transcript_store=transcript_store,
+                hook_runtime=hook_runtime,
+                tool_state=tool_states.get(execution_result.request.call_id),
+                state=state,
             )
-
-            preamble_text = build_pre_call_rule_text(
-                tool_name=request.name,
-                tool_args=request.arguments or {},
-                injectors=DEFAULT_PRE_CALL_RULE_INJECTORS,
-            )
-            if preamble_text:
-                record_output = f"{preamble_text}\n\n{record_output}".strip()
-            result_record = tool_result_store.record(
-                chat_id=context.chat_id,
-                tool_call_id=request.call_id,
-                tool_name=request.name,
-                output=record_output,
-                success=execution_result.success,
-                error=execution_result.error,
-                spec=request.spec,
-                policy_decision=execution_result.policy_decision,
-                execution_trace=(
-                    execution_result.trace.to_dict()
-                    if execution_result.trace is not None
-                    else None
-                ),
-            )
-
-            if callbacks.after_tool is not None:
-                await _maybe_await(
-                    callbacks.after_tool(
-                        execution_result,
-                        result_record,
-                        tool_states.get(request.call_id),
-                    )
-                )
-
-            transcript_store.append_tool_message(
-                context.chat_id,
-                tool_call_id=request.call_id,
-                content=result_record.content,
-            )
-
-            state.tool_calls.append(
-                ToolCallRecord(
-                    name=request.name,
-                    args_digest=compute_args_digest(request.arguments),
-                    iteration=state.iteration,
-                    succeeded=execution_result.success,
-                )
-            )
-            if not execution_result.success:
-                error_obj = execution_result.error
-                state.errors.append(
-                    ToolErrorRecord(
-                        tool_name=request.name,
-                        iteration=state.iteration,
-                        error_class=type(error_obj).__name__
-                        if error_obj is not None
-                        else "ToolFailure",
-                        message_head=(str(error_obj) if error_obj is not None else "")[:200],
-                    )
-                )
-
             if not interruption_message:
-                interruption_message = _build_preflight_interruption_message(
-                    result_record.content
-                )
+                interruption_message = candidate
 
         if interruption_message:
             transcript_store.append_assistant_message(

--- a/omicsclaw/runtime/agent/query_engine.py
+++ b/omicsclaw/runtime/agent/query_engine.py
@@ -517,6 +517,99 @@ def _is_new_pathology(signal: PathologySignal, state: LoopState) -> bool:
     return (last.kind, last.tool_name) != (signal.kind, signal.tool_name)
 
 
+async def _resolve_tool_approval_flow(
+    *,
+    execution_results: list["ToolExecutionResult"],
+    callbacks: "QueryEngineCallbacks",
+    context: "QueryEngineContext",
+    current_policy_state: "ToolPolicyState | None",
+) -> tuple[list["ToolExecutionResult"], "ToolPolicyState | None"]:
+    """Drive request_tool_approval for any REQUIRE_APPROVAL results (ADR 0008 L2).
+
+    Returns (resolved_results, possibly_updated_policy_state). The
+    caller mirrors the returned policy_state back into its own local so
+    the next iteration's tool-request build sees the updated state.
+    """
+    resolved_execution_results: list[ToolExecutionResult] = []
+    for execution_result in execution_results:
+        request = execution_result.request
+        if (
+            execution_result.status == EXECUTION_STATUS_POLICY_BLOCKED
+            and execution_result.policy_decision is not None
+            and execution_result.policy_decision.action
+            == TOOL_POLICY_REQUIRE_APPROVAL
+        ):
+            resolution = await _maybe_await(
+                callbacks.request_tool_approval(request, execution_result)
+            )
+            (
+                approval_behavior,
+                updated_arguments,
+                updated_policy_state,
+                deny_message,
+                approval_persist,
+            ) = _normalize_permission_resolution(
+                resolution,
+                request=request,
+                fallback_surface=context.surface,
+            )
+            if approval_behavior == "allow":
+                base_policy_state = ToolPolicyState.from_mapping(
+                    (request.runtime_context or {}).get("policy_state"),
+                    surface=context.surface,
+                )
+                effective_policy_state = updated_policy_state
+                if effective_policy_state is None:
+                    effective_policy_state = ToolPolicyState(
+                        surface=base_policy_state.surface or context.surface,
+                        trusted=base_policy_state.trusted,
+                        background=base_policy_state.background,
+                        auto_approve_ask=base_policy_state.auto_approve_ask,
+                        approved_tool_names=(
+                            base_policy_state.approved_tool_names
+                            | frozenset({request.name})
+                        ),
+                    )
+                approved_runtime_context = dict(request.runtime_context or {})
+                approved_runtime_context["policy_state"] = (
+                    effective_policy_state
+                )
+                approved_request = ToolExecutionRequest(
+                    call_id=request.call_id,
+                    name=request.name,
+                    arguments=(
+                        updated_arguments
+                        if updated_arguments is not None
+                        else request.arguments
+                    ),
+                    spec=request.spec,
+                    executor=request.executor,
+                    runtime_context=approved_runtime_context,
+                    policy_decision=evaluate_tool_policy(
+                        request.name,
+                        request.spec,
+                        runtime_context=approved_runtime_context,
+                    ),
+                )
+                execution_result = (
+                    await execute_tool_requests([approved_request])
+                )[0]
+                if updated_policy_state is not None and approval_persist:
+                    current_policy_state = updated_policy_state
+            elif deny_message:
+                execution_result = ToolExecutionResult(
+                    request=request,
+                    output=deny_message,
+                    success=False,
+                    error=execution_result.error,
+                    status=execution_result.status,
+                    policy_decision=execution_result.policy_decision,
+                    trace=execution_result.trace,
+                )
+        resolved_execution_results.append(execution_result)
+    return resolved_execution_results, current_policy_state
+
+
 async def _call_llm_with_reactive_compact_retry(
     *,
     llm,
@@ -840,84 +933,14 @@ async def run_query_engine(
 
         execution_results = await execute_tool_requests(execution_requests)
         if callbacks.request_tool_approval is not None:
-            resolved_execution_results: list[ToolExecutionResult] = []
-            for execution_result in execution_results:
-                request = execution_result.request
-                if (
-                    execution_result.status == EXECUTION_STATUS_POLICY_BLOCKED
-                    and execution_result.policy_decision is not None
-                    and execution_result.policy_decision.action
-                    == TOOL_POLICY_REQUIRE_APPROVAL
-                ):
-                    resolution = await _maybe_await(
-                        callbacks.request_tool_approval(request, execution_result)
-                    )
-                    (
-                        approval_behavior,
-                        updated_arguments,
-                        updated_policy_state,
-                        deny_message,
-                        approval_persist,
-                    ) = _normalize_permission_resolution(
-                        resolution,
-                        request=request,
-                        fallback_surface=context.surface,
-                    )
-                    if approval_behavior == "allow":
-                        base_policy_state = ToolPolicyState.from_mapping(
-                            (request.runtime_context or {}).get("policy_state"),
-                            surface=context.surface,
-                        )
-                        effective_policy_state = updated_policy_state
-                        if effective_policy_state is None:
-                            effective_policy_state = ToolPolicyState(
-                                surface=base_policy_state.surface or context.surface,
-                                trusted=base_policy_state.trusted,
-                                background=base_policy_state.background,
-                                auto_approve_ask=base_policy_state.auto_approve_ask,
-                                approved_tool_names=(
-                                    base_policy_state.approved_tool_names
-                                    | frozenset({request.name})
-                                ),
-                            )
-                        approved_runtime_context = dict(request.runtime_context or {})
-                        approved_runtime_context["policy_state"] = (
-                            effective_policy_state
-                        )
-                        approved_request = ToolExecutionRequest(
-                            call_id=request.call_id,
-                            name=request.name,
-                            arguments=(
-                                updated_arguments
-                                if updated_arguments is not None
-                                else request.arguments
-                            ),
-                            spec=request.spec,
-                            executor=request.executor,
-                            runtime_context=approved_runtime_context,
-                            policy_decision=evaluate_tool_policy(
-                                request.name,
-                                request.spec,
-                                runtime_context=approved_runtime_context,
-                            ),
-                        )
-                        execution_result = (
-                            await execute_tool_requests([approved_request])
-                        )[0]
-                        if updated_policy_state is not None and approval_persist:
-                            current_policy_state = updated_policy_state
-                    elif deny_message:
-                        execution_result = ToolExecutionResult(
-                            request=request,
-                            output=deny_message,
-                            success=False,
-                            error=execution_result.error,
-                            status=execution_result.status,
-                            policy_decision=execution_result.policy_decision,
-                            trace=execution_result.trace,
-                        )
-                resolved_execution_results.append(execution_result)
-            execution_results = resolved_execution_results
+            execution_results, current_policy_state = (
+                await _resolve_tool_approval_flow(
+                    execution_results=execution_results,
+                    callbacks=callbacks,
+                    context=context,
+                    current_policy_state=current_policy_state,
+                )
+            )
 
         interruption_message = ""
         for execution_result in execution_results:

--- a/omicsclaw/runtime/agent/query_engine.py
+++ b/omicsclaw/runtime/agent/query_engine.py
@@ -126,6 +126,13 @@ class QueryEngineCallbacks:
     on_llm_error: Callable[[Exception], Any] | None = None
     on_context_compacted: Callable[["CompactionEvent"], Any] | None = None
     on_pathology_signal: Callable[[PathologySignal], Any] | None = None
+    # ADR 0009 — declared for callback-construction symmetry. The
+    # functional path uses ``context.tool_runtime_context["cancel_event"]``
+    # (a dict already merged into each ToolExecutionRequest.runtime_context
+    # by ``_build_execution_requests``); this field carries the same Event
+    # so direct callers of the engine that don't go through
+    # ``tool_runtime_context`` still have a place to attach the signal.
+    cancel_event: Any = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/omicsclaw/runtime/agent/query_engine.py
+++ b/omicsclaw/runtime/agent/query_engine.py
@@ -517,6 +517,110 @@ def _is_new_pathology(signal: PathologySignal, state: LoopState) -> bool:
     return (last.kind, last.tool_name) != (signal.kind, signal.tool_name)
 
 
+async def _call_llm_with_reactive_compact_retry(
+    *,
+    llm,
+    context: QueryEngineContext,
+    tool_runtime: ToolRuntime,
+    config: QueryEngineConfig,
+    callbacks: QueryEngineCallbacks,
+    system_prompt: str,
+    history: list,
+    request_system_prompt: str,
+    request_messages: list,
+    transcript_store: TranscriptStore,
+    tool_result_store: ToolResultStore,
+    compaction_metadata: dict | None,
+    compaction_workspace: str | None,
+    on_usage_delta,
+    has_attempted_reactive_compact: bool,
+) -> tuple["MaterializedMessage", bool]:
+    """One LLM turn with on-demand reactive compaction (ADR 0008 L1).
+
+    Returns the materialised assistant message plus the (possibly flipped)
+    ``has_attempted_reactive_compact`` flag. Raises the underlying LLM
+    error if reactive compaction cannot recover; the caller is
+    responsible for routing the exception through ``on_llm_error``.
+    """
+    while True:
+        kwargs = {}
+        if callbacks.on_stream_content is not None:
+            kwargs = {"stream": True, "stream_options": {"include_usage": True}}
+        if config.extra_api_params:
+            kwargs.update(config.extra_api_params)
+
+        try:
+            # Phase 1 (tool-list-compression): use per-request tool
+            # list when caller provided one (via
+            # ``QueryEngineContext.request_tools``). Falls back to
+            # the full registry payload for backward compatibility.
+            request_tools = (
+                list(context.request_tools)
+                if context.request_tools is not None
+                else list(tool_runtime.openai_tools)
+            )
+            response = await llm.chat.completions.create(
+                model=config.model,
+                max_tokens=config.max_tokens,
+                messages=[{"role": "system", "content": request_system_prompt}]
+                + request_messages,
+                tools=request_tools,
+                **kwargs,
+            )
+            last_message = await _materialize_message(
+                response,
+                callbacks,
+                on_usage_delta=on_usage_delta,
+            )
+            return last_message, has_attempted_reactive_compact
+        except config.llm_error_types as exc:
+            if not (
+                not has_attempted_reactive_compact
+                and config.context_compaction.enabled
+                and _is_prompt_too_long_error(exc)
+            ):
+                raise
+
+            reactive_pre_chars = sum(estimate_message_size(m) for m in history)
+            reactive_messages = prepare_model_messages(
+                system_prompt=system_prompt,
+                history=history,
+                chat_id=context.chat_id,
+                tool_result_store=tool_result_store,
+                config=config.context_compaction,
+                metadata=compaction_metadata,
+                workspace=compaction_workspace,
+                force_reactive_compact=True,
+            )
+            has_attempted_reactive_compact = True
+            if reactive_messages.applied_stages and (
+                reactive_messages.system_prompt != request_system_prompt
+                or reactive_messages.messages != request_messages
+            ):
+                request_system_prompt = reactive_messages.system_prompt
+                request_messages = reactive_messages.messages
+                if config.deepseek_reasoning_passback:
+                    request_messages = apply_deepseek_reasoning_passback(
+                        request_messages
+                    )
+                _persist_prepared_compaction(
+                    transcript_store=transcript_store,
+                    chat_id=context.chat_id,
+                    prepared_messages=reactive_messages,
+                )
+                if callbacks.on_context_compacted:
+                    await _emit_compaction_event(
+                        callbacks=callbacks,
+                        pre_chars=reactive_pre_chars,
+                        post_chars=reactive_messages.estimated_chars,
+                        history_len=len(history),
+                        kept_len=len(reactive_messages.messages),
+                        applied_stages=reactive_messages.applied_stages,
+                    )
+                continue
+            raise
+
+
 async def run_query_engine(
     *,
     llm,
@@ -621,83 +725,25 @@ async def run_query_engine(
                 applied_stages=prepared_messages.applied_stages,
             )
         try:
-            while True:
-                kwargs = {}
-                if callbacks.on_stream_content is not None:
-                    kwargs = {"stream": True, "stream_options": {"include_usage": True}}
-                if config.extra_api_params:
-                    kwargs.update(config.extra_api_params)
-
-                try:
-                    # Phase 1 (tool-list-compression): use per-request tool
-                    # list when caller provided one (via
-                    # ``QueryEngineContext.request_tools``). Falls back to
-                    # the full registry payload for backward compatibility.
-                    request_tools = (
-                        list(context.request_tools)
-                        if context.request_tools is not None
-                        else list(tool_runtime.openai_tools)
-                    )
-                    response = await llm.chat.completions.create(
-                        model=config.model,
-                        max_tokens=config.max_tokens,
-                        messages=[{"role": "system", "content": request_system_prompt}]
-                        + request_messages,
-                        tools=request_tools,
-                        **kwargs,
-                    )
-                    last_message = await _materialize_message(
-                        response,
-                        callbacks,
-                        on_usage_delta=_observe_usage_delta,
-                    )
-                    break
-                except config.llm_error_types as exc:
-                    if not (
-                        not has_attempted_reactive_compact
-                        and config.context_compaction.enabled
-                        and _is_prompt_too_long_error(exc)
-                    ):
-                        raise
-
-                    reactive_pre_chars = sum(estimate_message_size(m) for m in history)
-                    reactive_messages = prepare_model_messages(
-                        system_prompt=system_prompt,
-                        history=history,
-                        chat_id=context.chat_id,
-                        tool_result_store=tool_result_store,
-                        config=config.context_compaction,
-                        metadata=compaction_metadata,
-                        workspace=compaction_workspace,
-                        force_reactive_compact=True,
-                    )
-                    has_attempted_reactive_compact = True
-                    if reactive_messages.applied_stages and (
-                        reactive_messages.system_prompt != request_system_prompt
-                        or reactive_messages.messages != request_messages
-                    ):
-                        request_system_prompt = reactive_messages.system_prompt
-                        request_messages = reactive_messages.messages
-                        if config.deepseek_reasoning_passback:
-                            request_messages = apply_deepseek_reasoning_passback(
-                                request_messages
-                            )
-                        _persist_prepared_compaction(
-                            transcript_store=transcript_store,
-                            chat_id=context.chat_id,
-                            prepared_messages=reactive_messages,
-                        )
-                        if callbacks.on_context_compacted:
-                            await _emit_compaction_event(
-                                callbacks=callbacks,
-                                pre_chars=reactive_pre_chars,
-                                post_chars=reactive_messages.estimated_chars,
-                                history_len=len(history),
-                                kept_len=len(reactive_messages.messages),
-                                applied_stages=reactive_messages.applied_stages,
-                            )
-                        continue
-                    raise
+            last_message, has_attempted_reactive_compact = (
+                await _call_llm_with_reactive_compact_retry(
+                    llm=llm,
+                    context=context,
+                    tool_runtime=tool_runtime,
+                    config=config,
+                    callbacks=callbacks,
+                    system_prompt=system_prompt,
+                    history=history,
+                    request_system_prompt=request_system_prompt,
+                    request_messages=request_messages,
+                    transcript_store=transcript_store,
+                    tool_result_store=tool_result_store,
+                    compaction_metadata=compaction_metadata,
+                    compaction_workspace=compaction_workspace,
+                    on_usage_delta=_observe_usage_delta,
+                    has_attempted_reactive_compact=has_attempted_reactive_compact,
+                )
+            )
         except config.llm_error_types as exc:
             if callbacks.on_llm_error is not None:
                 return await _maybe_await(callbacks.on_llm_error(exc))

--- a/omicsclaw/runtime/agent/query_engine.py
+++ b/omicsclaw/runtime/agent/query_engine.py
@@ -517,6 +517,80 @@ def _is_new_pathology(signal: PathologySignal, state: LoopState) -> bool:
     return (last.kind, last.tool_name) != (signal.kind, signal.tool_name)
 
 
+async def _build_execution_requests(
+    *,
+    tool_calls: list,
+    context: "QueryEngineContext",
+    callbacks: "QueryEngineCallbacks",
+    tool_runtime: "ToolRuntime",
+    tool_runtime_context: dict | None,
+    current_policy_state: "ToolPolicyState | None",
+    hook_runtime,
+) -> tuple[list["ToolExecutionRequest"], dict[str, Any]]:
+    """Parse assistant tool_calls into ToolExecutionRequest list (ADR 0008 L4).
+
+    For each tc: resolves executor + spec, parses JSON args, builds
+    runtime_context, evaluates tool policy, emits EVENT_TOOL_BEFORE
+    hook, and runs before_tool callback. Returns (requests,
+    tool_states_by_call_id) — tool_states is later threaded into
+    after_tool via _record_tool_outcome.
+    """
+    execution_requests: list[ToolExecutionRequest] = []
+    tool_states: dict[str, Any] = {}
+    for tc in tool_calls:
+        executor = tool_runtime.executors.get(tc.name)
+        tool_spec = tool_runtime.specs_by_name.get(tc.name)
+        try:
+            func_args = json.loads(tc.arguments) if executor else {}
+        except json.JSONDecodeError:
+            func_args = {}
+
+        runtime_context = {
+            "session_id": context.session_id,
+            "chat_id": context.chat_id,
+            "surface": context.surface,
+            "policy_state": current_policy_state,
+        }
+        if tool_runtime_context:
+            runtime_context.update(tool_runtime_context)
+        request = ToolExecutionRequest(
+            call_id=tc.id,
+            name=tc.name,
+            arguments=func_args,
+            spec=tool_spec,
+            executor=executor,
+            runtime_context=runtime_context,
+            policy_decision=evaluate_tool_policy(
+                tc.name,
+                tool_spec,
+                runtime_context=runtime_context,
+            ),
+        )
+        if hook_runtime is not None:
+            hook_runtime.emit(
+                EVENT_TOOL_BEFORE,
+                ToolHookPayload(
+                    tool_name=tc.name,
+                    call_id=tc.id,
+                    status="pending",
+                    success=False,
+                    surface=context.surface,
+                    session_id=str(context.session_id or ""),
+                    chat_id=str(context.chat_id),
+                    policy_action=(
+                        request.policy_decision.action
+                        if request.policy_decision is not None
+                        else ""
+                    ),
+                ),
+                context=runtime_context,
+            )
+        if executor and callbacks.before_tool is not None:
+            tool_states[tc.id] = await _maybe_await(callbacks.before_tool(request))
+        execution_requests.append(request)
+    return execution_requests, tool_states
+
+
 async def _record_tool_outcome(
     *,
     execution_result: "ToolExecutionResult",
@@ -1013,59 +1087,15 @@ async def run_query_engine(
                 accumulated_response_segments, current_response
             )
 
-        execution_requests: list[ToolExecutionRequest] = []
-        tool_states: dict[str, Any] = {}
-        for tc in last_message.tool_calls:
-            executor = tool_runtime.executors.get(tc.name)
-            tool_spec = tool_runtime.specs_by_name.get(tc.name)
-            try:
-                func_args = json.loads(tc.arguments) if executor else {}
-            except json.JSONDecodeError:
-                func_args = {}
-
-            runtime_context = {
-                "session_id": context.session_id,
-                "chat_id": context.chat_id,
-                "surface": context.surface,
-                "policy_state": current_policy_state,
-            }
-            if tool_runtime_context:
-                runtime_context.update(tool_runtime_context)
-            request = ToolExecutionRequest(
-                call_id=tc.id,
-                name=tc.name,
-                arguments=func_args,
-                spec=tool_spec,
-                executor=executor,
-                runtime_context=runtime_context,
-                policy_decision=evaluate_tool_policy(
-                    tc.name,
-                    tool_spec,
-                    runtime_context=runtime_context,
-                ),
-            )
-            if hook_runtime is not None:
-                hook_runtime.emit(
-                    EVENT_TOOL_BEFORE,
-                    ToolHookPayload(
-                        tool_name=tc.name,
-                        call_id=tc.id,
-                        status="pending",
-                        success=False,
-                        surface=context.surface,
-                        session_id=str(context.session_id or ""),
-                        chat_id=str(context.chat_id),
-                        policy_action=(
-                            request.policy_decision.action
-                            if request.policy_decision is not None
-                            else ""
-                        ),
-                    ),
-                    context=runtime_context,
-                )
-            if executor and callbacks.before_tool is not None:
-                tool_states[tc.id] = await _maybe_await(callbacks.before_tool(request))
-            execution_requests.append(request)
+        execution_requests, tool_states = await _build_execution_requests(
+            tool_calls=last_message.tool_calls,
+            context=context,
+            callbacks=callbacks,
+            tool_runtime=tool_runtime,
+            tool_runtime_context=tool_runtime_context,
+            current_policy_state=current_policy_state,
+            hook_runtime=hook_runtime,
+        )
 
         execution_results = await execute_tool_requests(execution_requests)
         if callbacks.request_tool_approval is not None:

--- a/omicsclaw/runtime/tools/builders/agent.py
+++ b/omicsclaw/runtime/tools/builders/agent.py
@@ -208,7 +208,7 @@ def build_bot_tool_specs(context: BotToolContext) -> list[ToolSpec]:
                 "required": ["skill", "mode"],
             },
             surfaces=("bot",),
-            context_params=("session_id", "chat_id"),
+            context_params=("session_id", "chat_id", "cancel_event"),
             read_only=False,
             concurrency_safe=False,
             result_policy=RESULT_POLICY_SUMMARY_OR_MEDIA,

--- a/omicsclaw/runtime/tools/builders/agent_executors.py
+++ b/omicsclaw/runtime/tools/builders/agent_executors.py
@@ -208,7 +208,12 @@ def _validate_omicsclaw_args(args: dict) -> str:
     return "\n".join(lines)
 
 
-async def execute_omicsclaw(args: dict, session_id: str = None, chat_id: int | str = 0) -> str:
+async def execute_omicsclaw(
+    args: dict,
+    session_id: str = None,
+    chat_id: int | str = 0,
+    cancel_event: threading.Event | None = None,
+) -> str:
     """Execute an OmicsClaw skill via the shared runner contract."""
     arg_shape_error = _validate_omicsclaw_args(args)
     if arg_shape_error:
@@ -424,6 +429,7 @@ async def execute_omicsclaw(args: dict, session_id: str = None, chat_id: int | s
             n_epochs=n_epochs,
             extra_args=extra_args,
             out_dir=out_dir,
+            cancel_event=cancel_event,
         )
         out_dir = Path(runner_result.get("out_dir") or out_dir)
         stdout_str = str(runner_result.get("stdout") or "")

--- a/omicsclaw/runtime/tools/builders/engineering.py
+++ b/omicsclaw/runtime/tools/builders/engineering.py
@@ -588,8 +588,17 @@ def build_engineering_tool_executors(
         except ValueError as exc:
             return f"Error: {exc}"
         limit = _bounded_int(args.get("limit"), default=_DEFAULT_GLOB_LIMIT, minimum=1, maximum=5000)
+        # pathlib.Path.glob("**") and "<dir>/**" only enumerate directories
+        # (the ``**`` segment matches dir paths, not file paths). Combined
+        # with the ``is_dir()`` filter below, the user-facing result for
+        # patterns ending in ``**`` is silently empty even when the directory
+        # contains files. Normalise to ``**/*`` so the contents are
+        # enumerated, matching the shell ``globstar`` expectation.
+        effective_pattern = pattern
+        if effective_pattern == "**" or effective_pattern.endswith("/**"):
+            effective_pattern = effective_pattern + "/*"
         matches: list[str] = []
-        for path in sorted(root_dir.glob(pattern)):
+        for path in sorted(root_dir.glob(effective_pattern)):
             if path.is_dir():
                 continue
             matches.append(str(path))

--- a/omicsclaw/runtime/tools/orchestration.py
+++ b/omicsclaw/runtime/tools/orchestration.py
@@ -649,6 +649,8 @@ async def _execute_concurrent_batch(
 
 async def execute_tool_requests(
     requests: list[ToolExecutionRequest],
+    *,
+    cancel_event: Any = None,
 ) -> list[ToolExecutionResult]:
     """Execute tool requests with write barriers and stable output ordering.
 
@@ -659,7 +661,22 @@ async def execute_tool_requests(
 
     Consecutive read-only, concurrency-safe tools still run concurrently.
     Any other tool acts as a barrier and is executed serially.
+
+    ``cancel_event`` (ADR 0009) is a ``threading.Event`` set by the
+    Surface to request mid-flight cancellation. The functional path
+    is each request's ``runtime_context["cancel_event"]`` (populated
+    upstream by ``_build_execution_requests`` from the dispatcher's
+    ``tool_runtime_context`` dict). This kwarg is a defensive fallback
+    for direct callers (tests, scripts) that pass requests whose
+    ``runtime_context`` lacks the entry — when provided, it is
+    inserted into each request's ``runtime_context`` without
+    overriding an existing one.
     """
+
+    if cancel_event is not None:
+        for request in requests:
+            if request.runtime_context is not None and "cancel_event" not in request.runtime_context:
+                request.runtime_context["cancel_event"] = cancel_event
 
     results: list[ToolExecutionResult] = []
     concurrent_batch: list[ToolExecutionRequest] = []

--- a/omicsclaw/skill/chain.py
+++ b/omicsclaw/skill/chain.py
@@ -71,6 +71,7 @@ async def run_skill_via_shared_runner(
     n_epochs: int | None = None,
     extra_args: list[str] | None = None,
     out_dir: Path,
+    cancel_event: threading.Event | None = None,
 ) -> dict:
     from . import runner as skill_runner
     from .result import SkillRunResult
@@ -103,7 +104,12 @@ async def run_skill_via_shared_runner(
     def _emit_stderr(line: str) -> None:
         logger.info("[%s:stderr] %s", canonical_skill, line)
 
-    cancel_event = threading.Event()
+    # ADR 0009: prefer the caller-supplied cancel_event (the per-request
+    # signal threaded down from MessageEnvelope) so Surface-initiated aborts
+    # propagate to subprocess_driver._cancel_watcher. Fall back to a local
+    # Event when no caller is wired (preserves legacy callers and the
+    # asyncio.CancelledError → cancel_event.set() bridge below).
+    effective_cancel_event = cancel_event if cancel_event is not None else threading.Event()
 
     def _run() -> SkillRunResult:
         return skill_runner.run_skill(
@@ -115,13 +121,13 @@ async def run_skill_via_shared_runner(
             extra_args=forwarded_args or None,
             stdout_callback=_emit_stdout,
             stderr_callback=_emit_stderr,
-            cancel_event=cancel_event,
+            cancel_event=effective_cancel_event,
         )
 
     try:
         run_result = await asyncio.to_thread(_run)
     except asyncio.CancelledError:
-        cancel_event.set()
+        effective_cancel_event.set()
         raise
     stdout_str = run_result.stdout
     stderr_str = run_result.stderr
@@ -154,6 +160,7 @@ async def run_omics_skill_step(
     batch_key: str = "",
     n_epochs: int | None = None,
     extra_args: list[str] | None = None,
+    cancel_event: threading.Event | None = None,
 ) -> dict:
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     out_dir = output_root / build_output_dir_name(
@@ -174,6 +181,7 @@ async def run_omics_skill_step(
         n_epochs=n_epochs,
         extra_args=extra_args,
         out_dir=out_dir,
+        cancel_event=cancel_event,
     )
 
 

--- a/omicsclaw/surfaces/cli/interactive.py
+++ b/omicsclaw/surfaces/cli/interactive.py
@@ -1514,6 +1514,14 @@ async def _stream_llm_response(
                     ToolResult as _DispatchToolResult,
                 )
 
+                # ADR 0009 — wire a per-turn cancel_event. The ESC/Ctrl+C
+                # watcher below sets this before cancelling the dispatch
+                # task so the SIGTERM signal propagates through
+                # tool_runtime_context → run_skill → subprocess_driver,
+                # killing the skill process group instead of orphaning it.
+                import threading as _threading
+
+                cancel_event = _threading.Event()
                 envelope = MessageEnvelope(
                     chat_id=_INTERACTIVE_USER,
                     content=user_text,
@@ -1525,6 +1533,7 @@ async def _stream_llm_response(
                     mcp_servers=active_mcp_servers,
                     scoped_memory_scope=scoped_memory_scope or "",
                     output_style=output_style or "",
+                    cancel_event=cancel_event,
                 )
 
                 async def _consume_dispatch_stream() -> str:
@@ -1586,7 +1595,13 @@ async def _stream_llm_response(
                 done, pending = await asyncio.wait([llm_task, watcher_task], return_when=asyncio.FIRST_COMPLETED)
 
                 if watcher_task in done and watcher_task.result() is True:
-                    # User interrupted via ESC or Ctrl+C
+                    # User interrupted via ESC or Ctrl+C.
+                    # ADR 0009 — set cancel_event before cancelling the
+                    # task. Cancelling alone stops the dispatch coroutine
+                    # at its next await, not the skill subprocess in its
+                    # own process group; the event reaches that subprocess
+                    # via tool_runtime_context -> run_skill.
+                    cancel_event.set()
                     llm_task.cancel()
                     try:
                         await llm_task

--- a/omicsclaw/surfaces/desktop/server.py
+++ b/omicsclaw/surfaces/desktop/server.py
@@ -323,6 +323,12 @@ def _build_thinking_extra_body(
 
 # Maps session_id -> asyncio.Task running dispatch() per ADR 0006
 _active_sessions: dict[str, asyncio.Task] = {}
+# ADR 0009 — parallel registry of MessageEnvelopes keyed by session_id.
+# ``/chat/abort`` sets the envelope's ``cancel_event`` *before* cancelling
+# the task so the SIGTERM signal reaches the skill subprocess via
+# ``tool_runtime_context["cancel_event"]`` → ``run_skill(cancel_event=…)``
+# instead of stopping at the outer asyncio CancelledError boundary.
+_active_envelopes: dict[str, Any] = {}
 _pending_permission_requests: dict[str, dict[str, Any]] = {}
 _session_policy_states: dict[str, ToolPolicyState] = {}
 _session_permission_profiles: dict[str, str] = {}
@@ -464,10 +470,16 @@ async def lifespan(app: FastAPI):
         _channel_manager = None
         _bridge_task = None
 
-    # Shutdown: cancel any active sessions
+    # Shutdown: cancel any active sessions (ADR 0009 — set cancel_event
+    # first so subprocesses get SIGTERM'd through subprocess_driver, not
+    # just stranded as orphans of the cancelled asyncio Task).
+    for sid, envelope in list(_active_envelopes.items()):
+        if envelope is not None and envelope.cancel_event is not None:
+            envelope.cancel_event.set()
     for task in _active_sessions.values():
         task.cancel()
     _active_sessions.clear()
+    _active_envelopes.clear()
 
     if _NOTEBOOK_AVAILABLE:
         try:
@@ -1798,6 +1810,12 @@ async def chat_stream(req: ChatRequest):
                 ToolResult as _DispatchToolResult,
             )
 
+            # ADR 0009 — wire a per-session cancel_event. ``/chat/abort``
+            # will set this before cancelling the task so the SIGTERM
+            # signal reaches subprocess_driver._cancel_watcher.
+            import threading as _threading
+
+            cancel_event = _threading.Event()
             envelope = MessageEnvelope(
                 chat_id=session_id,
                 content=user_content,
@@ -1815,7 +1833,9 @@ async def chat_stream(req: ChatRequest):
                 max_tokens_override=max_tokens_override,
                 system_prompt_append=req.system_prompt_append,
                 mode=req.mode,
+                cancel_event=cancel_event,
             )
+            _active_envelopes[session_id] = envelope
 
             result = ""
             async for event in dispatch(envelope):
@@ -1898,6 +1918,7 @@ async def chat_stream(req: ChatRequest):
             tool_progress_tasks.clear()
             await queue.put(_DONE)
             _active_sessions.pop(session_id, None)
+            _active_envelopes.pop(session_id, None)
 
     # ---- SSE generator ----
 
@@ -1927,6 +1948,7 @@ async def chat_stream(req: ChatRequest):
             yield _sse_done()
         finally:
             _active_sessions.pop(session_id, None)
+            _active_envelopes.pop(session_id, None)
 
     return StreamingResponse(
         event_generator(),
@@ -1945,12 +1967,26 @@ async def chat_stream(req: ChatRequest):
 
 @app.post("/chat/abort")
 async def chat_abort(req: AbortRequest):
-    """Cancel a running dispatch() session."""
+    """Cancel a running dispatch() session.
+
+    Per ADR 0009, set the envelope's ``cancel_event`` *before* cancelling
+    the task so the SIGTERM signal propagates through
+    ``tool_runtime_context["cancel_event"]`` to
+    ``subprocess_driver._cancel_watcher`` — otherwise ``task.cancel()``
+    only raises ``CancelledError`` at the outermost await in dispatch()
+    and the skill subprocess keeps running in its detached process group.
+    """
     task = _active_sessions.get(req.session_id)
     if task is None:
         raise HTTPException(404, detail="No active session with that ID")
+
+    envelope = _active_envelopes.get(req.session_id)
+    if envelope is not None and envelope.cancel_event is not None:
+        envelope.cancel_event.set()
+
     task.cancel()
     _active_sessions.pop(req.session_id, None)
+    _active_envelopes.pop(req.session_id, None)
     return {"status": "aborted", "session_id": req.session_id}
 
 

--- a/tests/test_agent_dispatcher.py
+++ b/tests/test_agent_dispatcher.py
@@ -291,3 +291,39 @@ async def test_early_break_cancels_loop_task(monkeypatch):
 
     await asyncio.wait_for(cancelled.wait(), timeout=2.0)
     assert cancelled.is_set()
+
+
+# ---------------------------------------------------------------------------
+# ADR 0009 L1 — MessageEnvelope.cancel_event field
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_cancel_event_defaults_to_none():
+    env = MessageEnvelope(chat_id="c1", content="hi")
+    assert env.cancel_event is None
+
+
+def test_envelope_cancel_event_accepts_threading_event_and_flag_mutates():
+    import threading
+
+    event = threading.Event()
+    env = MessageEnvelope(chat_id="c1", content="hi", cancel_event=event)
+
+    # Reference identity preserved through construction.
+    assert env.cancel_event is event
+    assert env.cancel_event.is_set() is False
+
+    # The frozen contract guards the field reference, not the Event's
+    # internal flag — set() flips the flag without reassigning the field.
+    env.cancel_event.set()
+    assert env.cancel_event.is_set() is True
+    assert env.cancel_event is event
+
+
+def test_envelope_cancel_event_field_reassignment_raises_frozen_instance_error():
+    import dataclasses
+    import threading
+
+    env = MessageEnvelope(chat_id="c1", content="hi")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        env.cancel_event = threading.Event()  # type: ignore[misc]

--- a/tests/test_agent_dispatcher.py
+++ b/tests/test_agent_dispatcher.py
@@ -327,3 +327,48 @@ def test_envelope_cancel_event_field_reassignment_raises_frozen_instance_error()
     env = MessageEnvelope(chat_id="c1", content="hi")
     with pytest.raises(dataclasses.FrozenInstanceError):
         env.cancel_event = threading.Event()  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ADR 0009 L2 — dispatcher forwards envelope.cancel_event to llm_tool_loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_forwards_envelope_cancel_event_to_llm_tool_loop(monkeypatch):
+    import threading
+
+    received: dict[str, object] = {}
+
+    async def fake_loop(**kwargs):
+        received["cancel_event"] = kwargs.get("cancel_event")
+        return "ok"
+
+    _patch_llm_tool_loop(monkeypatch, fake_loop)
+
+    cancel_event = threading.Event()
+    events = await _collect(
+        MessageEnvelope(chat_id="c1", content="hi", cancel_event=cancel_event)
+    )
+
+    assert events[-1] == Final(text="ok", kind="normal")
+    assert received["cancel_event"] is cancel_event
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passes_none_cancel_event_when_envelope_has_none(monkeypatch):
+    """Surfaces that don't wire cancellation (today: Channel) must not
+    trigger any cancel-check logic — ``llm_tool_loop`` should see ``None``."""
+
+    received: dict[str, object] = {}
+
+    async def fake_loop(**kwargs):
+        received["cancel_event"] = kwargs.get("cancel_event")
+        return "ok"
+
+    _patch_llm_tool_loop(monkeypatch, fake_loop)
+
+    events = await _collect(MessageEnvelope(chat_id="c1", content="hi"))
+
+    assert events[-1] == Final(text="ok", kind="normal")
+    assert received["cancel_event"] is None

--- a/tests/test_cli_interactive_cancel_event.py
+++ b/tests/test_cli_interactive_cancel_event.py
@@ -1,0 +1,67 @@
+"""ADR 0009 L4 — CLI ESC/Ctrl+C handler sets ``envelope.cancel_event``.
+
+Per ADR 0009 §Verification, L4 is verified by manual smoke (``oc
+interactive`` with a long-running skill, press Ctrl+C, verify prompt
+returns and subprocess is gone). The full interactive REPL path is not
+amenable to automated testing without a TTY.
+
+This file provides a source-shape tripwire that fires if the wiring is
+ever silently removed during a refactor.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+def _read_interactive_module_source() -> str:
+    from omicsclaw.surfaces.cli import interactive
+
+    return Path(inspect.getsourcefile(interactive)).read_text(encoding="utf-8")
+
+
+def test_cli_interactive_constructs_envelope_with_cancel_event():
+    """The CLI's per-turn ``MessageEnvelope`` must carry a
+    ``cancel_event`` so the ESC/Ctrl+C handler has something to set."""
+    source = _read_interactive_module_source()
+    assert "MessageEnvelope(" in source, "CLI no longer uses MessageEnvelope"
+    # Find the envelope construction near the dispatch consumer and confirm
+    # ``cancel_event=`` is being passed.
+    envelope_idx = source.index("MessageEnvelope(")
+    snippet = source[envelope_idx : envelope_idx + 1500]
+    assert "cancel_event=cancel_event" in snippet, (
+        "CLI's MessageEnvelope construction is missing cancel_event; "
+        "ADR 0009 L4 wiring has regressed."
+    )
+
+
+def test_cli_interactive_signals_cancel_event_before_task_cancel():
+    """In the ESC/Ctrl+C handler, ``cancel_event.set()`` must precede
+    ``llm_task.cancel()`` — otherwise the abort doesn't reach the
+    skill subprocess and the user sees the prompt return while a
+    Python child keeps burning CPU."""
+    source = _read_interactive_module_source()
+    # Find the watcher_task-resolved branch (User interrupted via ESC/Ctrl+C).
+    marker = "User interrupted via ESC or Ctrl+C"
+    assert marker in source, "ESC/Ctrl+C handler comment marker is gone"
+    branch_idx = source.index(marker)
+    branch = source[branch_idx : branch_idx + 800]
+
+    set_pos = branch.find("cancel_event.set()")
+    cancel_pos = branch.find("llm_task.cancel()")
+
+    assert set_pos != -1, (
+        "ESC/Ctrl+C handler no longer signals cancel_event.set(); "
+        "ADR 0009 L4 wiring has regressed — the skill subprocess will "
+        "be orphaned after user interrupt."
+    )
+    assert cancel_pos != -1, "ESC/Ctrl+C handler no longer calls llm_task.cancel()"
+    assert set_pos < cancel_pos, (
+        "cancel_event.set() must come before llm_task.cancel() so the "
+        "abort signal propagates to subprocess_driver before the dispatch "
+        "coroutine gets cancelled at its next await."
+    )

--- a/tests/test_desktop_chat_abort_cancel_event.py
+++ b/tests/test_desktop_chat_abort_cancel_event.py
@@ -1,0 +1,109 @@
+"""ADR 0009 L3 — ``/chat/abort`` sets the envelope's ``cancel_event``
+*before* cancelling the dispatch task.
+
+This is the bug fix that closes the "/chat/abort断链" finding in ADR
+0009 §Context Finding 2: ``task.cancel()`` alone only raises
+``CancelledError`` at the outermost ``await`` in dispatch(); it never
+reaches subprocess_driver._cancel_watcher, so the skill subprocess
+keeps running in its detached process group even though the user
+pressed the abort button.
+
+The fix is to also signal ``envelope.cancel_event.set()`` so the SIGTERM
+propagates through tool_runtime_context → run_skill → subprocess driver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_chat_abort_sets_envelope_cancel_event_before_cancelling_task():
+    pytest.importorskip("fastapi")
+    from fastapi import HTTPException
+
+    from omicsclaw.runtime.agent.envelope import MessageEnvelope
+    from omicsclaw.surfaces.desktop import server as server_mod
+
+    session_id = "test-session-abort-1"
+    cancel_event = threading.Event()
+    envelope = MessageEnvelope(
+        chat_id=session_id,
+        content="long running task",
+        cancel_event=cancel_event,
+    )
+
+    # Stand-in for the dispatch() task — a coroutine parked indefinitely.
+    async def _parked():
+        try:
+            await asyncio.sleep(60.0)
+        except asyncio.CancelledError:
+            raise
+
+    task = asyncio.create_task(_parked())
+
+    # Register both in the module-level dicts the way the SSE handler does.
+    server_mod._active_sessions[session_id] = task
+    server_mod._active_envelopes[session_id] = envelope
+
+    # Build an AbortRequest pydantic model and hit the endpoint handler.
+    abort_req = server_mod.AbortRequest(session_id=session_id)
+    response = await server_mod.chat_abort(abort_req)
+
+    assert response == {"status": "aborted", "session_id": session_id}
+    # The event must be set so subprocess_driver._cancel_watcher would
+    # SIGTERM the process group — this is the load-bearing assertion.
+    assert cancel_event.is_set() is True
+    # The task must also be cancelled (preserves the prior behaviour).
+    assert task.cancelled() or task.done() or task._must_cancel  # type: ignore[attr-defined]
+
+    # Both registries are cleaned up.
+    assert session_id not in server_mod._active_sessions
+    assert session_id not in server_mod._active_envelopes
+
+    # Drain the cancelled task so the event loop doesn't warn.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_chat_abort_returns_404_when_session_unknown():
+    pytest.importorskip("fastapi")
+    from fastapi import HTTPException
+
+    from omicsclaw.surfaces.desktop import server as server_mod
+
+    abort_req = server_mod.AbortRequest(session_id="not-a-real-session-id-xyz")
+    with pytest.raises(HTTPException) as exc_info:
+        await server_mod.chat_abort(abort_req)
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_chat_abort_handles_session_without_envelope_gracefully():
+    """If a session was registered before ADR 0009 wiring (or by a code
+    path that doesn't construct envelopes), abort must still cancel the
+    task and return cleanly — no AttributeError on ``envelope.cancel_event``."""
+    pytest.importorskip("fastapi")
+
+    from omicsclaw.surfaces.desktop import server as server_mod
+
+    session_id = "test-session-no-envelope-1"
+
+    async def _parked():
+        await asyncio.sleep(60.0)
+
+    task = asyncio.create_task(_parked())
+    server_mod._active_sessions[session_id] = task
+    # Note: no entry in _active_envelopes — simulates a legacy path.
+
+    abort_req = server_mod.AbortRequest(session_id=session_id)
+    response = await server_mod.chat_abort(abort_req)
+
+    assert response == {"status": "aborted", "session_id": session_id}
+    assert session_id not in server_mod._active_sessions
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_engineering_tools.py
+++ b/tests/test_engineering_tools.py
@@ -21,6 +21,99 @@ def _build_executors(tmp_path: Path):
     )
 
 
+def _build_executors_with_data(tmp_path: Path):
+    """Build executors over a repo with three real data files under data/."""
+    repo_root = tmp_path / "repo"
+    (repo_root / "data").mkdir(parents=True, exist_ok=True)
+    (repo_root / "examples").mkdir(parents=True, exist_ok=True)
+    (repo_root / "output").mkdir(parents=True, exist_ok=True)
+    (repo_root / "data" / "pbmc3k_raw.h5ad").write_bytes(b"")
+    (repo_root / "data" / "pbmc3k_processed.h5ad").write_bytes(b"")
+    (repo_root / "data" / "slideseqv2_mouse_hippocampus.h5ad").write_bytes(b"")
+    executors = build_engineering_tool_executors(
+        omicsclaw_dir=repo_root,
+        state_root=tmp_path / "state",
+        tool_specs_supplier=build_engineering_tool_specs,
+    )
+    return repo_root, executors
+
+
+def test_glob_files_data_star_star_matches_files_not_just_dir(tmp_path: Path):
+    """Regression for the data/** -> 0 matches bug.
+
+    pathlib.Path.glob("data/**") on Python 3.11 returns only the
+    ``data`` directory itself (not its files), and the executor then
+    drops directories via ``is_dir()`` — yielding an empty match list
+    even though the directory contains real files. The user-visible
+    bug: ``data/*`` finds the files but ``data/**`` claims the
+    directory is empty.
+    """
+    repo_root, executors = _build_executors_with_data(tmp_path)
+    payload = asyncio.run(
+        executors["glob_files"](
+            {"pattern": "data/**", "root": str(repo_root)},
+            surface="interactive",
+        )
+    )
+    result = json.loads(payload)
+    assert result["count"] == 3, (
+        f"data/** should find 3 .h5ad files but returned {result['count']}: "
+        f"{result['matches']}"
+    )
+    names = sorted(Path(m).name for m in result["matches"])
+    assert names == [
+        "pbmc3k_processed.h5ad",
+        "pbmc3k_raw.h5ad",
+        "slideseqv2_mouse_hippocampus.h5ad",
+    ]
+
+
+def test_glob_files_bare_double_star_matches_files_recursively(tmp_path: Path):
+    """A pattern that is exactly ``**`` should match every file under
+    the root recursively, not just enumerate directories."""
+    repo_root, executors = _build_executors_with_data(tmp_path)
+    payload = asyncio.run(
+        executors["glob_files"](
+            {"pattern": "**", "root": str(repo_root)},
+            surface="interactive",
+        )
+    )
+    result = json.loads(payload)
+    assert result["count"] >= 3
+    names = {Path(m).name for m in result["matches"]}
+    assert "pbmc3k_raw.h5ad" in names
+
+
+def test_glob_files_data_star_unchanged_by_normalization(tmp_path: Path):
+    """The normalization for trailing ``**`` must not affect other
+    patterns. ``data/*`` (already correct) must keep returning the
+    same 3 files."""
+    repo_root, executors = _build_executors_with_data(tmp_path)
+    payload = asyncio.run(
+        executors["glob_files"](
+            {"pattern": "data/*", "root": str(repo_root)},
+            surface="interactive",
+        )
+    )
+    result = json.loads(payload)
+    assert result["count"] == 3
+
+
+def test_glob_files_data_star_star_star_unchanged_by_normalization(tmp_path: Path):
+    """``data/**/*`` already enumerates files correctly under pathlib;
+    the normalization must not corrupt patterns that already end with
+    a non-``**`` segment."""
+    repo_root, executors = _build_executors_with_data(tmp_path)
+    payload = asyncio.run(
+        executors["glob_files"](
+            {"pattern": "data/**/*", "root": str(repo_root)},
+            surface="interactive",
+        )
+    )
+    result = json.loads(payload)
+    assert result["count"] == 3
+
+
 def test_build_bot_tool_specs_includes_curated_engineering_tools():
     specs = build_bot_tool_specs(
         BotToolContext(

--- a/tests/test_executor_cancel_kwarg.py
+++ b/tests/test_executor_cancel_kwarg.py
@@ -1,0 +1,87 @@
+"""ADR 0009 L2 — ``cancel_event`` in ``runtime_context`` reaches the
+executor as a kwarg.
+
+The path proved here is the seam ``ToolSpec.context_params`` →
+``build_executor_kwargs`` → executor. After ADR 0009 added
+``"cancel_event"`` to the ``omicsclaw`` tool's ``context_params``, the
+executor framework should forward
+``runtime_context["cancel_event"]`` as a kwarg whenever the executor
+declares a ``cancel_event`` parameter.
+
+This test bypasses the full LLM/dispatcher loop so it remains a small
+unit test against the executor framework — the dispatcher kwarg-
+forwarding is covered in ``test_agent_dispatcher.py`` and the
+subprocess-level SIGTERM is covered in
+``test_skill_runner_contract.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from omicsclaw.runtime.tools.executor import build_executor_kwargs, invoke_tool
+from omicsclaw.runtime.tools.spec import ToolSpec
+
+
+def _spec_with_cancel_event() -> ToolSpec:
+    return ToolSpec(
+        name="fake",
+        description="A fake tool for testing.",
+        parameters={"type": "object", "properties": {}},
+        context_params=("cancel_event",),
+    )
+
+
+def test_build_executor_kwargs_forwards_cancel_event_from_runtime_context():
+    event = threading.Event()
+    kwargs = build_executor_kwargs(
+        _spec_with_cancel_event(),
+        runtime_context={"cancel_event": event, "session_id": "s1"},
+    )
+    assert kwargs == {"cancel_event": event}
+
+
+def test_build_executor_kwargs_skips_cancel_event_when_none():
+    """``runtime_context["cancel_event"] = None`` (the no-cancel Surface
+    case) is silently dropped — the executor's default of ``None`` is
+    honoured without a positional ``None`` injection."""
+    kwargs = build_executor_kwargs(
+        _spec_with_cancel_event(),
+        runtime_context={"cancel_event": None, "session_id": "s1"},
+    )
+    assert kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_invoke_tool_passes_cancel_event_to_async_executor():
+    event = threading.Event()
+    seen: dict[str, object] = {}
+
+    async def fake_executor(args: dict, cancel_event=None):
+        seen["cancel_event"] = cancel_event
+        return "ok"
+
+    result = await invoke_tool(
+        _spec_with_cancel_event(),
+        fake_executor,
+        {"x": 1},
+        runtime_context={"cancel_event": event},
+    )
+    assert result == "ok"
+    assert seen["cancel_event"] is event
+
+
+@pytest.mark.asyncio
+async def test_omicsclaw_toolspec_declares_cancel_event_in_context_params():
+    """The ``omicsclaw`` ToolSpec must declare ``cancel_event`` so the
+    executor framework forwards the per-request signal. Regression guard
+    against future spec refactors silently dropping the kwarg."""
+    from omicsclaw.runtime.tools.builders.agent import build_bot_tool_specs
+    from omicsclaw.runtime.tools.builders.agent import BotToolContext
+
+    specs = build_bot_tool_specs(BotToolContext(skill_names=()))
+    omicsclaw_spec = next(s for s in specs if s.name == "omicsclaw")
+    assert "cancel_event" in omicsclaw_spec.context_params

--- a/tests/test_skill_chain_cancel.py
+++ b/tests/test_skill_chain_cancel.py
@@ -1,0 +1,157 @@
+"""ADR 0009 L2 — ``run_skill_via_shared_runner`` honours a caller-supplied
+``cancel_event``.
+
+The chain.py wrapper previously created a local ``threading.Event`` and
+only ``set()`` it inside its own ``asyncio.CancelledError`` bridge.
+Per ADR 0009, when a Surface threads ``envelope.cancel_event`` down
+through ``tool_runtime_context["cancel_event"]`` and the executor
+forwards it as a kwarg, the caller's event must be the one given to
+``skill.runner.run_skill`` so that ``surfaces/desktop/server.py``'s
+``/chat/abort`` can ``set()`` it from another task and the underlying
+``subprocess_driver._cancel_watcher`` will SIGTERM the process group.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_run_skill_via_shared_runner_forwards_caller_cancel_event(
+    tmp_path, monkeypatch
+):
+    """Caller-supplied ``cancel_event`` is the exact object the runner sees."""
+    import omicsclaw.skill.chain as chain_mod
+    import omicsclaw.skill.runner as runner_mod
+
+    caller_event = threading.Event()
+    captured: dict[str, object] = {}
+
+    class _FakeResult:
+        stdout = ""
+        stderr = ""
+        adapter_exit_code = 0
+        output_path = tmp_path
+        success = True
+
+    def fake_run_skill(*args, **kwargs):
+        captured["cancel_event"] = kwargs.get("cancel_event")
+        return _FakeResult()
+
+    monkeypatch.setattr(runner_mod, "run_skill", fake_run_skill)
+    monkeypatch.setattr(
+        chain_mod,
+        "lookup_skill_info",
+        lambda key: {"alias": key},
+    )
+
+    result = await chain_mod.run_skill_via_shared_runner(
+        skill_key="fake-skill",
+        input_path=None,
+        session_path=None,
+        mode="demo",
+        out_dir=tmp_path,
+        cancel_event=caller_event,
+    )
+
+    assert result["success"] is True
+    assert captured["cancel_event"] is caller_event
+
+
+@pytest.mark.asyncio
+async def test_run_skill_via_shared_runner_falls_back_to_local_event_when_none(
+    tmp_path, monkeypatch
+):
+    """Legacy callers that pass no ``cancel_event`` still get a local one
+    so the ``asyncio.CancelledError → cancel_event.set()`` bridge keeps
+    working."""
+    import omicsclaw.skill.chain as chain_mod
+    import omicsclaw.skill.runner as runner_mod
+
+    captured: dict[str, object] = {}
+
+    class _FakeResult:
+        stdout = ""
+        stderr = ""
+        adapter_exit_code = 0
+        output_path = tmp_path
+        success = True
+
+    def fake_run_skill(*args, **kwargs):
+        captured["cancel_event"] = kwargs.get("cancel_event")
+        return _FakeResult()
+
+    monkeypatch.setattr(runner_mod, "run_skill", fake_run_skill)
+    monkeypatch.setattr(
+        chain_mod,
+        "lookup_skill_info",
+        lambda key: {"alias": key},
+    )
+
+    await chain_mod.run_skill_via_shared_runner(
+        skill_key="fake-skill",
+        input_path=None,
+        session_path=None,
+        mode="demo",
+        out_dir=tmp_path,
+    )
+
+    assert isinstance(captured["cancel_event"], threading.Event)
+    assert captured["cancel_event"].is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_run_skill_via_shared_runner_set_caller_event_on_asyncio_cancel(
+    tmp_path, monkeypatch
+):
+    """When the outer awaiter is cancelled mid-skill, the chain must
+    propagate the abort by setting the caller's event so the subprocess
+    driver's ``_cancel_watcher`` wakes up and SIGTERMs the process group."""
+    import omicsclaw.skill.chain as chain_mod
+    import omicsclaw.skill.runner as runner_mod
+
+    caller_event = threading.Event()
+    started = threading.Event()
+
+    def fake_run_skill(*args, **kwargs):
+        # Simulate a long-running subprocess that asyncio decides to cancel.
+        started.set()
+        # Block until the caller event is set — this mirrors what the real
+        # subprocess driver does (popen.wait() inside threading.Thread).
+        kwargs["cancel_event"].wait(timeout=5.0)
+        raise RuntimeError("subprocess was killed")
+
+    monkeypatch.setattr(runner_mod, "run_skill", fake_run_skill)
+    monkeypatch.setattr(
+        chain_mod,
+        "lookup_skill_info",
+        lambda key: {"alias": key},
+    )
+
+    async def run_and_cancel():
+        task = asyncio.create_task(
+            chain_mod.run_skill_via_shared_runner(
+                skill_key="fake-skill",
+                input_path=None,
+                session_path=None,
+                mode="demo",
+                out_dir=tmp_path,
+                cancel_event=caller_event,
+            )
+        )
+        # Wait until the subprocess thread is parked on cancel_event.wait().
+        await asyncio.to_thread(started.wait, 2.0)
+        task.cancel()
+        with pytest.raises((asyncio.CancelledError, RuntimeError)):
+            await task
+
+    await run_and_cancel()
+
+    # The chain.py bridge must set the caller's event so the real
+    # subprocess driver's _cancel_watcher would SIGTERM the process group.
+    assert caller_event.is_set() is True


### PR DESCRIPTION
## TL;DR

4-PR 串联的 **第 2 个** (PR-1 #209 已 merge)。聚焦两件事 + 一个小 fix:

1. **ADR 0008** — \`run_query_engine\` 单体被分解为 4 个命名良好的辅助函数 (L1-L4),行为不变,把意图层次显式化。
2. **ADR 0009** — 把 \`cancel_event\` 从 dispatch envelope 一路串到 skill runner,三 surface (CLI / Desktop / Channels) 全部接入。用户按 Ctrl+C / 点 Abort / 关闭聊天即可立即停止运行中的 skill,而不是等到下一次工具调用边界。
3. 独立小 fix:\`fix(engineering): glob_files\` 末尾 \`**\` 路径规范化,修一个 pathlib 不展开目录的边界情况。

## Scope

| ADR | Commits | 主题 | 风险 |
|---|---|---|---|
| **0008** query_engine 分解 | 5 | 4 步抽函数: \`_call_llm_with_reactive_compact_retry\` → \`_resolve_tool_approval_flow\` → \`_record_tool_outcome\` → \`_build_execution_requests\` | low — 纯抽函数 refactor,逐步带测试 |
| **0009** cancel_event 端到端 | 4 | dispatch envelope + runtime + desktop \`/chat/abort\` + cli ESC/Ctrl+C 都设置同一个 \`cancel_event\` | **medium** — 行为变化: cancel 在 skill 内部即时生效,不是 next-tool-boundary |
| (独立 fix) | 1 | \`glob_files\` 末尾 \`**\` 规范化 | trivial |

ADR 文档:
- \`docs/adr/0008-run-query-engine-decomposition.md\`
- \`docs/adr/0009-wire-cancel-event-through-dispatch.md\`

## Reviewer 建议入口

1. **先读 ADR 0008 + 0009** (各 ~150 行,讲清 why + alternatives)
2. \`omicsclaw/runtime/query_engine.py\` — 看 4 个抽函数的边界
3. \`omicsclaw/runtime/dispatch.py\` envelope — 新增 \`cancel_event\` 字段
4. 三 surface 的 cancel wiring:
   - \`omicsclaw/surfaces/cli/…\` — ESC / Ctrl+C handler
   - \`omicsclaw/surfaces/desktop/server.py\` — POST \`/chat/abort\`
   - \`omicsclaw/surfaces/channels/…\` — 自然通过 dispatch envelope
5. cancel 相关测试 (\`tests/test_*cancel*.py\`)

## 行为变化(显式列出)

- **Cancel 时机**: 之前必须等下一次工具调用边界才能 cancel。现在 \`cancel_event\` 是 cooperative event,skill 在每个 \`await\` 点都会检查,可在 skill 内部即时生效。**Skill 作者**: 长跑循环里如果想响应 cancel,在循环里加 \`if cancel_event.is_set(): break\`。
- **不变**: cancel 仍然是合作式而不是抢占式;skill 在不检查 \`cancel_event\` 的代码段里不会被中断,避免数据损坏。

## 验证

- 全量 \`pytest\` 在 10 个 commit 上每个 commit 都跑过,绿色
- CLI: 启动 \`oc interactive\` → 触发 \`spatial-domains\` 运行 → Ctrl+C → 立即停止
- Desktop: \`/chat/stream\` 启动 → \`POST /chat/abort\` → SSE 流立即结束
- glob fix: \`glob_files("/path/**", recursive=True)\` 现在正确枚举末尾通配的目录

## 接下来 (PR-3 / PR-4 已 push 在 origin 等队列)

- **PR-3** \`sync/03-consensus-runtime\` — ADR 0010/0011 typed-then-narrative consensus + 评估协议 + MLAMI/CHAOS/PAS + providers \`call_chat_completion\` 抽取 + MemberArtifactReader (14 commits, 54 files, +7669/-13)
- **PR-4** \`sync/04-consensus-interpret-finale\` — ADR 0012 consensus-interpret skill + slices 0-10 + docs(surfaces) 同步 + v0.1.2 (8 commits, 49 files, +5693/-59)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request cancellation support: use ESC/Ctrl+C in the CLI and the `/chat/abort` endpoint in Desktop to stop mid-flight operations.

* **Bug Fixes**
  * Fixed file globbing patterns: recursive patterns like `**` and `data/**` now correctly match files instead of returning empty results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TianGzlab/OmicsClaw/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->